### PR TITLE
[codex] Record ingest errors without blocking files

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -77,10 +77,10 @@ struct SessionUpdate<'a> {
 
 struct IngestErrorRecord<'a> {
     source_file: &'a SourceFile,
-    session_id: i64,
-    generation: i64,
-    byte_offset: i64,
-    line_number: i64,
+    session_id: Option<i64>,
+    generation: Option<i64>,
+    byte_offset: Option<i64>,
+    line_number: Option<i64>,
     error_kind: &'a str,
     message: &'a str,
 }
@@ -122,7 +122,13 @@ pub fn run_ingest() -> Result<IngestReport> {
     let mut inserted_event_count = 0;
 
     for source_file in &source_files {
-        inserted_event_count += ingest_jsonl_file(&mut conn, source_file)?;
+        match ingest_jsonl_file(&mut conn, source_file) {
+            Ok(inserted) => inserted_event_count += inserted,
+            Err(error) if is_source_file_ingest_error(&error) => {
+                record_source_file_ingest_error(&mut conn, source_file, &error)?;
+            }
+            Err(error) => return Err(error),
+        }
     }
 
     let status = status_from_connection(&db_path, &conn)?;
@@ -362,10 +368,10 @@ fn import_committed_lines(
                     tx,
                     IngestErrorRecord {
                         source_file,
-                        session_id,
-                        generation,
-                        byte_offset: byte_offset as i64,
-                        line_number: seq,
+                        session_id: Some(session_id),
+                        generation: Some(generation),
+                        byte_offset: Some(byte_offset as i64),
+                        line_number: Some(seq + 1),
                         error_kind: "invalid_json",
                         message: &error.to_string(),
                     },
@@ -383,6 +389,45 @@ fn import_committed_lines(
         next_read_offset,
         metadata,
     })
+}
+
+fn record_source_file_ingest_error(
+    conn: &mut Connection,
+    source_file: &SourceFile,
+    error: &JottraceError,
+) -> Result<()> {
+    let tx = conn
+        .transaction()
+        .map_err(|source| sqlite_error(&source_file.path, source))?;
+    insert_session_if_missing(&tx, source_file)?;
+    let stored = load_session(&tx, source_file)?.expect("session row should exist after insert");
+    let message = error.to_string();
+    record_ingest_error(
+        &tx,
+        IngestErrorRecord {
+            source_file,
+            session_id: Some(stored.id),
+            generation: Some(stored.current_generation),
+            byte_offset: None,
+            line_number: None,
+            error_kind: source_file_error_kind(error),
+            message: &message,
+        },
+    )?;
+    tx.commit()
+        .map_err(|source| sqlite_error(&source_file.path, source))
+}
+
+fn is_source_file_ingest_error(error: &JottraceError) -> bool {
+    matches!(error, JottraceError::Io { .. } | JottraceError::NotFile(_))
+}
+
+fn source_file_error_kind(error: &JottraceError) -> &'static str {
+    match error {
+        JottraceError::Io { .. } => "read_error",
+        JottraceError::NotFile(_) => "not_file",
+        _ => "ingest_error",
+    }
 }
 
 fn insert_session_if_missing(tx: &Transaction<'_>, source_file: &SourceFile) -> Result<()> {
@@ -519,18 +564,20 @@ fn record_ingest_error(tx: &Transaction<'_>, record: IngestErrorRecord<'_>) -> R
     let updated = tx
         .execute(
             "UPDATE ingest_errors
-             SET message = ?1,
+             SET session_id = ?1,
+                 message = ?2,
                  last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
                  occurrence_count = occurrence_count + 1
-             WHERE source = ?2
-               AND source_session_id = ?3
-               AND file_path = ?4
-               AND generation = ?5
-               AND byte_offset = ?6
-               AND line_number = ?7
-               AND error_kind = ?8
+             WHERE source = ?3
+               AND source_session_id = ?4
+               AND file_path = ?5
+               AND generation IS ?6
+               AND byte_offset IS ?7
+               AND line_number IS ?8
+               AND error_kind = ?9
                AND resolved_at IS NULL",
             params![
+                record.session_id,
                 record.message,
                 record.source_file.source,
                 record.source_file.source_session_id.as_str(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
 pub mod ingest;
 pub mod storage;
 pub use ingest::{IngestReport, run_ingest};
-pub use storage::{StatusReport, run_status};
+pub use storage::{IngestErrorSummary, StatusReport, run_status};
 
 /// Default per-user data directory name for the current MVP.
 pub const APP_DIR_NAME: &str = ".jottrace";
@@ -23,6 +23,7 @@ pub const PRIVATE_DIR_MODE: u32 = 0o700;
 /// Files are kept even tighter than directories: readable and writable by the
 /// current user, with no group/world access.
 pub const PRIVATE_FILE_MODE: u32 = 0o600;
+const DOCTOR_INGEST_ERROR_LIMIT: usize = 5;
 
 #[derive(Debug)]
 pub enum JottraceError {
@@ -117,6 +118,8 @@ pub type Result<T> = std::result::Result<T, JottraceError>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DoctorReport {
     pub data_dir: PathBuf,
+    pub unresolved_ingest_error_count: u64,
+    pub recent_ingest_errors: Vec<IngestErrorSummary>,
 }
 
 /// Resolve the data directory from the environment.
@@ -136,7 +139,20 @@ pub fn data_dir_from_env() -> Result<PathBuf> {
 pub fn run_doctor() -> Result<DoctorReport> {
     let data_dir = data_dir_from_env()?;
     ensure_private_dir(&data_dir)?;
-    Ok(DoctorReport { data_dir })
+    let db_path = data_dir.join(storage::DB_FILE_NAME);
+    let conn = storage::open_database(&db_path)?;
+    let unresolved_ingest_error_count =
+        storage::unresolved_ingest_error_count_from_connection(&db_path, &conn)?;
+    let ingest_errors = storage::unresolved_ingest_errors_from_connection(
+        &db_path,
+        &conn,
+        DOCTOR_INGEST_ERROR_LIMIT,
+    )?;
+    Ok(DoctorReport {
+        data_dir,
+        unresolved_ingest_error_count,
+        recent_ingest_errors: ingest_errors,
+    })
 }
 
 pub(crate) struct DataLock {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,38 @@ fn run_doctor_command() -> ExitCode {
             println!("jottrace doctor");
             println!("data_dir: {} (ok)", report.data_dir.display());
             println!("permissions: private (ok)");
+            println!(
+                "unresolved_ingest_errors: {}",
+                report.unresolved_ingest_error_count
+            );
+            if !report.recent_ingest_errors.is_empty() {
+                println!(
+                    "recent_ingest_errors: {}",
+                    report.recent_ingest_errors.len()
+                );
+            }
+            for ingest_error in &report.recent_ingest_errors {
+                println!("recent_ingest_error:");
+                println!("  source: {}", ingest_error.source);
+                if let Some(source_session_id) = &ingest_error.source_session_id {
+                    println!("  source_session_id: {source_session_id}");
+                }
+                println!("  file: {}", ingest_error.file_path.display());
+                if let Some(line_number) = ingest_error.line_number {
+                    println!("  line: {line_number}");
+                }
+                if let Some(byte_offset) = ingest_error.byte_offset {
+                    println!("  byte_offset: {byte_offset}");
+                }
+                if let Some(generation) = ingest_error.generation {
+                    println!("  generation: {generation}");
+                }
+                println!("  kind: {}", ingest_error.error_kind);
+                println!("  first_seen_at: {}", ingest_error.first_seen_at);
+                println!("  last_seen_at: {}", ingest_error.last_seen_at);
+                println!("  occurrences: {}", ingest_error.occurrence_count);
+                println!("  message: {}", ingest_error.message);
+            }
             ExitCode::SUCCESS
         }
         Err(error) => {

--- a/src/migrations/002_ingest_error_recency_index.sql
+++ b/src/migrations/002_ingest_error_recency_index.sql
@@ -1,0 +1,7 @@
+UPDATE ingest_errors
+SET line_number = line_number + 1
+WHERE line_number IS NOT NULL;
+
+CREATE INDEX idx_ingest_errors_unresolved_last_seen
+    ON ingest_errors (last_seen_at DESC, id DESC)
+    WHERE resolved_at IS NULL;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,16 +1,24 @@
-use rusqlite::Connection;
+use rusqlite::{Connection, Row, params};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::{JottraceError, Result, data_dir_from_env, ensure_private_file};
 
 pub const DB_FILE_NAME: &str = "db.sqlite";
-pub const LATEST_SCHEMA_VERSION: i64 = 1;
+pub const LATEST_SCHEMA_VERSION: i64 = 2;
 
-const MIGRATIONS: &[Migration] = &[Migration {
-    version: 1,
-    sql: include_str!("migrations/001_initial_schema.sql"),
-}];
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        sql: include_str!("migrations/001_initial_schema.sql"),
+    },
+    Migration {
+        version: 2,
+        sql: include_str!("migrations/002_ingest_error_recency_index.sql"),
+    },
+];
+const UNRESOLVED_INGEST_ERROR_COUNT_SQL: &str =
+    "SELECT COUNT(*) FROM ingest_errors WHERE resolved_at IS NULL";
 
 #[derive(Debug)]
 struct Migration {
@@ -27,6 +35,21 @@ pub struct StatusReport {
     pub unresolved_ingest_error_count: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IngestErrorSummary {
+    pub source: String,
+    pub source_session_id: Option<String>,
+    pub file_path: PathBuf,
+    pub generation: Option<i64>,
+    pub byte_offset: Option<i64>,
+    pub line_number: Option<i64>,
+    pub error_kind: String,
+    pub message: String,
+    pub first_seen_at: String,
+    pub last_seen_at: String,
+    pub occurrence_count: u64,
+}
+
 pub fn db_path_from_env() -> Result<PathBuf> {
     Ok(data_dir_from_env()?.join(DB_FILE_NAME))
 }
@@ -39,6 +62,14 @@ pub fn run_status() -> Result<StatusReport> {
 pub fn status_for_path(path: &Path) -> Result<StatusReport> {
     let conn = open_database(path)?;
     status_from_connection(path, &conn)
+}
+
+pub fn unresolved_ingest_errors_for_path(
+    path: &Path,
+    limit: usize,
+) -> Result<Vec<IngestErrorSummary>> {
+    let conn = open_database(path)?;
+    unresolved_ingest_errors_from_connection(path, &conn, limit)
 }
 
 pub fn open_database(path: &Path) -> Result<Connection> {
@@ -98,11 +129,56 @@ pub(crate) fn status_from_connection(path: &Path, conn: &Connection) -> Result<S
         schema_version: user_version(path, conn)?,
         session_count: count(path, conn, "SELECT COUNT(*) FROM sessions")?,
         event_count: count(path, conn, "SELECT COUNT(*) FROM events")?,
-        unresolved_ingest_error_count: count(
-            path,
-            conn,
-            "SELECT COUNT(*) FROM ingest_errors WHERE resolved_at IS NULL",
-        )?,
+        unresolved_ingest_error_count: unresolved_ingest_error_count_from_connection(path, conn)?,
+    })
+}
+
+pub(crate) fn unresolved_ingest_error_count_from_connection(
+    path: &Path,
+    conn: &Connection,
+) -> Result<u64> {
+    count(path, conn, UNRESOLVED_INGEST_ERROR_COUNT_SQL)
+}
+
+pub(crate) fn unresolved_ingest_errors_from_connection(
+    path: &Path,
+    conn: &Connection,
+    limit: usize,
+) -> Result<Vec<IngestErrorSummary>> {
+    let mut statement = conn
+        .prepare(
+            "SELECT source, source_session_id, file_path, generation, byte_offset,
+                    line_number, error_kind, message, first_seen_at, last_seen_at,
+                    occurrence_count
+             FROM ingest_errors
+             WHERE resolved_at IS NULL
+             ORDER BY last_seen_at DESC, id DESC
+             LIMIT ?1",
+        )
+        .map_err(|source| sqlite_error(path, source))?;
+
+    statement
+        .query_map(params![limit as i64], ingest_error_summary_from_row)
+        .map_err(|source| sqlite_error(path, source))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|source| sqlite_error(path, source))
+}
+
+fn ingest_error_summary_from_row(row: &Row<'_>) -> rusqlite::Result<IngestErrorSummary> {
+    let file_path: String = row.get("file_path")?;
+    let occurrence_count: i64 = row.get("occurrence_count")?;
+    Ok(IngestErrorSummary {
+        source: row.get("source")?,
+        source_session_id: row.get("source_session_id")?,
+        file_path: PathBuf::from(file_path),
+        generation: row.get("generation")?,
+        byte_offset: row.get("byte_offset")?,
+        line_number: row.get("line_number")?,
+        error_kind: row.get("error_kind")?,
+        message: row.get("message")?,
+        first_seen_at: row.get("first_seen_at")?,
+        last_seen_at: row.get("last_seen_at")?,
+        occurrence_count: occurrence_count as u64,
     })
 }
 
@@ -149,6 +225,7 @@ mod tests {
         assert_sql_object(&conn, "index", "idx_sessions_source_started_at");
         assert_sql_object(&conn, "index", "idx_events_session_ts");
         assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved");
+        assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved_last_seen");
 
         assert!(columns(&conn, "sessions").contains(&"id".to_string()));
         assert!(columns(&conn, "sessions").contains(&"source_session_id".to_string()));
@@ -192,6 +269,50 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM v0_marker", [], |row| row.get(0))
             .expect("marker count");
         assert_eq!(marker_count, 1);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn migrates_existing_v1_database_to_latest_version() {
+        let root = temp_root("storage-upgrade-v1");
+        let db_path = root.join(DB_FILE_NAME);
+        ensure_private_file(&db_path).expect("create db file");
+
+        {
+            let conn = Connection::open(&db_path).expect("open v1 db");
+            conn.execute_batch(include_str!("migrations/001_initial_schema.sql"))
+                .expect("create v1 schema");
+            conn.execute(
+                "INSERT INTO sessions (source, source_session_id)
+                 VALUES ('claude_cli', 's1')",
+                [],
+            )
+            .expect("insert session");
+            conn.execute(
+                "INSERT INTO ingest_errors
+                    (source, source_session_id, session_id, file_path, line_number, error_kind, message)
+                 VALUES ('claude_cli', 's1', 1, '/tmp/s1.jsonl', 1, 'invalid_json', 'bad line')",
+                [],
+            )
+            .expect("insert v1 ingest error");
+            conn.pragma_update(None, "user_version", 1)
+                .expect("set user_version");
+        }
+
+        let conn = open_database(&db_path).expect("migrate db");
+
+        assert_eq!(
+            user_version(&db_path, &conn).expect("user_version"),
+            LATEST_SCHEMA_VERSION
+        );
+        assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved_last_seen");
+        let line_number: i64 = conn
+            .query_row("SELECT line_number FROM ingest_errors", [], |row| {
+                row.get(0)
+            })
+            .expect("migrated line number");
+        assert_eq!(line_number, 2);
 
         let _ = fs::remove_dir_all(root);
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -14,6 +14,9 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 const CLAUDE_FIXTURE_SESSION: &str = "claude-cli/projects/-Users-fixture-Workspace-jottrace/00000000-0000-4000-8000-000000000021.jsonl";
 const CLAUDE_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-000000000021";
+const CORRUPT_FIXTURE_SESSION: &str = "edge-cases/corrupt-line.jsonl";
+const CORRUPT_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-000000000000";
+const UNREADABLE_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-000000000001";
 
 #[test]
 fn version_prints_package_version() {
@@ -93,6 +96,165 @@ fn status_reports_empty_fresh_database() {
 
     #[cfg(unix)]
     assert_eq!(mode(&db_path), 0o600);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn doctor_reports_unresolved_ingest_errors() {
+    let root = temp_root("doctor-ingest-errors");
+    let data_dir = root.join(".jottrace");
+    install_claude_fixture(&root, CORRUPT_FIXTURE_SESSION_ID, CORRUPT_FIXTURE_SESSION);
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("unresolved_ingest_errors: 1"));
+
+    let output = Command::new(binary())
+        .arg("doctor")
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace doctor");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("unresolved_ingest_errors: 1"));
+    assert!(stdout.contains(CORRUPT_FIXTURE_SESSION_ID));
+    assert!(stdout.contains("line: 2"));
+    assert!(stdout.contains("kind: invalid_json"));
+    assert!(stdout.contains("message: "));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_records_corrupt_jsonl_without_blocking_unrelated_files() {
+    let root = temp_root("ingest-corrupt-nonblocking");
+    let data_dir = root.join(".jottrace");
+    let corrupt_file =
+        install_claude_fixture(&root, CORRUPT_FIXTURE_SESSION_ID, CORRUPT_FIXTURE_SESSION);
+    install_primary_claude_fixture(&root);
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("sessions: 2"));
+    assert!(ingest.contains("events: 13"));
+    assert!(ingest.contains("inserted_events: 13"));
+    assert!(ingest.contains("unresolved_ingest_errors: 1"));
+
+    let status = Command::new(binary())
+        .arg("status")
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace status");
+    assert!(
+        status.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(stdout.contains("sessions: 2"));
+    assert!(stdout.contains("events: 13"));
+    assert!(stdout.contains("unresolved_ingest_errors: 1"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let valid_event_count: i64 = conn
+        .query_row(
+            "SELECT event_count
+             FROM sessions
+             WHERE source_session_id = ?1",
+            [CLAUDE_FIXTURE_SESSION_ID],
+            |row| row.get(0),
+        )
+        .expect("valid session event count");
+    assert_eq!(valid_event_count, 12);
+
+    let errors = jottrace::storage::unresolved_ingest_errors_for_path(&db_path(&data_dir), 10)
+        .expect("unresolved ingest errors");
+    assert_eq!(errors.len(), 1);
+    let error = &errors[0];
+    let byte_offset = error.byte_offset.expect("error byte offset");
+    assert_eq!(error.source, "claude_cli");
+    assert_eq!(
+        error.source_session_id.as_deref(),
+        Some(CORRUPT_FIXTURE_SESSION_ID)
+    );
+    assert_eq!(error.file_path, corrupt_file);
+    assert!(byte_offset > 0);
+    assert_eq!(error.line_number, Some(2));
+    assert_eq!(error.error_kind, "invalid_json");
+    assert!(!error.message.is_empty());
+    assert!(!error.first_seen_at.is_empty());
+    assert!(!error.last_seen_at.is_empty());
+    assert_eq!(error.occurrence_count, 1);
+
+    let next_read_offset: i64 = conn
+        .query_row(
+            "SELECT next_read_offset
+             FROM sessions
+             WHERE source_session_id = ?1",
+            [CORRUPT_FIXTURE_SESSION_ID],
+            |row| row.get(0),
+        )
+        .expect("corrupt session offset");
+    assert_eq!(next_read_offset, byte_offset);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn ingest_records_unreadable_file_without_blocking_unrelated_files() {
+    let root = temp_root("ingest-unreadable-nonblocking");
+    let data_dir = root.join(".jottrace");
+    let unreadable_file =
+        install_claude_fixture(&root, UNREADABLE_FIXTURE_SESSION_ID, CLAUDE_FIXTURE_SESSION);
+    install_primary_claude_fixture(&root);
+    fs::set_permissions(&unreadable_file, fs::Permissions::from_mode(0o000))
+        .expect("make fixture unreadable");
+
+    if fs::File::open(&unreadable_file).is_ok() {
+        let _ = fs::remove_dir_all(root);
+        return;
+    }
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("sessions: 2"));
+    assert!(ingest.contains("events: 12"));
+    assert!(ingest.contains("inserted_events: 12"));
+    assert!(ingest.contains("unresolved_ingest_errors: 1"));
+
+    let errors = jottrace::storage::unresolved_ingest_errors_for_path(&db_path(&data_dir), 10)
+        .expect("unresolved ingest errors");
+    assert_eq!(errors.len(), 1);
+    let error = &errors[0];
+    assert_eq!(error.source, "claude_cli");
+    assert_eq!(
+        error.source_session_id.as_deref(),
+        Some(UNREADABLE_FIXTURE_SESSION_ID)
+    );
+    assert_eq!(error.file_path, unreadable_file);
+    assert_eq!(error.byte_offset, None);
+    assert_eq!(error.line_number, None);
+    assert_eq!(error.error_kind, "read_error");
+    assert!(!error.message.is_empty());
+
+    let valid_event_count: i64 = Connection::open(db_path(&data_dir))
+        .expect("open preserved db")
+        .query_row(
+            "SELECT event_count
+             FROM sessions
+             WHERE source_session_id = ?1",
+            [CLAUDE_FIXTURE_SESSION_ID],
+            |row| row.get(0),
+        )
+        .expect("valid session event count");
+    assert_eq!(valid_event_count, 12);
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary

Closes #26.

- record corrupt JSONL and unreadable source-file failures as unresolved ingest errors
- keep ingest non-fatal so unrelated valid files continue preserving
- keep offsets conservative around unpreserved data and show human-facing line numbers
- surface unresolved ingest error counts/details in `jottrace status` and `jottrace doctor`
- add a v2 migration for human-facing line numbers plus a recency index for doctor output

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check`