### PR TITLE
[codex] Add installer and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: Check installer shell syntax
+        run: bash -n install.sh
+
       - name: Run tests
         run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.artifact }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - artifact: linux-arm64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - artifact: darwin-arm64
+            os: macos-14
+            target: aarch64-apple-darwin
+          - artifact: darwin-x86_64
+            os: macos-15-intel
+            target: x86_64-apple-darwin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --locked --target "${{ matrix.target }}"
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist package
+          cp "target/${{ matrix.target }}/release/jottrace" package/jottrace
+          chmod 0755 package/jottrace
+          tar -C package -czf "dist/jottrace-${{ matrix.artifact }}.tar.gz" jottrace
+          (cd dist && shasum -a 256 "jottrace-${{ matrix.artifact }}.tar.gz" > "jottrace-${{ matrix.artifact }}.tar.gz.sha256")
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.artifact }}
+          path: dist/*
+          if-no-files-found: error
+
+  installer-smoke:
+    name: Installer smoke
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-linux-x86_64
+          path: ${{ runner.temp }}/jottrace-release/${{ github.ref_name }}
+
+      - name: Install from staged release artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          export HOME="${RUNNER_TEMP}/jottrace-home"
+          export PATH="${HOME}/.local/bin:${PATH}"
+          export JOTTRACE_VERSION="${GITHUB_REF_NAME}"
+          export JOTTRACE_RELEASE_BASE_URL="file://${RUNNER_TEMP}/jottrace-release"
+          bash install.sh
+          "${HOME}/.local/bin/jottrace" --version
+
+  publish:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: installer-smoke
+
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" dist/* --title "${GITHUB_REF_NAME}" --notes "Release ${GITHUB_REF_NAME}" --verify-tag

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="season179/jottrace"
+version="${JOTTRACE_VERSION:-latest}"
+
+if [ -z "${HOME:-}" ]; then
+  echo "jottrace installer: HOME is not set" >&2
+  exit 1
+fi
+
+detect_target() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "${os}:${arch}" in
+    Darwin:arm64) echo "darwin-arm64" ;;
+    Darwin:x86_64) echo "darwin-x86_64" ;;
+    Linux:x86_64) echo "linux-x86_64" ;;
+    Linux:aarch64 | Linux:arm64) echo "linux-arm64" ;;
+    *)
+      echo "jottrace installer: unsupported platform ${os}/${arch}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+release_url() {
+  local target artifact
+  target="$1"
+  artifact="jottrace-${target}.tar.gz"
+
+  if [ -n "${JOTTRACE_RELEASE_BASE_URL:-}" ]; then
+    echo "${JOTTRACE_RELEASE_BASE_URL%/}/${version}/${artifact}"
+  elif [ "$version" = "latest" ]; then
+    echo "https://github.com/${repo}/releases/latest/download/${artifact}"
+  else
+    echo "https://github.com/${repo}/releases/download/${version}/${artifact}"
+  fi
+}
+
+target="$(detect_target)"
+artifact_url="$(release_url "$target")"
+install_dir="${HOME}/.local/bin"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+archive="${tmp_dir}/jottrace.tar.gz"
+echo "Downloading jottrace for ${target}..."
+curl -fsSL "$artifact_url" -o "$archive"
+
+tar -xzf "$archive" -C "$tmp_dir"
+if [ ! -f "${tmp_dir}/jottrace" ]; then
+  echo "jottrace installer: artifact did not contain a jottrace binary" >&2
+  exit 1
+fi
+
+mkdir -p "$install_dir"
+install -m 0755 "${tmp_dir}/jottrace" "${install_dir}/jottrace"
+
+echo "Installed jottrace to ${install_dir}/jottrace"
+
+case ":${PATH:-}:" in
+  *":${install_dir}:"*) ;;
+  *)
+    echo
+    echo "${install_dir} is not on PATH."
+    echo "Add it by pasting this into your shell rc file:"
+    echo '  export PATH="$HOME/.local/bin:$PATH"'
+    ;;
+esac

--- a/tests/installer.rs
+++ b/tests/installer.rs
@@ -1,0 +1,163 @@
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+#[test]
+fn installer_downloads_matching_release_artifact_to_local_bin() {
+    let Some(target) = current_installer_target() else {
+        eprintln!("skipping installer smoke test on unsupported test host");
+        return;
+    };
+
+    let root = temp_root("installer-smoke");
+    let home = root.join("home");
+    let releases = root.join("releases");
+    let tag = "vtest";
+    fs::create_dir_all(&home).expect("create home");
+    create_release_artifact(&root, &releases, tag, target);
+
+    let install_dir = home.join(".local/bin");
+    let output = Command::new("bash")
+        .arg("install.sh")
+        .env("HOME", &home)
+        .env("PATH", format!("{}:/usr/bin:/bin", install_dir.display()))
+        .env("JOTTRACE_VERSION", tag)
+        .env(
+            "JOTTRACE_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .output()
+        .expect("run installer");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let installed = install_dir.join("jottrace");
+    assert!(
+        installed.exists(),
+        "installer should create ~/.local/bin/jottrace"
+    );
+    #[cfg(unix)]
+    assert_ne!(
+        fs::metadata(&installed).expect("installed metadata").mode() & 0o111,
+        0,
+        "installed jottrace should be executable"
+    );
+
+    let version = Command::new(&installed)
+        .arg("--version")
+        .output()
+        .expect("run installed jottrace");
+    assert!(version.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).trim(),
+        "jottrace 0.1.0"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn installer_prints_path_hint_without_editing_shell_rc_files() {
+    let Some(target) = current_installer_target() else {
+        eprintln!("skipping installer hint test on unsupported test host");
+        return;
+    };
+
+    let root = temp_root("installer-path-hint");
+    let home = root.join("home");
+    let releases = root.join("releases");
+    let tag = "vtest";
+    fs::create_dir_all(&home).expect("create home");
+    fs::write(home.join(".zshrc"), "# existing zsh config\n").expect("write zshrc");
+    fs::write(home.join(".bashrc"), "# existing bash config\n").expect("write bashrc");
+    create_release_artifact(&root, &releases, tag, target);
+
+    let output = Command::new("bash")
+        .arg("install.sh")
+        .env("HOME", &home)
+        .env("PATH", "/usr/bin:/bin")
+        .env("JOTTRACE_VERSION", tag)
+        .env(
+            "JOTTRACE_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .output()
+        .expect("run installer");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("export PATH=\"$HOME/.local/bin:$PATH\""));
+    assert_eq!(
+        fs::read_to_string(home.join(".zshrc")).expect("read zshrc"),
+        "# existing zsh config\n"
+    );
+    assert_eq!(
+        fs::read_to_string(home.join(".bashrc")).expect("read bashrc"),
+        "# existing bash config\n"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+fn create_release_artifact(
+    root: &std::path::Path,
+    releases: &std::path::Path,
+    tag: &str,
+    target: &str,
+) {
+    let release_dir = releases.join(tag);
+    let payload_dir = root.join(format!("payload-{target}"));
+    fs::create_dir_all(&release_dir).expect("create release dir");
+    fs::create_dir_all(&payload_dir).expect("create payload dir");
+
+    let fake_binary = payload_dir.join("jottrace");
+    fs::write(
+        &fake_binary,
+        "#!/usr/bin/env sh\nif [ \"$1\" = \"--version\" ]; then echo 'jottrace 0.1.0'; else exit 64; fi\n",
+    )
+    .expect("write fake binary");
+    #[cfg(unix)]
+    fs::set_permissions(&fake_binary, fs::Permissions::from_mode(0o755))
+        .expect("chmod fake binary");
+
+    let artifact = release_dir.join(format!("jottrace-{target}.tar.gz"));
+    let tar_status = Command::new("tar")
+        .args(["-C", payload_dir.to_str().expect("utf8 payload path")])
+        .args(["-czf", artifact.to_str().expect("utf8 artifact path")])
+        .arg("jottrace")
+        .status()
+        .expect("create release artifact");
+    assert!(tar_status.success(), "tar should create test artifact");
+}
+
+fn current_installer_target() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => Some("linux-x86_64"),
+        ("linux", "aarch64") => Some("linux-arm64"),
+        ("macos", "aarch64") => Some("darwin-arm64"),
+        ("macos", "x86_64") => Some("darwin-x86_64"),
+        _ => None,
+    }
+}
+
+fn temp_root(name: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!("jottrace-{name}-{}-{unique}", std::process::id()))
+}


### PR DESCRIPTION
## Summary

- Add a GitHub-hosted `install.sh` that detects OS/arch, downloads the matching release artifact, and installs `jottrace` to `~/.local/bin` without editing shell rc files.
- Add installer integration tests for artifact install and PATH hint behavior.
- Add tag-push release automation that builds per-platform artifacts, publishes checksums, smoke-tests the installer, and creates the GitHub Release.
- Add CI shell syntax checking for the installer.

Closes #20.

## Validation

- `bash -n install.sh`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`