### PR TITLE
Enforce CalVer release versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,11 @@ jobs:
       - name: Check installer shell syntax
         run: bash -n install.sh
 
+      - name: Check version script shell syntax
+        run: bash -n scripts/check-version.sh
+
+      - name: Check version policy
+        run: scripts/check-version.sh
+
       - name: Run tests
         run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check version policy
+        run: scripts/check-version.sh
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "jottrace"
-version = "0.1.0"
+version = "26.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jottrace"
-version = "0.1.0"
+version = "26.5.0"
 edition = "2024"
 license = "MIT"
 description = "Preserve AI coding-session transcripts into a local journal"

--- a/README.md
+++ b/README.md
@@ -62,14 +62,21 @@ cargo run -- doctor
 
 ## Maintainer Release
 
+Jottrace uses CalVer in `YY.M.PATCH` form. For example, the first release in
+May 2026 is `v26.5.0`; later releases in the same month increment the patch
+segment, such as `v26.5.1`.
+
+`scripts/check-version.sh` enforces that `Cargo.toml` uses this shape and that
+release tags match the Cargo package version.
+
 The release workflow runs on version tags and publishes the artifacts consumed
 by `install.sh`.
 
 ```sh
 git checkout main
 git pull --ff-only
-git tag v0.1.0
-git push origin v0.1.0
+git tag v26.5.0
+git push origin v26.5.0
 ```
 
 After the `Release` GitHub Action finishes, the install command above should

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest="${JOTTRACE_CARGO_TOML:-Cargo.toml}"
+tag="${1:-}"
+
+if [ ! -f "$manifest" ]; then
+  echo "version check failed: missing Cargo manifest at ${manifest}" >&2
+  exit 1
+fi
+
+version="$(sed -n 's/^version = "\([^"]*\)".*/\1/p' "$manifest" | head -n 1)"
+
+if [ -z "$version" ]; then
+  echo "version check failed: could not find package version in ${manifest}" >&2
+  exit 1
+fi
+
+if [[ ! "$version" =~ ^[1-9][0-9]\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)$ ]]; then
+  echo "version check failed: Cargo.toml version must use YY.M.PATCH CalVer, got ${version}" >&2
+  echo "example: 26.5.0" >&2
+  exit 1
+fi
+
+if [ -z "$tag" ] && [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+  tag="${GITHUB_REF_NAME:-}"
+fi
+
+if [ -n "$tag" ] && [ "$tag" != "v${version}" ]; then
+  echo "version check failed: release tag ${tag} must match Cargo.toml version v${version}" >&2
+  exit 1
+fi
+
+echo "version check ok: ${version}"

--- a/tests/installer.rs
+++ b/tests/installer.rs
@@ -58,7 +58,7 @@ fn installer_downloads_matching_release_artifact_to_local_bin() {
     assert!(version.status.success());
     assert_eq!(
         String::from_utf8_lossy(&version.stdout).trim(),
-        "jottrace 0.1.0"
+        "jottrace 26.5.0"
     );
 
     let _ = fs::remove_dir_all(root);
@@ -127,7 +127,7 @@ fn create_release_artifact(
     let fake_binary = payload_dir.join("jottrace");
     fs::write(
         &fake_binary,
-        "#!/usr/bin/env sh\nif [ \"$1\" = \"--version\" ]; then echo 'jottrace 0.1.0'; else exit 64; fi\n",
+        "#!/usr/bin/env sh\nif [ \"$1\" = \"--version\" ]; then echo 'jottrace 26.5.0'; else exit 64; fi\n",
     )
     .expect("write fake binary");
     #[cfg(unix)]

--- a/tests/version_policy.rs
+++ b/tests/version_policy.rs
@@ -1,0 +1,78 @@
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn version_policy_accepts_yy_month_patch_and_matching_tag() {
+    let root = temp_root("version-valid");
+    let manifest = root.join("Cargo.toml");
+    fs::create_dir_all(&root).expect("create temp root");
+    fs::write(&manifest, manifest_with_version("26.5.0")).expect("write manifest");
+
+    let output = Command::new("bash")
+        .arg("scripts/check-version.sh")
+        .arg("v26.5.0")
+        .env("JOTTRACE_CARGO_TOML", &manifest)
+        .output()
+        .expect("run version check");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn version_policy_rejects_four_numeric_segments() {
+    let root = temp_root("version-four-segments");
+    let manifest = root.join("Cargo.toml");
+    fs::create_dir_all(&root).expect("create temp root");
+    fs::write(&manifest, manifest_with_version("26.5.5.0")).expect("write manifest");
+
+    let output = Command::new("bash")
+        .arg("scripts/check-version.sh")
+        .env("JOTTRACE_CARGO_TOML", &manifest)
+        .output()
+        .expect("run version check");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("YY.M.PATCH"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn version_policy_rejects_tag_that_does_not_match_cargo_version() {
+    let root = temp_root("version-tag-mismatch");
+    let manifest = root.join("Cargo.toml");
+    fs::create_dir_all(&root).expect("create temp root");
+    fs::write(&manifest, manifest_with_version("26.5.0")).expect("write manifest");
+
+    let output = Command::new("bash")
+        .arg("scripts/check-version.sh")
+        .arg("v26.5.1")
+        .env("JOTTRACE_CARGO_TOML", &manifest)
+        .output()
+        .expect("run version check");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("must match"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+fn manifest_with_version(version: &str) -> String {
+    format!("[package]\nname = \"jottrace\"\nversion = \"{version}\"\nedition = \"2024\"\n")
+}
+
+fn temp_root(name: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!("jottrace-{name}-{}-{unique}", std::process::id()))
+}


### PR DESCRIPTION
## Summary

- Switch the crate version to the first CalVer release version, `26.5.0`.
- Add `scripts/check-version.sh` to enforce `YY.M.PATCH` and reject mismatched release tags.
- Run the version policy in CI and release builds before artifacts are produced.
- Document the release version scheme in the README.

## Validation

- `bash -n scripts/check-version.sh`
- `scripts/check-version.sh`
- `scripts/check-version.sh v26.5.0`
- `git diff --check`
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`