### PR TITLE
Add SQLite storage core and `jottrace status`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,263 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "jottrace"
 version = "26.5.0"
+dependencies = [
+ "rusqlite",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ license = "MIT"
 description = "Preserve AI coding-session transcripts into a local journal"
 
 [dependencies]
+rusqlite = { version = "0.39.0", default-features = false, features = ["bundled"] }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Jottrace preserves local AI coding-session transcripts into a journal you
 control. The first CLI surface is intentionally small: install the binary,
-check the version, and run `doctor` to verify the local data directory is
-private enough for transcript data.
+check the version, run `doctor` to verify the local data directory is private
+enough for transcript data, and run `status` to inspect the local database.
 
 ## Install
 
@@ -33,11 +33,15 @@ After installing, run:
 ```sh
 jottrace --version
 jottrace doctor
+jottrace status
 ```
 
 `jottrace doctor` creates or checks the local data directory at `~/.jottrace`
 and reports whether its permissions are private. On Unix systems, the directory
 is expected to use mode `0700`.
+
+`jottrace status` initializes `~/.jottrace/db.sqlite` if needed and reports
+session, event, and unresolved ingest-error counts.
 
 ## Update
 
@@ -58,6 +62,7 @@ Run the development binary with:
 
 ```sh
 cargo run -- doctor
+cargo run -- status
 ```
 
 ## Maintainer Release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
 
+pub mod storage;
+pub use storage::{StatusReport, run_status};
+
 /// Default per-user data directory name for the current MVP.
 pub const APP_DIR_NAME: &str = ".jottrace";
 /// Session transcripts may contain private code, prompts, and paths, so the
@@ -28,12 +31,26 @@ pub enum JottraceError {
     /// Refuse to reuse a path with the right name but the wrong kind; treating
     /// it as a directory would make later writes fail in surprising ways.
     NotDirectory(PathBuf),
+    /// Refuse to reuse a filesystem node as a state file unless it is a regular
+    /// file. SQLite needs a durable file path, not a directory or special file.
+    NotFile(PathBuf),
     /// Existing loose permissions are surfaced instead of silently chmodded so
     /// the user can notice and decide whether the location is trustworthy.
     InsecureMode {
         path: PathBuf,
         expected: u32,
         actual: u32,
+    },
+    /// The local database was created by a newer Jottrace than this binary
+    /// knows how to read safely.
+    UnsupportedSchemaVersion {
+        path: PathBuf,
+        actual: i64,
+        supported: i64,
+    },
+    Sqlite {
+        path: PathBuf,
+        source: rusqlite::Error,
     },
 }
 
@@ -45,6 +62,7 @@ impl fmt::Display for JottraceError {
             Self::NotDirectory(path) => {
                 write!(f, "{} exists but is not a directory", path.display())
             }
+            Self::NotFile(path) => write!(f, "{} exists but is not a file", path.display()),
             Self::InsecureMode {
                 path,
                 expected,
@@ -56,6 +74,18 @@ impl fmt::Display for JottraceError {
                 actual,
                 expected
             ),
+            Self::UnsupportedSchemaVersion {
+                path,
+                actual,
+                supported,
+            } => write!(
+                f,
+                "{} has schema version {}; this binary supports up to {}",
+                path.display(),
+                actual,
+                supported
+            ),
+            Self::Sqlite { path, source } => write!(f, "{}: {}", path.display(), source),
         }
     }
 }
@@ -64,6 +94,7 @@ impl std::error::Error for JottraceError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io { source, .. } => Some(source),
+            Self::Sqlite { source, .. } => Some(source),
             _ => None,
         }
     }
@@ -141,6 +172,30 @@ pub fn create_private_file(path: &Path) -> Result<File> {
     Ok(file)
 }
 
+/// Ensure a regular file exists and is private enough for local state.
+pub fn ensure_private_file(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        ensure_private_dir(parent)?;
+    }
+
+    match fs::metadata(path) {
+        Ok(metadata) => {
+            if !metadata.is_file() {
+                return Err(JottraceError::NotFile(path.to_path_buf()));
+            }
+            ensure_file_mode(path)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            drop(create_private_file(path)?);
+            Ok(())
+        }
+        Err(source) => Err(JottraceError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
 #[cfg(unix)]
 fn create_private_dir(path: &Path) -> Result<()> {
     let mut builder = fs::DirBuilder::new();
@@ -180,6 +235,24 @@ fn ensure_dir_mode(path: &Path) -> Result<()> {
 fn ensure_dir_mode(_path: &Path) -> Result<()> {
     // The numeric Unix mode contract does not apply on Windows; platform-
     // specific ACL hardening can be added behind this same check later.
+    Ok(())
+}
+
+#[cfg(unix)]
+fn ensure_file_mode(path: &Path) -> Result<()> {
+    let actual = mode(path)?;
+    if actual != PRIVATE_FILE_MODE {
+        return Err(JottraceError::InsecureMode {
+            path: path.to_path_buf(),
+            expected: PRIVATE_FILE_MODE,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_file_mode(_path: &Path) -> Result<()> {
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Some("doctor") => run_doctor_command(),
+        Some("status") => run_status_command(),
         Some(command) => {
             eprintln!("unknown command: {command}");
             eprintln!("run `jottrace --help` for usage");
@@ -44,6 +45,27 @@ fn run_doctor_command() -> ExitCode {
     }
 }
 
+fn run_status_command() -> ExitCode {
+    match jottrace::run_status() {
+        Ok(report) => {
+            println!("jottrace status");
+            println!("db: {}", report.db_path.display());
+            println!("schema_version: {}", report.schema_version);
+            println!("sessions: {}", report.session_count);
+            println!("events: {}", report.event_count);
+            println!(
+                "unresolved_ingest_errors: {}",
+                report.unresolved_ingest_error_count
+            );
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("jottrace status failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
 fn print_help() {
     // Cargo exposes package metadata at compile time, so --version and help
     // cannot drift away from Cargo.toml.
@@ -52,5 +74,6 @@ fn print_help() {
     println!();
     println!("Usage:");
     println!("  jottrace doctor");
+    println!("  jottrace status");
     println!("  jottrace --version");
 }

--- a/src/migrations/001_initial_schema.sql
+++ b/src/migrations/001_initial_schema.sql
@@ -1,0 +1,71 @@
+CREATE TABLE sessions (
+    id INTEGER PRIMARY KEY,
+    source TEXT NOT NULL,
+    source_session_id TEXT NOT NULL,
+    file_path TEXT,
+    cwd TEXT,
+    parent_session_id INTEGER REFERENCES sessions(id) ON DELETE SET NULL,
+    started_at TEXT,
+    ended_at TEXT,
+    current_generation INTEGER NOT NULL DEFAULT 0 CHECK (current_generation >= 0),
+    file_mtime INTEGER,
+    file_size INTEGER,
+    content_fingerprint TEXT,
+    next_read_offset INTEGER NOT NULL DEFAULT 0 CHECK (next_read_offset >= 0),
+    event_count INTEGER NOT NULL DEFAULT 0 CHECK (event_count >= 0),
+    last_read_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE UNIQUE INDEX idx_sessions_source_session_id
+    ON sessions (source, source_session_id);
+
+CREATE INDEX idx_sessions_source_started_at
+    ON sessions (source, started_at);
+
+CREATE INDEX idx_sessions_parent_session_id
+    ON sessions (parent_session_id)
+    WHERE parent_session_id IS NOT NULL;
+
+CREATE TABLE events (
+    session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    generation INTEGER NOT NULL CHECK (generation >= 0),
+    seq INTEGER NOT NULL CHECK (seq >= 0),
+    ts TEXT,
+    payload BLOB NOT NULL,
+    codec TEXT NOT NULL CHECK (codec IN ('raw', 'zstd')),
+    payload_size INTEGER NOT NULL CHECK (payload_size >= 0),
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (session_id, generation, seq)
+) WITHOUT ROWID;
+
+CREATE INDEX idx_events_session_ts
+    ON events (session_id, ts)
+    WHERE ts IS NOT NULL;
+
+CREATE TABLE ingest_errors (
+    id INTEGER PRIMARY KEY,
+    source TEXT NOT NULL,
+    source_session_id TEXT,
+    session_id INTEGER REFERENCES sessions(id) ON DELETE SET NULL,
+    file_path TEXT NOT NULL,
+    generation INTEGER CHECK (generation IS NULL OR generation >= 0),
+    byte_offset INTEGER CHECK (byte_offset IS NULL OR byte_offset >= 0),
+    line_number INTEGER CHECK (line_number IS NULL OR line_number >= 0),
+    error_kind TEXT NOT NULL,
+    message TEXT NOT NULL,
+    first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    last_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    occurrence_count INTEGER NOT NULL DEFAULT 1 CHECK (occurrence_count >= 1),
+    resolved_at TEXT,
+    resolution_note TEXT
+);
+
+CREATE INDEX idx_ingest_errors_unresolved
+    ON ingest_errors (source, source_session_id, file_path)
+    WHERE resolved_at IS NULL;
+
+CREATE INDEX idx_ingest_errors_session_unresolved
+    ON ingest_errors (session_id)
+    WHERE resolved_at IS NULL AND session_id IS NOT NULL;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,268 @@
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::{JottraceError, Result, data_dir_from_env, ensure_private_file};
+
+pub const DB_FILE_NAME: &str = "db.sqlite";
+pub const LATEST_SCHEMA_VERSION: i64 = 1;
+
+const MIGRATIONS: &[Migration] = &[Migration {
+    version: 1,
+    sql: include_str!("migrations/001_initial_schema.sql"),
+}];
+
+#[derive(Debug)]
+struct Migration {
+    version: i64,
+    sql: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusReport {
+    pub db_path: PathBuf,
+    pub schema_version: i64,
+    pub session_count: u64,
+    pub event_count: u64,
+    pub unresolved_ingest_error_count: u64,
+}
+
+pub fn db_path_from_env() -> Result<PathBuf> {
+    Ok(data_dir_from_env()?.join(DB_FILE_NAME))
+}
+
+pub fn run_status() -> Result<StatusReport> {
+    let db_path = db_path_from_env()?;
+    status_for_path(&db_path)
+}
+
+pub fn status_for_path(path: &Path) -> Result<StatusReport> {
+    let conn = open_database(path)?;
+    status_from_connection(path, &conn)
+}
+
+pub fn open_database(path: &Path) -> Result<Connection> {
+    ensure_private_file(path)?;
+
+    let mut conn = Connection::open(path).map_err(|source| sqlite_error(path, source))?;
+    configure_connection(path, &conn)?;
+    run_migrations(path, &mut conn)?;
+    Ok(conn)
+}
+
+fn configure_connection(path: &Path, conn: &Connection) -> Result<()> {
+    conn.busy_timeout(Duration::from_secs(5))
+        .map_err(|source| sqlite_error(path, source))?;
+    conn.execute_batch(
+        "PRAGMA foreign_keys = ON;
+         PRAGMA journal_mode = WAL;",
+    )
+    .map_err(|source| sqlite_error(path, source))
+}
+
+fn run_migrations(path: &Path, conn: &mut Connection) -> Result<()> {
+    let current = user_version(path, conn)?;
+
+    if current > LATEST_SCHEMA_VERSION {
+        return Err(JottraceError::UnsupportedSchemaVersion {
+            path: path.to_path_buf(),
+            actual: current,
+            supported: LATEST_SCHEMA_VERSION,
+        });
+    }
+
+    if current == LATEST_SCHEMA_VERSION {
+        return Ok(());
+    }
+
+    let tx = conn
+        .transaction()
+        .map_err(|source| sqlite_error(path, source))?;
+
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version > current)
+    {
+        tx.execute_batch(migration.sql)
+            .map_err(|source| sqlite_error(path, source))?;
+        tx.pragma_update(None, "user_version", migration.version)
+            .map_err(|source| sqlite_error(path, source))?;
+    }
+
+    tx.commit().map_err(|source| sqlite_error(path, source))
+}
+
+fn status_from_connection(path: &Path, conn: &Connection) -> Result<StatusReport> {
+    Ok(StatusReport {
+        db_path: path.to_path_buf(),
+        schema_version: user_version(path, conn)?,
+        session_count: count(path, conn, "SELECT COUNT(*) FROM sessions")?,
+        event_count: count(path, conn, "SELECT COUNT(*) FROM events")?,
+        unresolved_ingest_error_count: count(
+            path,
+            conn,
+            "SELECT COUNT(*) FROM ingest_errors WHERE resolved_at IS NULL",
+        )?,
+    })
+}
+
+fn count(path: &Path, conn: &Connection, sql: &str) -> Result<u64> {
+    let value: i64 = conn
+        .query_row(sql, [], |row| row.get(0))
+        .map_err(|source| sqlite_error(path, source))?;
+    Ok(value as u64)
+}
+
+fn user_version(path: &Path, conn: &Connection) -> Result<i64> {
+    conn.query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(|source| sqlite_error(path, source))
+}
+
+fn sqlite_error(path: &Path, source: rusqlite::Error) -> JottraceError {
+    JottraceError::Sqlite {
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn fresh_database_runs_initial_migration() {
+        let root = temp_root("storage-fresh");
+        let db_path = root.join(DB_FILE_NAME);
+
+        let conn = open_database(&db_path).expect("open database");
+
+        assert_eq!(
+            user_version(&db_path, &conn).expect("user_version"),
+            LATEST_SCHEMA_VERSION
+        );
+        assert_sql_object(&conn, "table", "sessions");
+        assert_sql_object(&conn, "table", "events");
+        assert_sql_object(&conn, "table", "ingest_errors");
+        assert_sql_object(&conn, "index", "idx_sessions_source_session_id");
+        assert_sql_object(&conn, "index", "idx_sessions_source_started_at");
+        assert_sql_object(&conn, "index", "idx_events_session_ts");
+        assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved");
+
+        assert!(columns(&conn, "sessions").contains(&"id".to_string()));
+        assert!(columns(&conn, "sessions").contains(&"source_session_id".to_string()));
+        assert!(columns(&conn, "events").contains(&"generation".to_string()));
+        assert!(columns(&conn, "events").contains(&"payload".to_string()));
+        assert!(columns(&conn, "events").contains(&"codec".to_string()));
+        assert!(columns(&conn, "ingest_errors").contains(&"resolved_at".to_string()));
+
+        let report = status_from_connection(&db_path, &conn).expect("status");
+        assert_eq!(report.session_count, 0);
+        assert_eq!(report.event_count, 0);
+        assert_eq!(report.unresolved_ingest_error_count, 0);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn migrates_existing_v0_database_to_latest_version() {
+        let root = temp_root("storage-upgrade");
+        let db_path = root.join(DB_FILE_NAME);
+        ensure_private_file(&db_path).expect("create db file");
+
+        {
+            let conn = Connection::open(&db_path).expect("open v0 db");
+            conn.execute("CREATE TABLE v0_marker (id INTEGER PRIMARY KEY)", [])
+                .expect("create marker");
+            conn.execute("INSERT INTO v0_marker DEFAULT VALUES", [])
+                .expect("insert marker");
+            conn.pragma_update(None, "user_version", 0)
+                .expect("set user_version");
+        }
+
+        let conn = open_database(&db_path).expect("migrate db");
+
+        assert_eq!(
+            user_version(&db_path, &conn).expect("user_version"),
+            LATEST_SCHEMA_VERSION
+        );
+        assert_sql_object(&conn, "table", "sessions");
+        let marker_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM v0_marker", [], |row| row.get(0))
+            .expect("marker count");
+        assert_eq!(marker_count, 1);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn status_counts_unresolved_ingest_errors_only() {
+        let root = temp_root("storage-status");
+        let db_path = root.join(DB_FILE_NAME);
+        let conn = open_database(&db_path).expect("open database");
+
+        conn.execute(
+            "INSERT INTO sessions (source, source_session_id) VALUES ('claude_cli', 's1')",
+            [],
+        )
+        .expect("insert session");
+        conn.execute(
+            "INSERT INTO events (session_id, generation, seq, payload, codec, payload_size)
+             VALUES (1, 0, 0, x'7B7D', 'raw', 2)",
+            [],
+        )
+        .expect("insert event");
+        conn.execute(
+            "INSERT INTO ingest_errors
+                (source, source_session_id, session_id, file_path, error_kind, message)
+             VALUES ('claude_cli', 's1', 1, '/tmp/s1.jsonl', 'invalid_json', 'bad line')",
+            [],
+        )
+        .expect("insert unresolved error");
+        conn.execute(
+            "INSERT INTO ingest_errors
+                (source, source_session_id, session_id, file_path, error_kind, message, resolved_at)
+             VALUES ('claude_cli', 's1', 1, '/tmp/s1.jsonl', 'invalid_json', 'fixed', '2026-05-05T00:00:00Z')",
+            [],
+        )
+        .expect("insert resolved error");
+
+        let report = status_from_connection(&db_path, &conn).expect("status");
+        assert_eq!(report.session_count, 1);
+        assert_eq!(report.event_count, 1);
+        assert_eq!(report.unresolved_ingest_error_count, 1);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    fn assert_sql_object(conn: &Connection, kind: &str, name: &str) {
+        let found: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = ?1 AND name = ?2",
+                [kind, name],
+                |row| row.get(0),
+            )
+            .expect("query sqlite_master");
+        assert_eq!(found, 1, "{kind} {name} should exist");
+    }
+
+    fn columns(conn: &Connection, table: &str) -> Vec<String> {
+        let mut statement = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .expect("prepare table_info");
+        statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query columns")
+            .map(|row| row.expect("column name"))
+            .collect()
+    }
+
+    fn temp_root(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!("jottrace-{name}-{}-{unique}", std::process::id()))
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -51,6 +51,42 @@ fn doctor_creates_private_data_dir() {
     let _ = fs::remove_dir_all(root);
 }
 
+#[test]
+fn status_reports_empty_fresh_database() {
+    let root = temp_root("status-empty");
+    let data_dir = root.join(".jottrace");
+
+    let output = Command::new(binary())
+        .arg("status")
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace status");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("jottrace status"));
+    assert!(stdout.contains("sessions: 0"));
+    assert!(stdout.contains("events: 0"));
+    assert!(stdout.contains("unresolved_ingest_errors: 0"));
+
+    let db_path = data_dir.join("db.sqlite");
+    assert!(
+        db_path.exists(),
+        "status should initialize the local database"
+    );
+
+    #[cfg(unix)]
+    assert_eq!(mode(&db_path), 0o600);
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[cfg(unix)]
 #[test]
 fn doctor_rejects_insecure_existing_data_dir() {


### PR DESCRIPTION
Fixes #22.

## Summary
- Add the embedded SQLite foundation with `PRAGMA user_version` migrations, the initial `sessions` / `events` / `ingest_errors` schema, and targeted indexes.
- Implement `jottrace status` to open the local DB, run migrations on demand, and report session, event, and unresolved ingest-error counts.
- Update the README to reflect the new command and add coverage for fresh DB and upgrade-path behavior.

## Testing
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`