### PR TITLE
Canonical Session/Event types + SQLite ledger

### DIFF
--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -1,0 +1,379 @@
+import { Database, SQLiteError } from "bun:sqlite";
+import type { Harness, Session } from "./models.ts";
+
+export type TopicSourceKind =
+	| "cwd"
+	| "git_branch"
+	| "repo"
+	| "file_path"
+	| "error"
+	| "outcome"
+	| "llm";
+
+export type SynthesisStatus = "pending" | "done" | "retry" | "skipped";
+
+export type SyncOutcome = "success" | "partial" | "error";
+
+export interface SessionSummaryRow {
+	harness: Harness;
+	source_session_id: string;
+	schema_version: number;
+	summary_json: string;
+	synthesized_at: string;
+	provider: string;
+	model: string;
+}
+
+export interface SyncRunRow {
+	id: number;
+	started_at: string;
+	ended_at: string | null;
+	outcome: SyncOutcome | null;
+	sessions_seen: number;
+	sessions_new: number;
+	sessions_updated: number;
+	synthesis_done: number;
+	synthesis_failed: number;
+	error_message: string | null;
+}
+
+export interface InsertSessionResult {
+	short_id: string;
+	collision_recovered: boolean;
+}
+
+export interface Digests {
+	short: string;
+	full: string;
+}
+
+export interface Ledger {
+	readonly db: Database;
+	close(): void;
+	insertSession(session: Session, digests?: Digests): InsertSessionResult;
+}
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS sessions (
+	harness            TEXT NOT NULL,
+	source_session_id  TEXT NOT NULL,
+	parent_session_id  TEXT,
+	source_path        TEXT NOT NULL,
+	source_revision    TEXT NOT NULL,
+	source_size        INTEGER NOT NULL,
+	source_mtime       INTEGER NOT NULL,
+	byte_offset        INTEGER NOT NULL DEFAULT 0,
+	started_at         TEXT NOT NULL,
+	ended_at           TEXT NOT NULL,
+	cwd                TEXT,
+	project            TEXT,
+	git_branch         TEXT,
+	model              TEXT,
+	event_count        INTEGER NOT NULL,
+	short_id           TEXT NOT NULL,
+	note_path          TEXT,
+	synthesis_status   TEXT NOT NULL DEFAULT 'pending',
+	synthesis_error    TEXT,
+	synthesis_attempts INTEGER NOT NULL DEFAULT 0,
+	processed_at       TEXT NOT NULL,
+	PRIMARY KEY (harness, source_session_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS sessions_short_id ON sessions (short_id);
+CREATE INDEX IF NOT EXISTS sessions_started ON sessions (started_at);
+CREATE INDEX IF NOT EXISTS sessions_project ON sessions (project);
+CREATE INDEX IF NOT EXISTS sessions_synthesis_status ON sessions (synthesis_status) WHERE synthesis_status != 'done';
+CREATE INDEX IF NOT EXISTS sessions_parent ON sessions (parent_session_id) WHERE parent_session_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS topic_candidates (
+	harness            TEXT NOT NULL,
+	source_session_id  TEXT NOT NULL,
+	label              TEXT NOT NULL,
+	source_kind        TEXT NOT NULL,
+	weight             REAL NOT NULL DEFAULT 1.0,
+	PRIMARY KEY (harness, source_session_id, label, source_kind),
+	FOREIGN KEY (harness, source_session_id) REFERENCES sessions (harness, source_session_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS topic_candidates_label ON topic_candidates (label);
+
+CREATE TABLE IF NOT EXISTS session_summaries (
+	harness            TEXT NOT NULL,
+	source_session_id  TEXT NOT NULL,
+	schema_version     INTEGER NOT NULL DEFAULT 1,
+	summary_json       TEXT NOT NULL,
+	synthesized_at     TEXT NOT NULL,
+	provider           TEXT NOT NULL,
+	model              TEXT NOT NULL,
+	PRIMARY KEY (harness, source_session_id),
+	FOREIGN KEY (harness, source_session_id) REFERENCES sessions (harness, source_session_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS sync_runs (
+	id              INTEGER PRIMARY KEY AUTOINCREMENT,
+	started_at      TEXT NOT NULL,
+	ended_at        TEXT,
+	outcome         TEXT,
+	sessions_seen   INTEGER NOT NULL DEFAULT 0,
+	sessions_new    INTEGER NOT NULL DEFAULT 0,
+	sessions_updated INTEGER NOT NULL DEFAULT 0,
+	synthesis_done  INTEGER NOT NULL DEFAULT 0,
+	synthesis_failed INTEGER NOT NULL DEFAULT 0,
+	error_message   TEXT
+);
+`;
+
+const INSERT_SESSION_SQL = `
+INSERT INTO sessions (
+	harness, source_session_id, parent_session_id,
+	source_path, source_revision, source_size, source_mtime, byte_offset,
+	started_at, ended_at, cwd, project, git_branch, model,
+	event_count, short_id, note_path,
+	synthesis_status, synthesis_error, synthesis_attempts, processed_at
+) VALUES (
+	$harness, $source_session_id, $parent_session_id,
+	$source_path, $source_revision, $source_size, $source_mtime, $byte_offset,
+	$started_at, $ended_at, $cwd, $project, $git_branch, $model,
+	$event_count, $short_id, $note_path,
+	$synthesis_status, $synthesis_error, $synthesis_attempts, $processed_at
+)
+`;
+
+export function computeDigests(
+	harness: Harness,
+	source_session_id: string,
+): Digests {
+	const hasher = new Bun.CryptoHasher("sha256");
+	hasher.update(`${harness}:${source_session_id}`);
+	const full = hasher.digest("hex");
+	return { full, short: full.slice(0, 12) };
+}
+
+export function openLedger(path: string): Ledger {
+	const db = new Database(path);
+	db.run("PRAGMA journal_mode = WAL");
+	db.run("PRAGMA busy_timeout = 5000");
+	db.run("PRAGMA foreign_keys = ON");
+	for (const stmt of splitStatements(SCHEMA_SQL)) {
+		db.run(stmt);
+	}
+
+	const insertStmt = db.prepare<never, [SessionInsertParams]>(
+		INSERT_SESSION_SQL,
+	);
+
+	const ledger: Ledger = {
+		db,
+		close() {
+			db.close();
+		},
+		insertSession(session, digests) {
+			const computed =
+				digests ?? computeDigests(session.harness, session.source_session_id);
+			const params = sessionParams(session, computed.short);
+			try {
+				insertStmt.run(params);
+				return { short_id: computed.short, collision_recovered: false };
+			} catch (err) {
+				if (!isUniqueShortIdError(err)) throw err;
+				insertStmt.run({ ...params, $short_id: computed.full });
+				return { short_id: computed.full, collision_recovered: true };
+			}
+		},
+	};
+
+	return ledger;
+}
+
+export interface UpsertTopicCandidateArgs {
+	harness: Harness;
+	source_session_id: string;
+	label: string;
+	source_kind: TopicSourceKind;
+	weight?: number;
+}
+
+export function upsertTopicCandidate(
+	ledger: Ledger,
+	args: UpsertTopicCandidateArgs,
+): void {
+	const weight = args.weight ?? 1.0;
+	ledger.db
+		.prepare(
+			`INSERT INTO topic_candidates (harness, source_session_id, label, source_kind, weight)
+			 VALUES ($harness, $sid, $label, $kind, $weight)
+			 ON CONFLICT (harness, source_session_id, label, source_kind)
+			 DO UPDATE SET weight = weight + excluded.weight`,
+		)
+		.run({
+			$harness: args.harness,
+			$sid: args.source_session_id,
+			$label: args.label,
+			$kind: args.source_kind,
+			$weight: weight,
+		});
+}
+
+export interface InsertSessionSummaryArgs {
+	harness: Harness;
+	source_session_id: string;
+	summary_json: string;
+	synthesized_at: string;
+	provider: string;
+	model: string;
+	schema_version?: number;
+}
+
+export function insertSessionSummary(
+	ledger: Ledger,
+	args: InsertSessionSummaryArgs,
+): void {
+	ledger.db
+		.prepare(
+			`INSERT INTO session_summaries (harness, source_session_id, schema_version, summary_json, synthesized_at, provider, model)
+			 VALUES ($harness, $sid, $schema_version, $summary_json, $synthesized_at, $provider, $model)
+			 ON CONFLICT (harness, source_session_id) DO UPDATE SET
+				schema_version = excluded.schema_version,
+				summary_json = excluded.summary_json,
+				synthesized_at = excluded.synthesized_at,
+				provider = excluded.provider,
+				model = excluded.model`,
+		)
+		.run({
+			$harness: args.harness,
+			$sid: args.source_session_id,
+			$schema_version: args.schema_version ?? 1,
+			$summary_json: args.summary_json,
+			$synthesized_at: args.synthesized_at,
+			$provider: args.provider,
+			$model: args.model,
+		});
+}
+
+export function getSessionSummary(
+	ledger: Ledger,
+	harness: Harness,
+	source_session_id: string,
+): SessionSummaryRow | null {
+	const row = ledger.db
+		.query<SessionSummaryRow, [string, string]>(
+			"SELECT * FROM session_summaries WHERE harness = ? AND source_session_id = ?",
+		)
+		.get(harness, source_session_id);
+	return row ?? null;
+}
+
+export interface StartSyncRunArgs {
+	started_at: string;
+}
+
+export function startSyncRun(ledger: Ledger, args: StartSyncRunArgs): number {
+	const result = ledger.db
+		.prepare("INSERT INTO sync_runs (started_at) VALUES ($started_at)")
+		.run({ $started_at: args.started_at });
+	return Number(result.lastInsertRowid);
+}
+
+export interface FinishSyncRunArgs {
+	id: number;
+	ended_at: string;
+	outcome: SyncOutcome;
+	sessions_seen?: number;
+	sessions_new?: number;
+	sessions_updated?: number;
+	synthesis_done?: number;
+	synthesis_failed?: number;
+	error_message?: string | null;
+}
+
+export function finishSyncRun(ledger: Ledger, args: FinishSyncRunArgs): void {
+	ledger.db
+		.prepare(
+			`UPDATE sync_runs SET
+				ended_at = $ended_at,
+				outcome = $outcome,
+				sessions_seen = $sessions_seen,
+				sessions_new = $sessions_new,
+				sessions_updated = $sessions_updated,
+				synthesis_done = $synthesis_done,
+				synthesis_failed = $synthesis_failed,
+				error_message = $error_message
+			WHERE id = $id`,
+		)
+		.run({
+			$id: args.id,
+			$ended_at: args.ended_at,
+			$outcome: args.outcome,
+			$sessions_seen: args.sessions_seen ?? 0,
+			$sessions_new: args.sessions_new ?? 0,
+			$sessions_updated: args.sessions_updated ?? 0,
+			$synthesis_done: args.synthesis_done ?? 0,
+			$synthesis_failed: args.synthesis_failed ?? 0,
+			$error_message: args.error_message ?? null,
+		});
+}
+
+interface SessionInsertParams {
+	[key: string]: string | number | null;
+	$harness: Harness;
+	$source_session_id: string;
+	$parent_session_id: string | null;
+	$source_path: string;
+	$source_revision: string;
+	$source_size: number;
+	$source_mtime: number;
+	$byte_offset: number;
+	$started_at: string;
+	$ended_at: string;
+	$cwd: string | null;
+	$project: string | null;
+	$git_branch: string | null;
+	$model: string | null;
+	$event_count: number;
+	$short_id: string;
+	$note_path: string | null;
+	$synthesis_status: SynthesisStatus;
+	$synthesis_error: string | null;
+	$synthesis_attempts: number;
+	$processed_at: string;
+}
+
+function sessionParams(
+	session: Session,
+	short_id: string,
+): SessionInsertParams {
+	return {
+		$harness: session.harness,
+		$source_session_id: session.source_session_id,
+		$parent_session_id: session.parent_session_id,
+		$source_path: session.source_path,
+		$source_revision: session.source_revision,
+		$source_size: session.source_size,
+		$source_mtime: session.source_mtime,
+		$byte_offset: session.byte_offset,
+		$started_at: session.started_at,
+		$ended_at: session.ended_at,
+		$cwd: session.cwd,
+		$project: session.project,
+		$git_branch: session.git_branch,
+		$model: session.model,
+		$event_count: session.events.length,
+		$short_id: short_id,
+		$note_path: null,
+		$synthesis_status: "pending",
+		$synthesis_error: null,
+		$synthesis_attempts: 0,
+		$processed_at: new Date().toISOString(),
+	};
+}
+
+function isUniqueShortIdError(err: unknown): boolean {
+	if (!(err instanceof SQLiteError)) return false;
+	const msg = err.message.toLowerCase();
+	return msg.includes("unique") && msg.includes("sessions.short_id");
+}
+
+function splitStatements(sql: string): string[] {
+	return sql
+		.split(";")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,40 @@
+export type Harness = "claude-code" | "codex";
+
+export type EventKind =
+	| "user"
+	| "assistant"
+	| "tool_call"
+	| "tool_result"
+	| "system"
+	| "error";
+
+export interface Event {
+	ts: string;
+	kind: EventKind;
+	text?: string;
+	tool?: string;
+	tool_call_id?: string;
+	tool_input?: unknown;
+	tool_output?: string;
+	exit_code?: number;
+	error?: string;
+	extra?: Record<string, unknown>;
+}
+
+export interface Session {
+	harness: Harness;
+	source_session_id: string;
+	parent_session_id: string | null;
+	source_path: string;
+	source_revision: string;
+	source_size: number;
+	source_mtime: number;
+	byte_offset: number;
+	started_at: string;
+	ended_at: string;
+	cwd: string | null;
+	project: string | null;
+	git_branch: string | null;
+	model: string | null;
+	events: Event[];
+}

--- a/tests/ledger.test.ts
+++ b/tests/ledger.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+	computeDigests,
+	type Ledger,
+	openLedger,
+	upsertTopicCandidate,
+} from "../src/ledger.ts";
+import type { Session } from "../src/models.ts";
+
+let ledger: Ledger;
+
+beforeEach(() => {
+	ledger = openLedger(":memory:");
+});
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+	return {
+		harness: "claude-code",
+		source_session_id: "session-fixture",
+		parent_session_id: null,
+		source_path: "/tmp/fixture.jsonl",
+		source_revision: "0".repeat(64),
+		source_size: 0,
+		source_mtime: 0,
+		byte_offset: 0,
+		started_at: "2026-05-02T00:00:00Z",
+		ended_at: "2026-05-02T00:01:00Z",
+		cwd: null,
+		project: null,
+		git_branch: null,
+		model: null,
+		events: [],
+		...overrides,
+	};
+}
+
+describe("schema and pragmas", () => {
+	test("opening :memory: applies the three required PRAGMAs", () => {
+		const journal = ledger.db.query("PRAGMA journal_mode").get() as {
+			journal_mode: string;
+		};
+		const busy = ledger.db.query("PRAGMA busy_timeout").get() as {
+			timeout: number;
+		};
+		const fkeys = ledger.db.query("PRAGMA foreign_keys").get() as {
+			foreign_keys: number;
+		};
+		// :memory: SQLite reports 'memory' for journal_mode regardless of WAL request,
+		// but a filesystem DB would report 'wal'. We assert WAL was attempted by setting
+		// it (no error) and the other two PRAGMAs that DO stick on :memory:.
+		expect(["wal", "memory"]).toContain(journal.journal_mode);
+		expect(busy.timeout).toBe(5000);
+		expect(fkeys.foreign_keys).toBe(1);
+	});
+
+	test("schema-init creates all four tables and required indexes", () => {
+		const tables = ledger.db
+			.query<{ name: string }, []>(
+				"SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+			)
+			.all()
+			.map((row) => row.name);
+		expect(tables).toEqual([
+			"session_summaries",
+			"sessions",
+			"sync_runs",
+			"topic_candidates",
+		]);
+
+		const indexes = ledger.db
+			.query<{ name: string }, []>(
+				"SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+			)
+			.all()
+			.map((row) => row.name);
+		expect(indexes).toEqual([
+			"sessions_parent",
+			"sessions_project",
+			"sessions_short_id",
+			"sessions_started",
+			"sessions_synthesis_status",
+			"topic_candidates_label",
+		]);
+	});
+
+	test("schema-init is idempotent — opening again does not error", () => {
+		ledger.close();
+		// Re-open the same in-memory handle would be a different DB, so use a tmp file.
+		const tmp = `/tmp/jottrace-test-${Date.now()}-${Math.random()}.db`;
+		const a = openLedger(tmp);
+		a.close();
+		const b = openLedger(tmp);
+		b.close();
+	});
+});
+
+describe("insertSession with short_id collision", () => {
+	test("12-hex collision falls back to full 64-hex digest", () => {
+		const sessionA = makeSession({ source_session_id: "session-A" });
+		const sessionB = makeSession({ source_session_id: "session-B" });
+
+		const fullA = `${"a".repeat(12)}${"1".repeat(52)}`;
+		const fullB = `${"a".repeat(12)}${"2".repeat(52)}`;
+
+		const a = ledger.insertSession(sessionA, {
+			short: "a".repeat(12),
+			full: fullA,
+		});
+		expect(a.short_id).toBe("a".repeat(12));
+		expect(a.collision_recovered).toBe(false);
+
+		const b = ledger.insertSession(sessionB, {
+			short: "a".repeat(12),
+			full: fullB,
+		});
+		expect(b.collision_recovered).toBe(true);
+		expect(b.short_id).toBe(fullB);
+		expect(b.short_id.length).toBe(64);
+
+		const persistedA = ledger.db
+			.query<{ short_id: string }, [string, string]>(
+				"SELECT short_id FROM sessions WHERE harness = ? AND source_session_id = ?",
+			)
+			.get("claude-code", "session-A");
+		expect(persistedA?.short_id).toBe("a".repeat(12));
+
+		const persistedB = ledger.db
+			.query<{ short_id: string }, [string, string]>(
+				"SELECT short_id FROM sessions WHERE harness = ? AND source_session_id = ?",
+			)
+			.get("claude-code", "session-B");
+		expect(persistedB?.short_id).toBe(fullB);
+	});
+
+	test("computeDigests returns 12-hex short and 64-hex full from sha256(harness:id)", () => {
+		const d = computeDigests("claude-code", "abc");
+		expect(d.full.length).toBe(64);
+		expect(d.short).toBe(d.full.slice(0, 12));
+		expect(/^[0-9a-f]+$/.test(d.full)).toBe(true);
+	});
+});
+
+describe("topic_candidates UPSERT", () => {
+	test("re-seen (harness, sid, label, source_kind) tuple increments weight", () => {
+		const session = makeSession({ source_session_id: "topic-fixture" });
+		ledger.insertSession(session);
+
+		upsertTopicCandidate(ledger, {
+			harness: "claude-code",
+			source_session_id: "topic-fixture",
+			label: "rust",
+			source_kind: "cwd",
+		});
+		upsertTopicCandidate(ledger, {
+			harness: "claude-code",
+			source_session_id: "topic-fixture",
+			label: "rust",
+			source_kind: "cwd",
+		});
+		upsertTopicCandidate(ledger, {
+			harness: "claude-code",
+			source_session_id: "topic-fixture",
+			label: "rust",
+			source_kind: "git_branch",
+		});
+
+		const rows = ledger.db
+			.query<
+				{ label: string; source_kind: string; weight: number },
+				[string, string]
+			>(
+				"SELECT label, source_kind, weight FROM topic_candidates WHERE harness = ? AND source_session_id = ? ORDER BY source_kind",
+			)
+			.all("claude-code", "topic-fixture");
+
+		expect(rows).toEqual([
+			{ label: "rust", source_kind: "cwd", weight: 2 },
+			{ label: "rust", source_kind: "git_branch", weight: 1 },
+		]);
+	});
+});


### PR DESCRIPTION
Closes #2.

## Summary
- `src/models.ts` — `Harness`, `EventKind`, `Event`, `Session` per design § Canonical Session / Event Model.
- `src/ledger.ts` — open/close API, WAL + busy_timeout + foreign_keys PRAGMAs, idempotent schema init for all four tables and six indexes, typed CRUD helpers (`insertSession`, `upsertTopicCandidate`, `insertSessionSummary`, `getSessionSummary`, `startSyncRun`, `finishSyncRun`).
- `insertSession` retries with the full 64-hex digest on `sessions_short_id` UNIQUE collision; an optional `digests` parameter exists as a test seam (real 12-hex sha256 collisions can't be provoked).
- `upsertTopicCandidate` uses `ON CONFLICT DO UPDATE SET weight = weight + excluded.weight` so re-seen tuples accumulate weight rather than replace it.

## Test plan
- [x] `bun test` — 7 pass (collision recovery, weight UPSERT, schema-init, PRAGMAs, idempotent re-open, computeDigests shape).
- [x] `bunx biome check .` — clean.
- [x] `bunx tsc --noEmit` — clean.
- [ ] CI runs the same three steps on push.

## Notes
- WAL is requested via PRAGMA but `:memory:` SQLite reports back `memory`; the PRAGMA test accepts either, and a filesystem-backed DB will honor WAL.
- `db.exec` was swapped for `db.run` over split statements to avoid hitting the deprecated bindings overload TS resolves to.