### PR TITLE
[codex] Add Claude Code skeleton sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+
+Default to using Bun instead of Node.js.
+
+- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
+- Use `bun test` instead of `jest` or `vitest`
+- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
+- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
+- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
+- Use `bunx <package> <command>` instead of `npx <package> <command>`
+- Bun automatically loads .env, so don't use dotenv.
+
+## APIs
+
+- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
+- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
+- `Bun.redis` for Redis. Don't use `ioredis`.
+- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
+- `WebSocket` is built-in. Don't use `ws`.
+- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
+- Bun.$`ls` instead of execa.
+
+## Testing
+
+Use `bun test` to run tests.
+
+```ts#index.test.ts
+import { test, expect } from "bun:test";
+
+test("hello world", () => {
+  expect(1).toBe(1);
+});
+```
+
+## Frontend
+
+Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
+
+Server:
+
+```ts#index.ts
+import index from "./index.html"
+
+Bun.serve({
+  routes: {
+    "/": index,
+    "/api/users/:id": {
+      GET: (req) => {
+        return new Response(JSON.stringify({ id: req.params.id }));
+      },
+    },
+  },
+  // optional websocket support
+  websocket: {
+    open: (ws) => {
+      ws.send("Hello, world!");
+    },
+    message: (ws, message) => {
+      ws.send(message);
+    },
+    close: (ws) => {
+      // handle close
+    }
+  },
+  development: {
+    hmr: true,
+    console: true,
+  }
+})
+```
+
+HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
+
+```html#index.html
+<html>
+  <body>
+    <h1>Hello, world!</h1>
+    <script type="module" src="./frontend.tsx"></script>
+  </body>
+</html>
+```
+
+With the following `frontend.tsx`:
+
+```tsx#frontend.tsx
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+// import .css files directly and it works
+import './index.css';
+
+const root = createRoot(document.body);
+
+export default function Frontend() {
+  return <h1>Hello, world!</h1>;
+}
+
+root.render(<Frontend />);
+```
+
+Then, run index.ts
+
+```sh
+bun --hot ./index.ts
+```
+
+For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -1,0 +1,12 @@
+import type { Harness, Session } from "../models.ts";
+
+export interface DiscoveryResult {
+	count: number;
+	samples: string[];
+}
+
+export interface Adapter {
+	readonly harness: Harness;
+	discover(root?: string): Promise<DiscoveryResult>;
+	parse(sourcePath: string): Promise<Session>;
+}

--- a/src/adapters/claude_code.ts
+++ b/src/adapters/claude_code.ts
@@ -1,0 +1,350 @@
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, extname, join } from "node:path";
+import { isNodeError } from "../errors.ts";
+import type { Event, Session } from "../models.ts";
+import type { Adapter } from "./base.ts";
+
+const MAX_TOOL_OUTPUT_BYTES = 4096;
+const ERRORED_HEAD_BYTES = 1024;
+const ERRORED_TAIL_BYTES = 3072;
+const FALLBACK_TS = "__jottrace_fallback_ts__";
+
+export const claudeCodeAdapter: Adapter = {
+	harness: "claude-code",
+	async discover(root = join(homedir(), ".claude", "projects")) {
+		const paths = await collectJsonl(root);
+		return { count: paths.length, samples: paths.slice(0, 5) };
+	},
+	async parse(sourcePath) {
+		return parseClaudeCodeSession(sourcePath);
+	},
+};
+
+export async function parseClaudeCodeSession(
+	sourcePath: string,
+): Promise<Session> {
+	const file = Bun.file(sourcePath);
+	const stat = await file.stat();
+	const parsed = await parseRecords(sourcePath, file);
+	const fallbackTs =
+		parsed.firstTimestamp ?? new Date(stat.mtimeMs).toISOString();
+	const events = parsed.events.map((event) =>
+		event.ts === FALLBACK_TS ? { ...event, ts: fallbackTs } : event,
+	);
+	const started_at = minTimestamp(events) ?? fallbackTs;
+	const ended_at = maxTimestamp(events) ?? started_at;
+	const source_session_id = parsed.sourceSessionId;
+
+	return {
+		harness: "claude-code",
+		source_session_id,
+		parent_session_id: parsed.parentSessionId,
+		source_path: sourcePath,
+		source_revision: parsed.sourceRevision,
+		source_size: stat.size,
+		source_mtime: Math.floor(stat.mtimeMs / 1000),
+		byte_offset: stat.size,
+		started_at,
+		ended_at,
+		cwd: parsed.cwd,
+		project: parsed.cwd ? basename(parsed.cwd) : null,
+		git_branch: parsed.gitBranch,
+		model: parsed.model,
+		events,
+	};
+}
+
+export function truncateToolOutput(
+	output: string,
+	options: { exit_code?: number | null; error?: string | null } = {},
+): string {
+	const bytes = new TextEncoder().encode(output);
+	if (bytes.byteLength <= MAX_TOOL_OUTPUT_BYTES) return output;
+
+	const isErrored =
+		(options.exit_code != null && options.exit_code !== 0) ||
+		options.error != null;
+	if (!isErrored) {
+		const tail = decodeBytes(
+			bytes.slice(bytes.byteLength - MAX_TOOL_OUTPUT_BYTES),
+		);
+		return `${elision(bytes.byteLength - MAX_TOOL_OUTPUT_BYTES)}${tail}`;
+	}
+
+	const head = decodeBytes(bytes.slice(0, ERRORED_HEAD_BYTES));
+	const tail = decodeBytes(bytes.slice(bytes.byteLength - ERRORED_TAIL_BYTES));
+	return `${head}${elision(
+		bytes.byteLength - ERRORED_HEAD_BYTES - ERRORED_TAIL_BYTES,
+	)}${tail}`;
+}
+
+async function collectJsonl(root: string): Promise<string[]> {
+	try {
+		const entries = await readdir(root, { withFileTypes: true });
+		const paths: string[] = [];
+		for (const entry of entries) {
+			const path = join(root, entry.name);
+			if (entry.isDirectory()) {
+				paths.push(...(await collectJsonl(path)));
+			} else if (entry.isFile() && extname(entry.name) === ".jsonl") {
+				paths.push(path);
+			}
+		}
+		return paths.sort();
+	} catch (err) {
+		if (isNodeError(err) && err.code === "ENOENT") return [];
+		throw err;
+	}
+}
+
+async function parseRecords(
+	sourcePath: string,
+	file: Bun.BunFile,
+): Promise<ParsedRecords> {
+	const hasher = new Bun.CryptoHasher("sha256");
+	const decoder = new TextDecoder();
+	const reader = file.stream().getReader();
+	const parsed: MutableParsedRecords = {
+		events: [],
+		sourceSessionId: basename(sourcePath, ".jsonl"),
+		parentSessionId: null,
+		cwd: null,
+		gitBranch: null,
+		model: null,
+		firstTimestamp: null,
+	};
+	let pending = "";
+
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		hasher.update(value);
+		pending += decoder.decode(value, { stream: true });
+		pending = processCompleteLines(pending, parsed);
+	}
+
+	pending += decoder.decode();
+	if (pending.trim().length > 0) {
+		applyRecord(JSON.parse(pending) as ClaudeRecord, parsed);
+	}
+
+	return {
+		...parsed,
+		sourceRevision: hasher.digest("hex"),
+	};
+}
+
+function processCompleteLines(
+	text: string,
+	parsed: MutableParsedRecords,
+): string {
+	const lines = text.split(/\r?\n/);
+	const pending = lines.pop() ?? "";
+	for (const line of lines) {
+		if (line.trim().length === 0) continue;
+		applyRecord(JSON.parse(line) as ClaudeRecord, parsed);
+	}
+	return pending;
+}
+
+function applyRecord(record: ClaudeRecord, parsed: MutableParsedRecords): void {
+	parsed.parentSessionId ??=
+		stringOrNull(record.parentSessionId) ??
+		(record.isSidechain === true ? stringOrNull(record.sessionId) : null);
+	parsed.cwd ??= stringOrNull(record.cwd);
+	parsed.gitBranch ??= stringOrNull(record.gitBranch);
+	parsed.model ??= stringOrNull(record.message?.model);
+	parsed.firstTimestamp ??= stringOrNull(record.timestamp);
+	parsed.events.push(...eventsFromRecord(record, FALLBACK_TS));
+}
+
+function eventsFromRecord(record: ClaudeRecord, fallbackTs: string): Event[] {
+	const ts = record.timestamp ?? fallbackTs;
+	if (record.type === "user") return userEvents(record, ts);
+	if (record.type === "assistant") return assistantEvents(record, ts);
+
+	if (isSystemSubtype(record.type)) {
+		return [
+			{
+				ts,
+				kind: "system",
+				extra: { subtype: record.type },
+			},
+		];
+	}
+
+	return [];
+}
+
+function userEvents(record: ClaudeRecord, ts: string): Event[] {
+	const content = normalizeContent(record.message?.content);
+	const events: Event[] = [];
+	const text = content
+		.filter((block) => block.type === "text")
+		.map((block) => block.text)
+		.filter(isString)
+		.join("\n\n");
+
+	if (text.length > 0 || typeof record.message?.content === "string") {
+		events.push({ ts, kind: "user", text });
+	}
+
+	for (const block of content.filter((item) => item.type === "tool_result")) {
+		const exit_code = numberValue(record.toolUseResult?.exit_code);
+		const error = stringValue(record.toolUseResult?.error);
+		events.push({
+			ts,
+			kind: "tool_result",
+			tool_call_id: stringValue(block.tool_use_id),
+			tool_output: truncateToolOutput(stringifyContent(block.content), {
+				exit_code,
+				error: error ?? (block.is_error === true ? "tool result error" : null),
+			}),
+			exit_code: exit_code ?? undefined,
+			error: error ?? undefined,
+		});
+	}
+
+	return events;
+}
+
+function assistantEvents(record: ClaudeRecord, ts: string): Event[] {
+	const content = normalizeContent(record.message?.content);
+	const events: Event[] = [];
+	const text = content
+		.filter((block) => block.type === "text")
+		.map((block) => block.text)
+		.filter(isString)
+		.join("\n\n");
+
+	if (text.length > 0 || typeof record.message?.content === "string") {
+		events.push({ ts, kind: "assistant", text });
+	}
+
+	for (const block of content.filter((item) => item.type === "tool_use")) {
+		events.push({
+			ts,
+			kind: "tool_call",
+			tool: stringValue(block.name),
+			tool_call_id: stringValue(block.id),
+			tool_input: block.input,
+		});
+	}
+
+	return events;
+}
+
+function normalizeContent(content: unknown): ContentBlock[] {
+	if (typeof content === "string") return [{ type: "text", text: content }];
+	if (Array.isArray(content)) return content as ContentBlock[];
+	return [];
+}
+
+function stringifyContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (Array.isArray(content)) {
+		return content
+			.map((item) =>
+				typeof item === "string" ? item : JSON.stringify(item, null, 2),
+			)
+			.join("\n");
+	}
+	if (content == null) return "";
+	return JSON.stringify(content, null, 2);
+}
+
+function minTimestamp(events: Event[]): string | null {
+	const first = events[0];
+	if (!first) return null;
+	return events.reduce(
+		(min, event) => (event.ts < min ? event.ts : min),
+		first.ts,
+	);
+}
+
+function maxTimestamp(events: Event[]): string | null {
+	const first = events[0];
+	if (!first) return null;
+	return events.reduce(
+		(max, event) => (event.ts > max ? event.ts : max),
+		first.ts,
+	);
+}
+
+function isSystemSubtype(type: string | undefined): type is string {
+	return (
+		type === "system" ||
+		type === "permission-mode" ||
+		type === "last-prompt" ||
+		type === "attachment" ||
+		type === "file-history-snapshot"
+	);
+}
+
+function decodeBytes(bytes: Uint8Array): string {
+	return new TextDecoder().decode(bytes);
+}
+
+function elision(bytes: number): string {
+	return `[…${bytes} bytes elided…]`;
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+	return typeof value === "number" ? value : undefined;
+}
+
+function stringOrNull(value: unknown): string | null {
+	return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function isString(value: unknown): value is string {
+	return typeof value === "string";
+}
+
+interface ClaudeRecord {
+	type?: string;
+	timestamp?: string;
+	sessionId?: string;
+	isSidechain?: boolean;
+	parentSessionId?: string | null;
+	cwd?: string;
+	gitBranch?: string;
+	message?: {
+		role?: string;
+		model?: string;
+		content?: unknown;
+	};
+	toolUseResult?: {
+		exit_code?: number;
+		error?: string | null;
+	};
+}
+
+interface ContentBlock {
+	type?: string;
+	text?: unknown;
+	id?: unknown;
+	name?: unknown;
+	input?: unknown;
+	tool_use_id?: unknown;
+	content?: unknown;
+	is_error?: boolean;
+}
+
+interface ParsedRecords {
+	events: Event[];
+	sourceSessionId: string;
+	parentSessionId: string | null;
+	cwd: string | null;
+	gitBranch: string | null;
+	model: string | null;
+	firstTimestamp: string | null;
+	sourceRevision: string;
+}
+
+type MutableParsedRecords = Omit<ParsedRecords, "sourceRevision">;

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,0 +1,3 @@
+import { claudeCodeAdapter } from "./claude_code.ts";
+
+export const adapters = [claudeCodeAdapter];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,2 +1,46 @@
 #!/usr/bin/env bun
-console.log("jottrace (stub)");
+import { acquireOrExit } from "./lock.ts";
+import { syncClaudeCodeFixture } from "./sync.ts";
+
+const [, , command, ...args] = Bun.argv;
+
+if (command === "sync") {
+	const fixture = readFlag(args, "--fixture");
+	const output = readFlag(args, "--output");
+	const db = readFlag(args, "--db");
+	const lockPath = readFlag(args, "--lock") ?? process.env.JOTTRACE_LOCK_PATH;
+
+	if (!fixture || !output || !db) {
+		console.error(
+			"Usage: jottrace sync --fixture <jsonl> --output <dir> --db <db>",
+		);
+		process.exit(1);
+	}
+
+	const lock = acquireOrExit({ lockPath });
+	try {
+		const result = await syncClaudeCodeFixture({
+			sourcePath: fixture,
+			outputPath: output,
+			ledgerPath: db,
+		});
+		if (result.warning) {
+			console.error(result.warning);
+			process.exitCode = 1;
+		} else {
+			console.log(result.notePath);
+		}
+	} finally {
+		lock.release();
+	}
+} else {
+	console.log(
+		"Usage: jottrace sync --fixture <jsonl> --output <dir> --db <db>",
+	);
+}
+
+function readFlag(args: string[], flag: string): string | null {
+	const index = args.indexOf(flag);
+	if (index === -1) return null;
+	return args[index + 1] ?? null;
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,3 @@
+export function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+	return err instanceof Error && "code" in err;
+}

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -183,6 +183,78 @@ export function openLedger(path: string): Ledger {
 	return ledger;
 }
 
+export interface UpsertSessionSkeletonArgs {
+	session: Session;
+	note_path: string;
+	processed_at: string;
+	digests?: Digests;
+	short_id?: string;
+}
+
+export function resolveSessionShortId(
+	ledger: Ledger,
+	session: Session,
+	digests = computeDigests(session.harness, session.source_session_id),
+): string {
+	const existing = ledger.db
+		.query<
+			{ harness: Harness; source_session_id: string; short_id: string },
+			[string]
+		>(
+			"SELECT harness, source_session_id, short_id FROM sessions WHERE short_id = ?",
+		)
+		.get(digests.short);
+
+	if (!existing) return digests.short;
+	if (
+		existing.harness === session.harness &&
+		existing.source_session_id === session.source_session_id
+	) {
+		return existing.short_id;
+	}
+	return digests.full;
+}
+
+export function upsertSessionSkeleton(
+	ledger: Ledger,
+	args: UpsertSessionSkeletonArgs,
+): InsertSessionResult {
+	const existing = ledger.db
+		.query<SessionSkeletonRow, [Harness, string]>(
+			`SELECT
+				short_id, parent_session_id, source_path, source_revision, source_size,
+				source_mtime, byte_offset, started_at, ended_at, cwd, project,
+				git_branch, model, event_count, note_path, synthesis_status,
+				synthesis_error, synthesis_attempts
+			FROM sessions WHERE harness = ? AND source_session_id = ?`,
+		)
+		.get(args.session.harness, args.session.source_session_id);
+
+	if (existing) {
+		if (!sessionSkeletonMatches(existing, args)) {
+			updateSessionSkeleton(ledger, args, existing.short_id);
+		}
+		return { short_id: existing.short_id, collision_recovered: false };
+	}
+
+	const digests =
+		args.digests ??
+		computeDigests(args.session.harness, args.session.source_session_id);
+	const short_id =
+		args.short_id ?? resolveSessionShortId(ledger, args.session, digests);
+	const result = insertSessionSkeleton(ledger, args, short_id);
+	if (result) {
+		return {
+			...result,
+			collision_recovered:
+				short_id === digests.full && short_id !== digests.short,
+		};
+	}
+
+	insertSessionSkeleton(ledger, args, digests.full);
+	return { short_id: digests.full, collision_recovered: true };
+}
+
 export interface UpsertTopicCandidateArgs {
 	harness: Harness;
 	source_session_id: string;
@@ -336,6 +408,27 @@ interface SessionInsertParams {
 	$processed_at: string;
 }
 
+interface SessionSkeletonRow {
+	short_id: string;
+	parent_session_id: string | null;
+	source_path: string;
+	source_revision: string;
+	source_size: number;
+	source_mtime: number;
+	byte_offset: number;
+	started_at: string;
+	ended_at: string;
+	cwd: string | null;
+	project: string | null;
+	git_branch: string | null;
+	model: string | null;
+	event_count: number;
+	note_path: string | null;
+	synthesis_status: SynthesisStatus;
+	synthesis_error: string | null;
+	synthesis_attempts: number;
+}
+
 function sessionParams(
 	session: Session,
 	short_id: string,
@@ -363,6 +456,89 @@ function sessionParams(
 		$synthesis_attempts: 0,
 		$processed_at: new Date().toISOString(),
 	};
+}
+
+function skeletonParams(
+	args: UpsertSessionSkeletonArgs,
+	short_id: string,
+): SessionInsertParams {
+	return {
+		...sessionParams(args.session, short_id),
+		$note_path: args.note_path,
+		$processed_at: args.processed_at,
+	};
+}
+
+function insertSessionSkeleton(
+	ledger: Ledger,
+	args: UpsertSessionSkeletonArgs,
+	short_id: string,
+): InsertSessionResult | null {
+	try {
+		ledger.db.prepare(INSERT_SESSION_SQL).run(skeletonParams(args, short_id));
+		return { short_id, collision_recovered: false };
+	} catch (err) {
+		if (!isUniqueShortIdError(err)) throw err;
+		return null;
+	}
+}
+
+function updateSessionSkeleton(
+	ledger: Ledger,
+	args: UpsertSessionSkeletonArgs,
+	short_id: string,
+): void {
+	const params = skeletonParams(args, short_id);
+	ledger.db
+		.prepare(
+			`UPDATE sessions SET
+				parent_session_id = $parent_session_id,
+				source_path = $source_path,
+				source_revision = $source_revision,
+				source_size = $source_size,
+				source_mtime = $source_mtime,
+				byte_offset = $byte_offset,
+				started_at = $started_at,
+				ended_at = $ended_at,
+				cwd = $cwd,
+				project = $project,
+				git_branch = $git_branch,
+				model = $model,
+				event_count = $event_count,
+				note_path = $note_path,
+				synthesis_status = $synthesis_status,
+				synthesis_error = $synthesis_error,
+				synthesis_attempts = $synthesis_attempts,
+				processed_at = $processed_at
+			WHERE harness = $harness AND source_session_id = $source_session_id`,
+		)
+		.run(params);
+}
+
+function sessionSkeletonMatches(
+	row: SessionSkeletonRow,
+	args: UpsertSessionSkeletonArgs,
+): boolean {
+	const session = args.session;
+	return (
+		row.parent_session_id === session.parent_session_id &&
+		row.source_path === session.source_path &&
+		row.source_revision === session.source_revision &&
+		row.source_size === session.source_size &&
+		row.source_mtime === session.source_mtime &&
+		row.byte_offset === session.byte_offset &&
+		row.started_at === session.started_at &&
+		row.ended_at === session.ended_at &&
+		row.cwd === session.cwd &&
+		row.project === session.project &&
+		row.git_branch === session.git_branch &&
+		row.model === session.model &&
+		row.event_count === session.events.length &&
+		row.note_path === args.note_path &&
+		row.synthesis_status === "pending" &&
+		row.synthesis_error === null &&
+		row.synthesis_attempts === 0
+	);
 }
 
 function isUniqueShortIdError(err: unknown): boolean {

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { isNodeError } from "./errors.ts";
 
 export interface LockHandle {
 	readonly lockPath: string;
@@ -171,8 +172,4 @@ function readLock(lockPath: string): LockInfo {
 	}
 
 	return { pid, startedAt };
-}
-
-function isNodeError(err: unknown): err is NodeJS.ErrnoException {
-	return err instanceof Error && "code" in err;
 }

--- a/src/render/frontmatter.ts
+++ b/src/render/frontmatter.ts
@@ -1,0 +1,56 @@
+export type FrontmatterValue = string | number | boolean | null;
+
+export function emitFrontmatter(
+	values: Record<string, FrontmatterValue>,
+): string {
+	const lines = ["---"];
+	for (const [key, value] of Object.entries(values)) {
+		lines.push(`${key}: ${formatValue(value)}`);
+	}
+	lines.push("---", "");
+	return lines.join("\n");
+}
+
+export function parseFrontmatter(
+	markdown: string,
+): Record<string, FrontmatterValue> | null {
+	if (!markdown.startsWith("---\n")) return null;
+	const end = markdown.indexOf("\n---\n", 4);
+	if (end === -1) return null;
+
+	const entries: Record<string, FrontmatterValue> = {};
+	for (const line of markdown.slice(4, end).split("\n")) {
+		const sep = line.indexOf(":");
+		if (sep === -1) continue;
+		entries[line.slice(0, sep).trim()] = parseValue(line.slice(sep + 1).trim());
+	}
+	return entries;
+}
+
+function formatValue(value: FrontmatterValue): string {
+	if (value == null) return "null";
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value);
+	}
+	if (value === "null" || value === "true" || value === "false") {
+		return JSON.stringify(value);
+	}
+	if (/^-?\d+(\.\d+)?$/.test(value)) return JSON.stringify(value);
+	if (/^[a-zA-Z0-9_./:-]+$/.test(value)) return value;
+	return JSON.stringify(value);
+}
+
+function parseValue(value: string): FrontmatterValue {
+	if (value === "null") return null;
+	if (value === "true") return true;
+	if (value === "false") return false;
+	if (/^-?\d+(\.\d+)?$/.test(value)) return Number(value);
+	if (value.startsWith('"') && value.endsWith('"')) {
+		try {
+			return JSON.parse(value) as string;
+		} catch {
+			return value;
+		}
+	}
+	return value;
+}

--- a/src/render/markers.ts
+++ b/src/render/markers.ts
@@ -1,0 +1,13 @@
+export function markerStart(name: string): string {
+	return `<!-- jottrace:${name}:start v=1 -->`;
+}
+
+export function markerEnd(name: string): string {
+	return `<!-- jottrace:${name}:end -->`;
+}
+
+export function renderRegion(name: string, content: string): string {
+	return `${markerStart(name)}
+${content}
+${markerEnd(name)}`;
+}

--- a/src/render/regions.ts
+++ b/src/render/regions.ts
@@ -1,0 +1,119 @@
+import { closeSync, fsyncSync, openSync } from "node:fs";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { isNodeError } from "../errors.ts";
+import { renderRegion } from "./markers.ts";
+
+export interface UpdateGeneratedRegionsArgs {
+	notePath: string;
+	template: string;
+	regions: ReadonlyMap<string, string> | Record<string, string>;
+}
+
+export interface UpdateGeneratedRegionsResult {
+	wrote: boolean;
+	warning?: string;
+}
+
+export async function updateGeneratedRegions(
+	args: UpdateGeneratedRegionsArgs,
+): Promise<UpdateGeneratedRegionsResult> {
+	const existing = await readExisting(args.notePath);
+
+	if (existing === null) {
+		await writeAtomically(args.notePath, args.template);
+		return { wrote: true };
+	}
+
+	const replacementRegions = new Map(entries(args.regions));
+	const validation = validateRegions(existing, replacementRegions);
+	if (validation.warning) return { wrote: false, warning: validation.warning };
+
+	const proposed = replaceRegions(existing, replacementRegions);
+
+	if (proposed === existing) return { wrote: false };
+	await writeAtomically(args.notePath, proposed);
+	return { wrote: true };
+}
+
+async function readExisting(path: string): Promise<string | null> {
+	try {
+		return await readFile(path, "utf8");
+	} catch (err) {
+		if (isNodeError(err) && err.code === "ENOENT") return null;
+		throw err;
+	}
+}
+
+async function writeAtomically(path: string, content: string): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	const tmpPath = `${path}.tmp`;
+	await writeFile(tmpPath, content, "utf8");
+	const fd = openSync(tmpPath, "r");
+	try {
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
+	}
+	try {
+		await rename(tmpPath, path);
+	} catch (err) {
+		await unlink(tmpPath).catch(() => {});
+		throw err;
+	}
+}
+
+function validateRegions(
+	text: string,
+	regions: Map<string, string>,
+): { warning?: string } {
+	const pairCounts = new Map<string, number>();
+	for (const match of text.matchAll(regionPattern())) {
+		const name = match[1];
+		if (name) pairCounts.set(name, (pairCounts.get(name) ?? 0) + 1);
+	}
+
+	for (const name of regions.keys()) {
+		const startCount = markerCount(text, markerStartPattern(name));
+		const endCount = markerCount(text, markerEndPattern(name));
+		if (startCount !== 1 || endCount !== 1 || pairCounts.get(name) !== 1) {
+			return { warning: `Malformed or missing jottrace region: ${name}` };
+		}
+	}
+	return {};
+}
+
+function replaceRegions(text: string, regions: Map<string, string>): string {
+	return text.replace(regionPattern(), (match, name: string) => {
+		const replacement = regions.get(name);
+		return replacement == null ? match : renderRegion(name, replacement);
+	});
+}
+
+function regionPattern(): RegExp {
+	return /<!-- jottrace:([^:]+):start v=1 -->\n[\s\S]*?\n<!-- jottrace:\1:end -->/g;
+}
+
+function markerStartPattern(name: string): RegExp {
+	return new RegExp(`<!-- jottrace:${escapeRegex(name)}:start v=1 -->`, "g");
+}
+
+function markerEndPattern(name: string): RegExp {
+	return new RegExp(`<!-- jottrace:${escapeRegex(name)}:end -->`, "g");
+}
+
+function markerCount(text: string, pattern: RegExp): number {
+	return text.match(pattern)?.length ?? 0;
+}
+
+function entries(
+	regions: ReadonlyMap<string, string> | Record<string, string>,
+): [string, string][] {
+	return regions instanceof Map
+		? [...regions.entries()]
+		: Object.entries(regions);
+}
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/render/session_md.ts
+++ b/src/render/session_md.ts
@@ -1,0 +1,64 @@
+import type { Session } from "../models.ts";
+import { emitFrontmatter } from "./frontmatter.ts";
+import { renderRegion } from "./markers.ts";
+
+export const PLACEHOLDER =
+	"_synthesis pending — run `jottrace synth` after restoring LLM connectivity_";
+
+export const SESSION_REGION_NAMES = [
+	"source-trace",
+	"summary",
+	"timeline",
+	"wins",
+	"dead-ends",
+	"decisions",
+	"outcome",
+	"artifacts",
+	"followups",
+] as const;
+
+export type SessionRegionName = (typeof SESSION_REGION_NAMES)[number];
+
+export function renderSkeletonSessionNote(session: Session): string {
+	const regions = skeletonRegions(session);
+	return `${emitFrontmatter({
+		type: "jottrace-session",
+		harness: session.harness,
+		source_session_id: session.source_session_id,
+		parent_session_id: session.parent_session_id,
+		started_at: session.started_at,
+		ended_at: session.ended_at,
+		cwd: session.cwd,
+		project: session.project,
+		git_branch: session.git_branch,
+		model: session.model,
+		synthesis_status: "pending",
+	})}# Jottrace Session
+
+${SESSION_REGION_NAMES.map((name) => renderRegion(name, regions[name])).join("\n\n")}
+`;
+}
+
+export function skeletonRegions(
+	session: Session,
+): Record<SessionRegionName, string> {
+	return {
+		"source-trace": [
+			`- Source file: \`${session.source_path}\``,
+			`- Harness: ${session.harness}`,
+			`- Source session: \`${session.source_session_id}\``,
+			`- Events: ${session.events.length}`,
+			`- Source revision: \`${session.source_revision}\``,
+		].join("\n"),
+		summary: PLACEHOLDER,
+		timeline: PLACEHOLDER,
+		wins: PLACEHOLDER,
+		"dead-ends": PLACEHOLDER,
+		decisions: PLACEHOLDER,
+		outcome: PLACEHOLDER,
+		artifacts: PLACEHOLDER,
+		followups: PLACEHOLDER,
+	};
+}
+
+export { renderRegion };

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,0 +1,86 @@
+import { join, relative } from "node:path";
+import { claudeCodeAdapter } from "./adapters/claude_code.ts";
+import {
+	computeDigests,
+	openLedger,
+	resolveSessionShortId,
+	upsertSessionSkeleton,
+} from "./ledger.ts";
+import { updateGeneratedRegions } from "./render/regions.ts";
+import {
+	renderSkeletonSessionNote,
+	skeletonRegions,
+} from "./render/session_md.ts";
+
+export interface SyncClaudeCodeFixtureOptions {
+	sourcePath: string;
+	outputPath: string;
+	ledgerPath: string;
+	now?: () => Date;
+}
+
+export interface SyncClaudeCodeFixtureResult {
+	sourceSessionId: string;
+	shortId: string;
+	notePath: string;
+	wroteNote: boolean;
+	warning?: string;
+}
+
+export async function syncClaudeCodeFixture(
+	options: SyncClaudeCodeFixtureOptions,
+): Promise<SyncClaudeCodeFixtureResult> {
+	const session = await claudeCodeAdapter.parse(options.sourcePath);
+	const digests = computeDigests(session.harness, session.source_session_id);
+	const processedAt = (options.now ?? (() => new Date()))().toISOString();
+	const ledger = openLedger(options.ledgerPath);
+
+	try {
+		const shortId = resolveSessionShortId(ledger, session, digests);
+		const notePath = sessionNotePath(
+			options.outputPath,
+			session.started_at,
+			session.harness,
+			shortId,
+		);
+		const noteRelativePath = relative(options.outputPath, notePath);
+
+		const update = await updateGeneratedRegions({
+			notePath,
+			template: renderSkeletonSessionNote(session),
+			regions: skeletonRegions(session),
+		});
+
+		if (!update.warning) {
+			upsertSessionSkeleton(ledger, {
+				session,
+				note_path: noteRelativePath,
+				processed_at: processedAt,
+				digests,
+				short_id: shortId,
+			});
+		}
+
+		return {
+			sourceSessionId: session.source_session_id,
+			shortId,
+			notePath,
+			wroteNote: update.wrote,
+			warning: update.warning,
+		};
+	} finally {
+		ledger.close();
+	}
+}
+
+function sessionNotePath(
+	outputPath: string,
+	startedAt: string,
+	harness: string,
+	shortId: string,
+): string {
+	const date = new Date(startedAt);
+	const year = String(date.getUTCFullYear());
+	const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+	return join(outputPath, "sessions", year, month, harness, `${shortId}.md`);
+}

--- a/tests/claude_code_adapter.test.ts
+++ b/tests/claude_code_adapter.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+	parseClaudeCodeSession,
+	truncateToolOutput,
+} from "../src/adapters/claude_code.ts";
+import { cleanupTempDirs, createTempDir, jsonl } from "./helpers/test-files.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	cleanupTempDirs(tempDirs);
+});
+
+describe("Claude Code adapter", () => {
+	test("maps Claude Code records to canonical session events", async () => {
+		const dir = createTempDir(tempDirs, "jottrace-cc-adapter-test-");
+		const sourcePath = join(dir, "bbbbbbbb-cccc-dddd-eeee-ffffffffffff.jsonl");
+		await Bun.write(
+			sourcePath,
+			jsonl([
+				{
+					type: "permission-mode",
+					permissionMode: "auto",
+					sessionId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+				},
+				{
+					type: "file-history-snapshot",
+					sessionId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+					timestamp: "2026-05-01T09:59:00.000Z",
+				},
+				{
+					type: "user",
+					message: { role: "user", content: "Check the project" },
+					timestamp: "2026-05-01T10:00:00.000Z",
+					cwd: "/Users/season/Personal/jottrace",
+					sessionId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+					gitBranch: "main",
+				},
+				{
+					type: "assistant",
+					message: {
+						role: "assistant",
+						model: "claude-opus-4-7",
+						content: [
+							{ type: "text", text: "I will inspect files." },
+							{
+								type: "tool_use",
+								id: "toolu_123",
+								name: "Bash",
+								input: { command: "ls" },
+							},
+						],
+					},
+					timestamp: "2026-05-01T10:01:00.000Z",
+					cwd: "/Users/season/Personal/jottrace",
+					sessionId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+					gitBranch: "main",
+				},
+				{
+					type: "user",
+					message: {
+						role: "user",
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: "toolu_123",
+								content: "src\nREADME.md",
+								is_error: false,
+							},
+						],
+					},
+					timestamp: "2026-05-01T10:02:00.000Z",
+					cwd: "/Users/season/Personal/jottrace",
+					sessionId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+					gitBranch: "main",
+				},
+				{
+					type: "last-prompt",
+					lastPrompt: "Check the project",
+					sessionId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+				},
+			]),
+		);
+
+		const session = await parseClaudeCodeSession(sourcePath);
+
+		expect(session.source_session_id).toBe(
+			"bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+		);
+		expect(session.project).toBe("jottrace");
+		expect(session.git_branch).toBe("main");
+		expect(session.model).toBe("claude-opus-4-7");
+		expect(session.started_at).toBe("2026-05-01T09:59:00.000Z");
+		expect(session.ended_at).toBe("2026-05-01T10:02:00.000Z");
+		expect(session.events.map((event) => event.kind)).toEqual([
+			"system",
+			"system",
+			"user",
+			"assistant",
+			"tool_call",
+			"tool_result",
+			"system",
+		]);
+		expect(session.events[0]?.extra).toEqual({ subtype: "permission-mode" });
+		expect(session.events[1]?.extra).toEqual({
+			subtype: "file-history-snapshot",
+		});
+		expect(session.events[4]).toMatchObject({
+			kind: "tool_call",
+			tool: "Bash",
+			tool_call_id: "toolu_123",
+			tool_input: { command: "ls" },
+		});
+		expect(session.events[5]).toMatchObject({
+			kind: "tool_result",
+			tool_call_id: "toolu_123",
+			tool_output: "src\nREADME.md",
+		});
+		expect(session.events[6]?.extra).toEqual({ subtype: "last-prompt" });
+	});
+
+	test("uses the JSONL filename as source id and links sidechains to parent session id", async () => {
+		const dir = createTempDir(tempDirs, "jottrace-cc-adapter-test-");
+		const sourcePath = join(dir, "agent-a0fa7c4.jsonl");
+		await Bun.write(
+			sourcePath,
+			jsonl([
+				{
+					parentUuid: null,
+					isSidechain: true,
+					type: "user",
+					message: { role: "user", content: "Inspect schema files" },
+					timestamp: "2026-05-01T10:00:00.000Z",
+					cwd: "/Users/season/Personal/jottrace",
+					sessionId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+					agentId: "a0fa7c4",
+				},
+			]),
+		);
+
+		const session = await parseClaudeCodeSession(sourcePath);
+
+		expect(session.source_session_id).toBe("agent-a0fa7c4");
+		expect(session.parent_session_id).toBe(
+			"bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+		);
+	});
+
+	test("does not treat a main-session record sessionId as a parent link", async () => {
+		const dir = createTempDir(tempDirs, "jottrace-cc-adapter-test-");
+		const sourcePath = join(dir, "bbbbbbbb-cccc-dddd-eeee-ffffffffffff.jsonl");
+		await Bun.write(
+			sourcePath,
+			jsonl([
+				{
+					parentUuid: null,
+					isSidechain: false,
+					type: "user",
+					message: { role: "user", content: "Inspect schema files" },
+					timestamp: "2026-05-01T10:00:00.000Z",
+					cwd: "/Users/season/Personal/jottrace",
+					sessionId: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+				},
+			]),
+		);
+
+		const session = await parseClaudeCodeSession(sourcePath);
+
+		expect(session.source_session_id).toBe(
+			"bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+		);
+		expect(session.parent_session_id).toBeNull();
+	});
+
+	test("truncates normal tool outputs to the last 4 KB", () => {
+		const output = `${"a".repeat(1000)}${"b".repeat(4096)}`;
+
+		const truncated = truncateToolOutput(output);
+
+		expect(truncated).toBe(`[…1000 bytes elided…]${"b".repeat(4096)}`);
+	});
+
+	test("truncates errored tool outputs to the first 1 KB and last 3 KB", () => {
+		const output = `${"a".repeat(2000)}${"b".repeat(4000)}`;
+
+		const truncated = truncateToolOutput(output, { exit_code: 1 });
+
+		expect(truncated).toBe(
+			`${"a".repeat(1024)}[…1904 bytes elided…]${"b".repeat(3072)}`,
+		);
+	});
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { cleanupTempDirs, createTempDir, jsonl } from "./helpers/test-files.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	cleanupTempDirs(tempDirs);
+});
+
+describe("jottrace CLI", () => {
+	test("sync reads a Claude Code fixture path and prints the note path", async () => {
+		const dir = createTempDir(tempDirs, "jottrace-cli-test-");
+		const sourcePath = join(dir, "cccccccc-dddd-eeee-ffff-000000000000.jsonl");
+		const outputPath = join(dir, "journal");
+		const ledgerPath = join(dir, "jottrace.db");
+		const lockPath = join(dir, "jottrace.lock");
+		await Bun.write(
+			sourcePath,
+			jsonl([
+				{
+					type: "user",
+					message: { role: "user", content: "Make a note" },
+					timestamp: "2026-05-01T11:00:00.000Z",
+					cwd: "/Users/season/Personal/jottrace",
+					sessionId: "cccccccc-dddd-eeee-ffff-000000000000",
+				},
+			]),
+		);
+
+		const result = await runCliSync(
+			sourcePath,
+			outputPath,
+			ledgerPath,
+			lockPath,
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		const notePath = result.stdout.trim();
+		expect(notePath).toMatch(
+			/sessions\/2026\/05\/claude-code\/[0-9a-f]{12}\.md$/,
+		);
+		expect(existsSync(notePath)).toBe(true);
+		expect(existsSync(lockPath)).toBe(false);
+	});
+
+	test("sync exits nonzero when generated region update aborts", async () => {
+		const dir = createTempDir(tempDirs, "jottrace-cli-test-");
+		const sourcePath = join(dir, "dddddddd-eeee-ffff-0000-111111111111.jsonl");
+		const outputPath = join(dir, "journal");
+		const ledgerPath = join(dir, "jottrace.db");
+		const lockPath = join(dir, "jottrace.lock");
+		await Bun.write(
+			sourcePath,
+			jsonl([
+				{
+					type: "user",
+					message: { role: "user", content: "Make a note" },
+					timestamp: "2026-05-01T11:00:00.000Z",
+					cwd: "/Users/season/Personal/jottrace",
+					sessionId: "dddddddd-eeee-ffff-0000-111111111111",
+				},
+			]),
+		);
+
+		const first = await runCliSync(
+			sourcePath,
+			outputPath,
+			ledgerPath,
+			lockPath,
+		);
+		expect(first.exitCode).toBe(0);
+		const notePath = first.stdout.trim();
+		await Bun.write(
+			notePath,
+			`${await Bun.file(notePath).text()}\n<!-- jottrace:summary:start v=1 -->\n`,
+		);
+
+		const second = await runCliSync(
+			sourcePath,
+			outputPath,
+			ledgerPath,
+			lockPath,
+		);
+
+		expect(second.exitCode).toBe(1);
+		expect(second.stdout).toBe("");
+		expect(second.stderr).toContain("summary");
+		expect(existsSync(lockPath)).toBe(false);
+	});
+});
+
+async function runCliSync(
+	sourcePath: string,
+	outputPath: string,
+	ledgerPath: string,
+	lockPath: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const child = Bun.spawn(
+		[
+			process.execPath,
+			"src/cli.ts",
+			"sync",
+			"--fixture",
+			sourcePath,
+			"--output",
+			outputPath,
+			"--db",
+			ledgerPath,
+			"--lock",
+			lockPath,
+		],
+		{
+			cwd: process.cwd(),
+			stderr: "pipe",
+			stdout: "pipe",
+		},
+	);
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	return { stdout, stderr, exitCode };
+}

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+	emitFrontmatter,
+	parseFrontmatter,
+} from "../src/render/frontmatter.ts";
+
+describe("frontmatter rendering", () => {
+	test("emits and parses renderer-owned YAML metadata", () => {
+		const markdown = `${emitFrontmatter({
+			type: "jottrace-session",
+			harness: "claude-code",
+			source_session_id: "session with spaces",
+			model: "123",
+			project: "true",
+			synthesis_attempts: 0,
+			parent_session_id: null,
+		})}# Jottrace Session
+`;
+
+		expect(markdown).toContain('source_session_id: "session with spaces"');
+		expect(markdown).toContain('model: "123"');
+		expect(markdown).toContain('project: "true"');
+		expect(parseFrontmatter(markdown)).toEqual({
+			type: "jottrace-session",
+			harness: "claude-code",
+			source_session_id: "session with spaces",
+			model: "123",
+			project: "true",
+			synthesis_attempts: 0,
+			parent_session_id: null,
+		});
+	});
+});

--- a/tests/helpers/test-files.ts
+++ b/tests/helpers/test-files.ts
@@ -1,0 +1,22 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function createTempDir(
+	tempDirs: string[],
+	prefix = "jottrace-test-",
+): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+export function cleanupTempDirs(tempDirs: string[]): void {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { force: true, recursive: true });
+	}
+}
+
+export function jsonl(records: unknown[]): string {
+	return `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+}

--- a/tests/ledger.test.ts
+++ b/tests/ledger.test.ts
@@ -3,6 +3,7 @@ import {
 	computeDigests,
 	type Ledger,
 	openLedger,
+	upsertSessionSkeleton,
 	upsertTopicCandidate,
 } from "../src/ledger.ts";
 import type { Session } from "../src/models.ts";
@@ -130,6 +131,32 @@ describe("insertSession with short_id collision", () => {
 			)
 			.get("claude-code", "session-B");
 		expect(persistedB?.short_id).toBe(fullB);
+	});
+
+	test("upsertSessionSkeleton reports collision recovery when pre-resolved to full digest", () => {
+		const sessionA = makeSession({ source_session_id: "session-A" });
+		const sessionB = makeSession({ source_session_id: "session-B" });
+
+		ledger.insertSession(sessionA, {
+			short: "a".repeat(12),
+			full: `${"a".repeat(12)}${"1".repeat(52)}`,
+		});
+
+		const fullB = `${"a".repeat(12)}${"2".repeat(52)}`;
+		const result = upsertSessionSkeleton(ledger, {
+			session: sessionB,
+			note_path: "sessions/2026/05/claude-code/session-B.md",
+			processed_at: "2026-05-02T08:00:00.000Z",
+			digests: {
+				short: "a".repeat(12),
+				full: fullB,
+			},
+		});
+
+		expect(result).toEqual({
+			short_id: fullB,
+			collision_recovered: true,
+		});
 	});
 
 	test("computeDigests returns 12-hex short and 64-hex full from sha256(harness:id)", () => {

--- a/tests/regions.test.ts
+++ b/tests/regions.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { updateGeneratedRegions } from "../src/render/regions.ts";
+import { renderRegion } from "../src/render/session_md.ts";
+import { cleanupTempDirs, createTempDir } from "./helpers/test-files.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	cleanupTempDirs(tempDirs);
+});
+
+describe("generated region updates", () => {
+	test("replaces marker content while preserving hand edits outside markers", async () => {
+		const dir = createTempDir(tempDirs, "jottrace-regions-test-");
+		const notePath = join(dir, "note.md");
+		await Bun.write(
+			notePath,
+			[
+				"---",
+				"type: jottrace-session",
+				"---",
+				"",
+				"# Jottrace Session",
+				"",
+				"personal note before",
+				"",
+				renderRegion("summary", "old summary"),
+				"",
+				"personal note between",
+				"",
+				renderRegion("timeline", "old timeline"),
+				"",
+				"personal note after",
+				"",
+			].join("\n"),
+		);
+
+		const result = await updateGeneratedRegions({
+			notePath,
+			template: "",
+			regions: {
+				summary: "new summary",
+				timeline: "new timeline",
+			},
+		});
+
+		const updated = await Bun.file(notePath).text();
+		expect(result).toEqual({ wrote: true });
+		expect(updated).toContain("personal note before");
+		expect(updated).toContain("personal note between");
+		expect(updated).toContain("personal note after");
+		expect(updated).toContain(renderRegion("summary", "new summary"));
+		expect(updated).toContain(renderRegion("timeline", "new timeline"));
+		expect(updated).not.toContain("old summary");
+		expect(updated).not.toContain("old timeline");
+	});
+
+	test("aborts without rewriting when a marker pair is malformed", async () => {
+		const dir = createTempDir(tempDirs, "jottrace-regions-test-");
+		const notePath = join(dir, "note.md");
+		const original = [
+			"# Jottrace Session",
+			"",
+			"personal note before",
+			"",
+			"<!-- jottrace:summary:start v=1 -->",
+			"old summary",
+			"",
+			"personal note after",
+			"",
+		].join("\n");
+		await Bun.write(notePath, original);
+
+		const result = await updateGeneratedRegions({
+			notePath,
+			template: "",
+			regions: { summary: "new summary" },
+		});
+
+		expect(result.wrote).toBe(false);
+		expect(result.warning).toContain("summary");
+		expect(await Bun.file(notePath).text()).toBe(original);
+	});
+
+	test("aborts when an otherwise valid region has an extra unmatched marker", async () => {
+		const dir = createTempDir(tempDirs, "jottrace-regions-test-");
+		const notePath = join(dir, "note.md");
+		const original = [
+			"# Jottrace Session",
+			"",
+			renderRegion("summary", "old summary"),
+			"",
+			"<!-- jottrace:summary:start v=1 -->",
+			"dangling duplicate",
+			"",
+		].join("\n");
+		await Bun.write(notePath, original);
+
+		const result = await updateGeneratedRegions({
+			notePath,
+			template: "",
+			regions: { summary: "new summary" },
+		});
+
+		expect(result.wrote).toBe(false);
+		expect(result.warning).toContain("summary");
+		expect(await Bun.file(notePath).text()).toBe(original);
+	});
+});

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,0 +1,157 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { SESSION_REGION_NAMES } from "../src/render/session_md.ts";
+import { syncClaudeCodeFixture } from "../src/sync.ts";
+import { cleanupTempDirs, createTempDir, jsonl } from "./helpers/test-files.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	cleanupTempDirs(tempDirs);
+});
+
+describe("Claude Code fixture sync", () => {
+	test("writes one skeleton session note and a pending ledger row", async () => {
+		const dir = createTempDir(tempDirs, "jottrace-sync-test-");
+		const sourcePath = join(dir, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+		const outputPath = join(dir, "journal");
+		const ledgerPath = join(dir, "jottrace.db");
+
+		await Bun.write(
+			sourcePath,
+			jsonl([
+				{
+					type: "permission-mode",
+					permissionMode: "auto",
+					sessionId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+				},
+				{
+					parentUuid: null,
+					isSidechain: false,
+					type: "user",
+					message: { role: "user", content: "Summarize this project" },
+					uuid: "user-1",
+					timestamp: "2026-05-01T10:15:00.000Z",
+					cwd: "/Users/season/Personal/jottrace",
+					sessionId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					gitBranch: "codex/issue-4-tracer-bullet",
+					version: "2.1.118",
+				},
+				{
+					parentUuid: "user-1",
+					isSidechain: false,
+					type: "assistant",
+					message: {
+						role: "assistant",
+						model: "claude-opus-4-7",
+						content: [{ type: "text", text: "I will inspect the repo." }],
+					},
+					uuid: "assistant-1",
+					timestamp: "2026-05-01T10:16:00.000Z",
+					cwd: "/Users/season/Personal/jottrace",
+					sessionId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					gitBranch: "codex/issue-4-tracer-bullet",
+				},
+			]),
+		);
+
+		const result = await syncClaudeCodeFixture({
+			sourcePath,
+			outputPath,
+			ledgerPath,
+			now: () => new Date("2026-05-02T08:00:00.000Z"),
+		});
+
+		expect(result.notePath).toMatch(
+			/sessions\/2026\/05\/claude-code\/[0-9a-f]{12}\.md$/,
+		);
+		expect(result.wroteNote).toBe(true);
+		expect(existsSync(result.notePath)).toBe(true);
+
+		const note = await Bun.file(result.notePath).text();
+		expect(note).toContain("type: jottrace-session");
+		expect(note).toContain("harness: claude-code");
+		expect(note).toContain(
+			"source_session_id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		);
+		expect(note).toContain("# Jottrace Session");
+		expect(markerCount(note)).toBe(SESSION_REGION_NAMES.length * 2);
+		for (const name of SESSION_REGION_NAMES) {
+			expect(note).toContain(`<!-- jottrace:${name}:start v=1 -->`);
+			expect(note).toContain(`<!-- jottrace:${name}:end -->`);
+		}
+		expect(note).toContain("Source file:");
+		expect(note).toContain(
+			"_synthesis pending — run `jottrace synth` after restoring LLM connectivity_",
+		);
+
+		const db = new Database(ledgerPath, { readonly: true });
+		const row = db
+			.query<
+				{
+					synthesis_status: string;
+					synthesis_attempts: number;
+					processed_at: string;
+					note_path: string;
+				},
+				[]
+			>(
+				"SELECT synthesis_status, synthesis_attempts, processed_at, note_path FROM sessions",
+			)
+			.get();
+		db.close();
+
+		expect(row).toEqual({
+			synthesis_status: "pending",
+			synthesis_attempts: 0,
+			processed_at: "2026-05-02T08:00:00.000Z",
+			note_path: relative(outputPath, result.notePath),
+		});
+
+		const before = statSync(result.notePath).mtimeMs;
+		const second = await syncClaudeCodeFixture({
+			sourcePath,
+			outputPath,
+			ledgerPath,
+			now: () => new Date("2026-05-02T08:01:00.000Z"),
+		});
+		const after = statSync(result.notePath).mtimeMs;
+
+		expect(second.wroteNote).toBe(false);
+		expect(after).toBe(before);
+
+		const dbAfterSecondRun = new Database(ledgerPath, { readonly: true });
+		const afterSecondRun = dbAfterSecondRun
+			.query<{ processed_at: string }, []>("SELECT processed_at FROM sessions")
+			.get();
+		dbAfterSecondRun.close();
+		expect(afterSecondRun?.processed_at).toBe("2026-05-02T08:00:00.000Z");
+
+		await Bun.write(
+			result.notePath,
+			`${await Bun.file(result.notePath).text()}\n<!-- jottrace:summary:start v=1 -->\n`,
+		);
+
+		const malformed = await syncClaudeCodeFixture({
+			sourcePath,
+			outputPath,
+			ledgerPath,
+			now: () => new Date("2026-05-02T08:02:00.000Z"),
+		});
+
+		expect(malformed.wroteNote).toBe(false);
+		expect(malformed.warning).toContain("summary");
+		const dbAfterMalformedRun = new Database(ledgerPath, { readonly: true });
+		const afterMalformedRun = dbAfterMalformedRun
+			.query<{ processed_at: string }, []>("SELECT processed_at FROM sessions")
+			.get();
+		dbAfterMalformedRun.close();
+		expect(afterMalformedRun?.processed_at).toBe("2026-05-02T08:00:00.000Z");
+	});
+});
+
+function markerCount(note: string): number {
+	return note.match(/<!-- jottrace:[^>]+ -->/g)?.length ?? 0;
+}


### PR DESCRIPTION
## Summary
- add a Claude Code adapter and registry for parsing JSONL exports into canonical session skeletons
- render deterministic session notes with generated regions, frontmatter, and user-edit preservation
- wire the minimal fixture sync CLI path with ledger updates, locking, and malformed-region safety

## Validation
- bun test
- bunx tsc --noEmit
- bunx biome check .
- git diff --check

Closes #4