### PR TITLE
[codex] Add single-instance lockfile

### DIFF
--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,0 +1,178 @@
+import {
+	closeSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export interface LockHandle {
+	readonly lockPath: string;
+	release(): void;
+}
+
+export interface LockInfo {
+	pid: number;
+	startedAt: string;
+}
+
+export interface AcquireOptions {
+	lockPath?: string;
+	now?: () => Date;
+	writeMessage?: (message: string) => void;
+}
+
+export class LockHeldError extends Error {
+	readonly exitCode = 0;
+	readonly holder: LockInfo;
+
+	constructor(holder: LockInfo) {
+		super(
+			`jottrace is already running (pid ${holder.pid}, started at ${holder.startedAt}); exiting without starting another run.`,
+		);
+		this.name = "LockHeldError";
+		this.holder = holder;
+	}
+}
+
+const DEFAULT_LOCK_PATH = join(
+	homedir(),
+	".config",
+	"jottrace",
+	"jottrace.lock",
+);
+
+export function acquire(options: AcquireOptions = {}): LockHandle {
+	const lockPath = options.lockPath ?? DEFAULT_LOCK_PATH;
+	const startedAt = (options.now ?? (() => new Date()))().toISOString();
+
+	mkdirSync(dirname(lockPath), { recursive: true });
+
+	for (;;) {
+		const fd = tryCreateLock(lockPath);
+		if (fd === null) {
+			const holder = readLock(lockPath);
+			if (isProcessAlive(holder.pid)) {
+				throw new LockHeldError(holder);
+			}
+			removeLock(lockPath);
+			continue;
+		}
+
+		return writeHeldLock(lockPath, fd, startedAt);
+	}
+}
+
+export function acquireOrExit(options: AcquireOptions = {}): LockHandle {
+	try {
+		return acquire(options);
+	} catch (err) {
+		if (err instanceof LockHeldError) {
+			const writeMessage =
+				options.writeMessage ?? ((message) => console.log(message));
+			writeMessage(err.message);
+			process.exit(err.exitCode);
+		}
+		throw err;
+	}
+}
+
+function tryCreateLock(lockPath: string): number | null {
+	let fd: number;
+	try {
+		fd = openSync(lockPath, "wx", 0o600);
+	} catch (err) {
+		if (isNodeError(err) && err.code === "EEXIST") {
+			return null;
+		}
+		throw err;
+	}
+
+	return fd;
+}
+
+function writeHeldLock(
+	lockPath: string,
+	fd: number,
+	startedAt: string,
+): LockHandle {
+	try {
+		writeFileSync(fd, `pid=${process.pid}\nstarted_at=${startedAt}\n`, "utf8");
+	} finally {
+		closeSync(fd);
+	}
+
+	let released = false;
+	const heldLock = { pid: process.pid, startedAt };
+	return {
+		lockPath,
+		release() {
+			if (released) return;
+			released = true;
+			removeHeldLock(lockPath, heldLock);
+		},
+	};
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		if (isNodeError(err) && (err.code === "ESRCH" || err.code === "ENOENT")) {
+			return false;
+		}
+		return true;
+	}
+}
+
+function removeLock(lockPath: string): void {
+	try {
+		unlinkSync(lockPath);
+	} catch (err) {
+		if (!isNodeError(err) || err.code !== "ENOENT") {
+			throw err;
+		}
+	}
+}
+
+function removeHeldLock(lockPath: string, heldLock: LockInfo): void {
+	let current: LockInfo;
+	try {
+		current = readLock(lockPath);
+	} catch (err) {
+		if (isNodeError(err) && err.code === "ENOENT") {
+			return;
+		}
+		throw err;
+	}
+
+	if (
+		current.pid === heldLock.pid &&
+		current.startedAt === heldLock.startedAt
+	) {
+		removeLock(lockPath);
+	}
+}
+
+function readLock(lockPath: string): LockInfo {
+	const text = readFileSync(lockPath, "utf8");
+	const lines = text.split(/\r?\n/);
+	const pidLine = lines.find((line) => line.startsWith("pid="));
+	const startedAtLine = lines.find((line) => line.startsWith("started_at="));
+	const pid = Number(pidLine?.slice("pid=".length));
+	const startedAt = startedAtLine?.slice("started_at=".length);
+
+	if (!Number.isInteger(pid) || !startedAt) {
+		throw new Error(`Invalid jottrace lock file at ${lockPath}`);
+	}
+
+	return { pid, startedAt };
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+	return err instanceof Error && "code" in err;
+}

--- a/tests/helpers/lock-child.ts
+++ b/tests/helpers/lock-child.ts
@@ -1,0 +1,18 @@
+import { acquireOrExit } from "../../src/lock.ts";
+
+const [lockPath, holdMsArg] = process.argv.slice(2);
+
+if (!lockPath) {
+	throw new Error("Usage: lock-child.ts <lock-path> <hold-ms>");
+}
+
+const holdMs = Number(holdMsArg ?? 0);
+const handle = acquireOrExit({
+	lockPath,
+	writeMessage: (message) => console.log(message),
+});
+
+console.log(`acquired pid=${process.pid}`);
+await Bun.sleep(holdMs);
+handle.release();
+console.log(`released pid=${process.pid}`);

--- a/tests/lock.test.ts
+++ b/tests/lock.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { acquire, LockHeldError } from "../src/lock.ts";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const lockChildPath = join(testDir, "helpers", "lock-child.ts");
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { force: true, recursive: true });
+	}
+});
+
+function tempLockPath(): string {
+	const dir = mkdtempSync(join(tmpdir(), "jottrace-lock-test-"));
+	tempDirs.push(dir);
+	return join(dir, "jottrace.lock");
+}
+
+describe("single-instance lock", () => {
+	test("acquire writes pid and started_at lines, then release removes the lock", async () => {
+		const lockPath = tempLockPath();
+		const handle = acquire({
+			lockPath,
+			now: () => new Date("2026-05-02T07:45:00.000Z"),
+		});
+
+		expect(await Bun.file(lockPath).text()).toBe(
+			`pid=${process.pid}\nstarted_at=2026-05-02T07:45:00.000Z\n`,
+		);
+
+		handle.release();
+
+		expect(existsSync(lockPath)).toBe(false);
+	});
+
+	test("release can be called more than once", () => {
+		const lockPath = tempLockPath();
+		const handle = acquire({ lockPath });
+
+		handle.release();
+		handle.release();
+
+		expect(existsSync(lockPath)).toBe(false);
+	});
+
+	test("release does not remove a newer lock written after this handle", async () => {
+		const lockPath = tempLockPath();
+		const handle = acquire({
+			lockPath,
+			now: () => new Date("2026-05-02T07:46:00.000Z"),
+		});
+		const replacement = `pid=${process.pid}\nstarted_at=2026-05-02T07:47:00.000Z\n`;
+		rmSync(lockPath);
+		await Bun.write(lockPath, replacement);
+
+		handle.release();
+
+		expect(await Bun.file(lockPath).text()).toBe(replacement);
+	});
+
+	test("release ignores a lock already removed elsewhere", () => {
+		const lockPath = tempLockPath();
+		const handle = acquire({ lockPath });
+		rmSync(lockPath);
+
+		handle.release();
+
+		expect(existsSync(lockPath)).toBe(false);
+	});
+
+	test("acquire reports a live holder as a clean exit condition", async () => {
+		const lockPath = tempLockPath();
+		const startedAt = "2026-05-02T07:50:00.000Z";
+		await Bun.write(lockPath, `pid=${process.pid}\nstarted_at=${startedAt}\n`);
+
+		let caught: unknown;
+		try {
+			acquire({ lockPath });
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(caught).toBeInstanceOf(LockHeldError);
+		expect((caught as LockHeldError).exitCode).toBe(0);
+		expect((caught as LockHeldError).holder).toEqual({
+			pid: process.pid,
+			startedAt,
+		});
+		expect((caught as Error).message).toContain(String(process.pid));
+		expect((caught as Error).message).toContain(startedAt);
+	});
+
+	test("acquire silently reclaims a stale lock from a dead process", async () => {
+		const lockPath = tempLockPath();
+		const deadPid = await exitedChildPid();
+		const now = "2026-05-02T07:55:00.000Z";
+		await Bun.write(
+			lockPath,
+			`pid=${deadPid}\nstarted_at=2026-05-02T07:00:00.000Z\n`,
+		);
+
+		const handle = acquire({
+			lockPath,
+			now: () => new Date(now),
+		});
+
+		expect(await Bun.file(lockPath).text()).toBe(
+			`pid=${process.pid}\nstarted_at=${now}\n`,
+		);
+
+		handle.release();
+	});
+
+	test("two child processes contend cleanly, and a later third acquire succeeds", async () => {
+		const lockPath = tempLockPath();
+		const first = spawnLockChild(lockPath, 250);
+		await waitForLock(lockPath);
+
+		const second = spawnLockChild(lockPath, 0);
+		const secondOutput = await readProcessOutput(second);
+		expect(await second.exited).toBe(0);
+		expect(secondOutput.stdout).toContain("jottrace is already running");
+		expect(secondOutput.stdout).toContain("pid ");
+		expect(secondOutput.stdout).toContain("started at ");
+
+		expect(await first.exited).toBe(0);
+
+		const third = spawnLockChild(lockPath, 0);
+		const thirdOutput = await readProcessOutput(third);
+		expect(await third.exited).toBe(0);
+		expect(thirdOutput.stdout).toContain("acquired");
+		expect(thirdOutput.stdout).toContain("released");
+	});
+});
+
+async function exitedChildPid(): Promise<number> {
+	const child = Bun.spawn([process.execPath, "-e", ""], {
+		stderr: "ignore",
+		stdout: "ignore",
+	});
+	await child.exited;
+	return child.pid;
+}
+
+function spawnLockChild(lockPath: string, holdMs: number) {
+	return Bun.spawn(
+		[process.execPath, lockChildPath, lockPath, String(holdMs)],
+		{
+			stderr: "pipe",
+			stdout: "pipe",
+		},
+	);
+}
+
+async function waitForLock(lockPath: string): Promise<void> {
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (existsSync(lockPath)) return;
+		await Bun.sleep(10);
+	}
+	throw new Error(`Timed out waiting for ${lockPath}`);
+}
+
+async function readProcessOutput(
+	process: ReturnType<typeof spawnLockChild>,
+): Promise<{ stdout: string; stderr: string }> {
+	const [stdout, stderr] = await Promise.all([
+		new Response(process.stdout).text(),
+		new Response(process.stderr).text(),
+	]);
+	return { stdout, stderr };
+}


### PR DESCRIPTION
## Summary

Adds the single-instance lock primitive for future `jottrace sync` and `jottrace synth` command handlers. The new lock module writes `pid=<int>` and `started_at=<ISO 8601>` to the configured lock path, reports live holders as a clean exit condition, silently reclaims stale dead-PID locks, and makes release idempotent.

The tests cover the public behavior through temporary lock paths and child-process contention, including a second process exiting cleanly while the first holds the lock and a third process acquiring after release.

Closes #3.

## Validation

- `bunx biome check .`
- `bunx tsc --noEmit`
- `bun test`