### PR TITLE
[codex] Harden JSONL ingest append safety

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -6,7 +6,7 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-use crate::storage::{db_path_from_env, open_database, sqlite_error, status_from_connection};
+use crate::storage::{DB_FILE_NAME, open_database, sqlite_error, status_from_connection};
 use crate::{JottraceError, Result};
 
 const CLAUDE_SOURCE: &str = "claude_cli";
@@ -41,6 +41,7 @@ struct SourceFile {
 #[derive(Debug, Clone)]
 struct StoredSession {
     id: i64,
+    file_path: Option<String>,
     current_generation: i64,
     file_size: Option<i64>,
     file_mtime: Option<i64>,
@@ -101,8 +102,10 @@ struct SnapshotHeader<'a> {
 }
 
 pub fn run_ingest() -> Result<IngestReport> {
+    let data_dir = crate::data_dir_from_env()?;
+    let _lock = crate::acquire_data_lock(&data_dir)?;
     let source_files = discover_claude_session_files()?;
-    let db_path = db_path_from_env()?;
+    let db_path = data_dir.join(DB_FILE_NAME);
     let mut conn = open_database(&db_path)?;
     let mut inserted_event_count = 0;
 
@@ -202,6 +205,9 @@ fn ingest_jsonl_file(conn: &mut Connection, source_file: &SourceFile) -> Result<
     if let Some(stored) = load_session(conn, source_file)?
         && unchanged_by_mtime(&stored, pass_size, file_mtime)
     {
+        if stored.file_path.as_deref() == Some(source_file.path.to_string_lossy().as_ref()) {
+            return Ok(0);
+        }
         let tx = conn
             .transaction()
             .map_err(|source| sqlite_error(&source_file.path, source))?;
@@ -365,18 +371,19 @@ fn insert_session_if_missing(tx: &Transaction<'_>, source_file: &SourceFile) -> 
 
 fn load_session(conn: &Connection, source_file: &SourceFile) -> Result<Option<StoredSession>> {
     conn.query_row(
-        "SELECT id, current_generation, file_size, file_mtime, content_fingerprint, next_read_offset
+        "SELECT id, file_path, current_generation, file_size, file_mtime, content_fingerprint, next_read_offset
          FROM sessions
          WHERE source = ?1 AND source_session_id = ?2",
         params![source_file.source, source_file.source_session_id.as_str()],
         |row| {
             Ok(StoredSession {
                 id: row.get(0)?,
-                current_generation: row.get(1)?,
-                file_size: row.get(2)?,
-                file_mtime: row.get(3)?,
-                content_fingerprint: row.get(4)?,
-                next_read_offset: row.get(5)?,
+                file_path: row.get(1)?,
+                current_generation: row.get(2)?,
+                file_size: row.get(3)?,
+                file_mtime: row.get(4)?,
+                content_fingerprint: row.get(5)?,
+                next_read_offset: row.get(6)?,
             })
         },
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 use std::env;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(unix)]
 use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
@@ -14,6 +15,8 @@ pub use storage::{StatusReport, run_status};
 
 /// Default per-user data directory name for the current MVP.
 pub const APP_DIR_NAME: &str = ".jottrace";
+/// Single-instance guard for commands that mutate the local database.
+pub const LOCK_FILE_NAME: &str = "jottrace.lock";
 /// Session transcripts may contain private code, prompts, and paths, so the
 /// default directory is readable only by the current user.
 pub const PRIVATE_DIR_MODE: u32 = 0o700;
@@ -50,6 +53,8 @@ pub enum JottraceError {
         actual: i64,
         supported: i64,
     },
+    /// A DB-mutating command is already active in this data directory.
+    LockHeld(PathBuf),
     Sqlite {
         path: PathBuf,
         source: rusqlite::Error,
@@ -86,6 +91,11 @@ impl fmt::Display for JottraceError {
                 path.display(),
                 actual,
                 supported
+            ),
+            Self::LockHeld(path) => write!(
+                f,
+                "another jottrace DB-mutating command is already running; lock: {}",
+                path.display()
             ),
             Self::Sqlite { path, source } => write!(f, "{}: {}", path.display(), source),
         }
@@ -129,6 +139,49 @@ pub fn run_doctor() -> Result<DoctorReport> {
     Ok(DoctorReport { data_dir })
 }
 
+pub(crate) struct DataLock {
+    path: PathBuf,
+    token: String,
+}
+
+pub(crate) fn acquire_data_lock(data_dir: &Path) -> Result<DataLock> {
+    ensure_private_dir(data_dir)?;
+    let path = data_dir.join(LOCK_FILE_NAME);
+    let token = lock_token();
+
+    let mut file = match create_private_file(&path) {
+        Ok(file) => file,
+        Err(JottraceError::Io {
+            path: error_path,
+            source,
+        }) if source.kind() == io::ErrorKind::AlreadyExists => {
+            return Err(JottraceError::LockHeld(error_path));
+        }
+        Err(error) => return Err(error),
+    };
+
+    if let Err(source) = writeln!(file, "{token}") {
+        let _ = fs::remove_file(&path);
+        return Err(JottraceError::Io {
+            path: path.clone(),
+            source,
+        });
+    }
+
+    Ok(DataLock { path, token })
+}
+
+impl Drop for DataLock {
+    fn drop(&mut self) {
+        let Ok(contents) = fs::read_to_string(&self.path) else {
+            return;
+        };
+        if contents.trim_end() == self.token {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
 /// Ensure a directory exists and is private enough for transcript data.
 pub fn ensure_private_dir(path: &Path) -> Result<()> {
     match fs::metadata(path) {
@@ -169,7 +222,10 @@ pub fn create_private_file(path: &Path) -> Result<File> {
     #[cfg(unix)]
     // The open mode is the first line of defense, but chmod after creation
     // corrects for umask and keeps behavior stable across Unix environments.
-    set_mode(path, PRIVATE_FILE_MODE)?;
+    if let Err(error) = set_mode(path, PRIVATE_FILE_MODE) {
+        let _ = fs::remove_file(path);
+        return Err(error);
+    }
 
     Ok(file)
 }
@@ -293,6 +349,13 @@ fn private_open_options() -> OpenOptions {
     // afterwards would leave a small window with process-default permissions.
     options.mode(PRIVATE_FILE_MODE);
     options
+}
+
+fn lock_token() -> String {
+    let started_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!("pid={}\nstarted_at_ns={started_at}", std::process::id())
 }
 
 #[cfg(test)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,6 +2,7 @@ mod common;
 
 use common::reader_fixture;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -84,7 +85,7 @@ fn status_reports_empty_fresh_database() {
     assert!(stdout.contains("events: 0"));
     assert!(stdout.contains("unresolved_ingest_errors: 0"));
 
-    let db_path = data_dir.join("db.sqlite");
+    let db_path = db_path(&data_dir);
     assert!(
         db_path.exists(),
         "status should initialize the local database"
@@ -102,20 +103,13 @@ fn ingest_is_idempotent_for_unchanged_claude_cli_fixture() {
     let data_dir = root.join(".jottrace");
     install_primary_claude_fixture(&root);
 
-    for _ in 0..2 {
-        let output = Command::new(binary())
-            .arg("ingest")
-            .env("HOME", &root)
-            .env("JOTTRACE_HOME", &data_dir)
-            .output()
-            .expect("run jottrace ingest");
-        assert!(
-            output.status.success(),
-            "stdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    let first = run_ingest(&root, &data_dir);
+    assert!(first.contains("events: 12"));
+    assert!(first.contains("inserted_events: 12"));
+
+    let second = run_ingest(&root, &data_dir);
+    assert!(second.contains("events: 12"));
+    assert!(second.contains("inserted_events: 0"));
 
     let status = Command::new(binary())
         .arg("status")
@@ -127,6 +121,115 @@ fn ingest_is_idempotent_for_unchanged_claude_cli_fixture() {
     assert!(stdout.contains("sessions: 1"));
     assert!(stdout.contains("events: 12"));
 
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let event_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+        .expect("event count");
+    assert_eq!(event_count, 12);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_appends_only_new_complete_claude_cli_lines() {
+    let root = temp_root("ingest-append");
+    let data_dir = root.join(".jottrace");
+    let session_file = install_primary_claude_fixture(&root);
+
+    let first = run_ingest(&root, &data_dir);
+    assert!(first.contains("events: 12"));
+    assert!(first.contains("inserted_events: 12"));
+
+    let appended_line = first_fixture_line();
+    let mut file = fs::OpenOptions::new()
+        .append(true)
+        .open(&session_file)
+        .expect("open session for append");
+    file.write_all(&appended_line).expect("append event line");
+    file.write_all(b"\n").expect("append newline");
+
+    let second = run_ingest(&root, &data_dir);
+    assert!(second.contains("events: 13"));
+    assert!(second.contains("inserted_events: 1"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let event_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+        .expect("event count");
+    let last_seq: i64 = conn
+        .query_row("SELECT MAX(seq) FROM events", [], |row| row.get(0))
+        .expect("last seq");
+    assert_eq!(event_count, 13);
+    assert_eq!(last_seq, 12);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_defers_unterminated_claude_cli_tail() {
+    let root = temp_root("ingest-partial-tail");
+    let data_dir = root.join(".jottrace");
+    let session_file = install_primary_claude_fixture(&root);
+
+    let first = run_ingest(&root, &data_dir);
+    assert!(first.contains("events: 12"));
+    assert!(first.contains("inserted_events: 12"));
+    let original_len = fs::metadata(&session_file).expect("session metadata").len() as i64;
+
+    let appended_line = first_fixture_line();
+    let partial_len = appended_line.len() / 2;
+    let mut file = fs::OpenOptions::new()
+        .append(true)
+        .open(&session_file)
+        .expect("open session for partial append");
+    file.write_all(&appended_line[..partial_len])
+        .expect("append partial event line");
+
+    let second = run_ingest(&root, &data_dir);
+    assert!(second.contains("events: 12"));
+    assert!(second.contains("inserted_events: 0"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let (event_count, file_size, next_read_offset): (i64, i64, i64) = conn
+        .query_row(
+            "SELECT event_count, file_size, next_read_offset
+             FROM sessions
+             WHERE source = 'claude_cli'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("session offsets");
+    assert_eq!(event_count, 12);
+    assert_eq!(file_size, original_len + partial_len as i64);
+    assert_eq!(next_read_offset, original_len);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_reports_lock_contention_as_clear_cli_failure() {
+    let root = temp_root("ingest-lock-held");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+    let mut lock_file = jottrace::create_private_file(&data_dir.join(jottrace::LOCK_FILE_NAME))
+        .expect("create held lock");
+    lock_file
+        .write_all(b"held by integration test\n")
+        .expect("write held lock");
+
+    let output = Command::new(binary())
+        .arg("ingest")
+        .env("HOME", &root)
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace ingest");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("jottrace ingest failed"));
+    assert!(stderr.contains("another jottrace DB-mutating command is already running"));
+    assert!(stderr.contains(jottrace::LOCK_FILE_NAME));
+
     let _ = fs::remove_dir_all(root);
 }
 
@@ -136,19 +239,7 @@ fn ingest_preserves_claude_cli_fixture_and_status_reports_counts() {
     let data_dir = root.join(".jottrace");
     let session_file = install_primary_claude_fixture(&root);
 
-    let ingest = Command::new(binary())
-        .arg("ingest")
-        .env("HOME", &root)
-        .env("JOTTRACE_HOME", &data_dir)
-        .output()
-        .expect("run jottrace ingest");
-
-    assert!(
-        ingest.status.success(),
-        "stdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&ingest.stdout),
-        String::from_utf8_lossy(&ingest.stderr)
-    );
+    run_ingest(&root, &data_dir);
 
     let status = Command::new(binary())
         .arg("status")
@@ -168,7 +259,7 @@ fn ingest_preserves_claude_cli_fixture_and_status_reports_counts() {
     assert!(stdout.contains("events: 12"));
     assert!(stdout.contains("unresolved_ingest_errors: 0"));
 
-    let conn = Connection::open(data_dir.join("db.sqlite")).expect("open preserved db");
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
     let (source_session_id, cwd, started_at, ended_at, event_count, file_size, file_mtime): (
         String,
         String,
@@ -263,6 +354,26 @@ fn first_fixture_line() -> Vec<u8> {
         .next()
         .expect("first line")
         .to_vec()
+}
+
+fn run_ingest(home: &Path, data_dir: &Path) -> String {
+    let output = Command::new(binary())
+        .arg("ingest")
+        .env("HOME", home)
+        .env("JOTTRACE_HOME", data_dir)
+        .output()
+        .expect("run jottrace ingest");
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("stdout should be utf-8")
+}
+
+fn db_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(jottrace::storage::DB_FILE_NAME)
 }
 
 fn install_primary_claude_fixture(root: &Path) -> PathBuf {


### PR DESCRIPTION
Closes #24

## Summary
- Add a single-instance data lock around DB-mutating ingest runs so concurrent writers fail clearly before source-scan and offset decisions.
- Expand CLI integration coverage for idempotent no-op reruns, append-only complete JSONL lines, unterminated partial tails, and lock contention.
- Avoid unnecessary no-op SQLite writes for unchanged files while preserving metadata updates when the same source session is discovered at a new path.

## Validation
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo fmt --check
- git diff --check