### PR TITLE
[codex] Ingest Claude subagent sidechains

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -321,7 +321,14 @@ sidechains. The observed current shape is
 often with a sibling `agent-<id>.meta.json` file that carries lightweight
 agent metadata. Each subagent JSONL file is stored as its own row in
 `sessions`, with a nullable `parent_session_id` column linking back to
-the spawning session. Subagent events use the same
+the spawning session. The sidechain's canonical `source_session_id` is
+the JSONL filename stem (`agent-<id>`). Parent linkage is derived from
+the path segment immediately above `subagents`; for the observed fixture
+shape, that segment is the parent Claude session UUID. If the parent row
+is not available yet, the sidechain is still preserved with a null
+`parent_session_id`; its `file_path` retains the parent source id so a
+later run can resolve the link after the parent session is imported.
+Subagent events use the same
 `(session_id, generation, seq)` PK shape as regular sessions; they are
 not folded into the parent's event stream. Re-read behavior is identical
 to a regular session.
@@ -594,13 +601,10 @@ Listed so we don't pretend they're decided.
 - **Multi-source orchestration.** Whether all readers run inside one
   binary or as separate processes invoked by the scheduler. (The
   shared-DB question is decided: one DB per user, see Schema.)
-- **Subagent / parent-child linkage derivation.** For Claude CLI's
-  `agent-<uuid>.jsonl` files and OpenCode's parent/child sessions:
-  what's the cheapest deterministic way to derive `parent_session_id`
-  from the file plus the parent's events? Likely the parent's
-  `parentUuid` chain or a `Task` tool_use event referencing the
-  subagent's UUID. Decide after looking at real fixtures; the schema
-  column already exists.
+- **OpenCode parent-child linkage derivation.** The Claude CLI sidechain
+  rule is settled above. OpenCode's parent/child sessions still need the
+  cheapest deterministic `parent_session_id` derivation once real
+  fixtures land.
 - **Distribution caveats.** macOS Gatekeeper quarantine on unsigned
   binaries (ad-hoc sign vs. notarize vs. document `xattr -d`
   workaround); Linux glibc compatibility (build on oldest-supported

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, named_params, params};
 use serde::Deserialize;
 use std::env;
 use std::fs::{self, File, Metadata};
@@ -35,6 +35,7 @@ pub struct IngestReport {
 struct SourceFile {
     source: &'static str,
     source_session_id: String,
+    parent_source_session_id: Option<String>,
     path: PathBuf,
 }
 
@@ -42,6 +43,7 @@ struct SourceFile {
 struct StoredSession {
     id: i64,
     file_path: Option<String>,
+    parent_session_id: Option<i64>,
     current_generation: i64,
     file_size: Option<i64>,
     file_mtime: Option<i64>,
@@ -66,6 +68,7 @@ struct ParsedMetadata {
 struct SessionUpdate<'a> {
     source_file: &'a SourceFile,
     session_id: i64,
+    parent_session_id: Option<i64>,
     generation: i64,
     pass_size: i64,
     file_mtime: Option<i64>,
@@ -88,6 +91,7 @@ struct IngestErrorRecord<'a> {
 struct SkippedSessionUpdate<'a> {
     source_file: &'a SourceFile,
     session_id: i64,
+    parent_session_id: Option<i64>,
     checked_file: Option<CheckedFileState<'a>>,
 }
 
@@ -157,16 +161,27 @@ fn discover_claude_session_files() -> Result<Vec<SourceFile>> {
     paths.sort();
     paths.dedup();
 
-    paths
+    let mut source_files = paths
         .into_iter()
         .map(|path| {
+            let source_session_id = source_session_id_from_path(&path)?;
+            let parent_source_session_id =
+                parent_source_session_id_from_path(&path, &source_session_id);
             Ok(SourceFile {
                 source: CLAUDE_SOURCE,
-                source_session_id: source_session_id_from_path(&path)?,
+                source_session_id,
+                parent_source_session_id,
                 path,
             })
         })
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    source_files.sort_by(|left, right| {
+        left.parent_source_session_id
+            .is_some()
+            .cmp(&right.parent_source_session_id.is_some())
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    Ok(source_files)
 }
 
 fn collect_jsonl_files(root: &Path, recursive: bool, paths: &mut Vec<PathBuf>) -> Result<()> {
@@ -223,9 +238,13 @@ fn ingest_jsonl_file(conn: &mut Connection, source_file: &SourceFile) -> Result<
     if let Some(stored) = load_session(conn, source_file)?
         && unchanged_by_mtime(&stored, pass_size, file_mtime)
     {
-        if stored.file_path.as_deref() == Some(source_file.path.to_string_lossy().as_ref()) {
+        let path_is_current =
+            stored.file_path.as_deref() == Some(source_file.path.to_string_lossy().as_ref());
+        let parent_session_id = resolve_parent_session_id(conn, source_file)?;
+        if path_is_current && stored.parent_session_id == parent_session_id {
             return Ok(0);
         }
+
         let tx = conn
             .transaction()
             .map_err(|source| sqlite_error(&source_file.path, source))?;
@@ -234,6 +253,7 @@ fn ingest_jsonl_file(conn: &mut Connection, source_file: &SourceFile) -> Result<
             SkippedSessionUpdate {
                 source_file,
                 session_id: stored.id,
+                parent_session_id,
                 checked_file: None,
             },
         )?;
@@ -254,11 +274,13 @@ fn ingest_jsonl_file(conn: &mut Connection, source_file: &SourceFile) -> Result<
     let import_mode = import_mode(&stored, pass_size, &content_fingerprint);
 
     if import_mode == ImportMode::Skip {
+        let parent_session_id = resolve_parent_session_id(&tx, source_file)?;
         update_skipped_session(
             &tx,
             SkippedSessionUpdate {
                 source_file,
                 session_id: stored.id,
+                parent_session_id,
                 checked_file: Some(CheckedFileState {
                     pass_size,
                     file_mtime,
@@ -292,11 +314,13 @@ fn ingest_jsonl_file(conn: &mut Connection, source_file: &SourceFile) -> Result<
     )?;
 
     let event_count = generation_event_count(&tx, source_file, stored.id, generation)?;
+    let parent_session_id = resolve_parent_session_id(&tx, source_file)?;
     update_session_after_import(
         &tx,
         SessionUpdate {
             source_file,
             session_id: stored.id,
+            parent_session_id,
             generation,
             pass_size,
             file_mtime,
@@ -445,25 +469,41 @@ fn insert_session_if_missing(tx: &Transaction<'_>, source_file: &SourceFile) -> 
 }
 
 fn load_session(conn: &Connection, source_file: &SourceFile) -> Result<Option<StoredSession>> {
+    load_session_by_source_session_id(
+        conn,
+        &source_file.path,
+        source_file.source,
+        &source_file.source_session_id,
+    )
+}
+
+fn load_session_by_source_session_id(
+    conn: &Connection,
+    error_path: &Path,
+    source: &str,
+    source_session_id: &str,
+) -> Result<Option<StoredSession>> {
     conn.query_row(
-        "SELECT id, file_path, current_generation, file_size, file_mtime, content_fingerprint, next_read_offset
+        "SELECT id, file_path, parent_session_id, current_generation, file_size, file_mtime,
+                content_fingerprint, next_read_offset
          FROM sessions
          WHERE source = ?1 AND source_session_id = ?2",
-        params![source_file.source, source_file.source_session_id.as_str()],
+        params![source, source_session_id],
         |row| {
             Ok(StoredSession {
                 id: row.get(0)?,
                 file_path: row.get(1)?,
-                current_generation: row.get(2)?,
-                file_size: row.get(3)?,
-                file_mtime: row.get(4)?,
-                content_fingerprint: row.get(5)?,
-                next_read_offset: row.get(6)?,
+                parent_session_id: row.get(2)?,
+                current_generation: row.get(3)?,
+                file_size: row.get(4)?,
+                file_mtime: row.get(5)?,
+                content_fingerprint: row.get(6)?,
+                next_read_offset: row.get(7)?,
             })
         },
     )
     .optional()
-    .map_err(|source| sqlite_error(&source_file.path, source))
+    .map_err(|source| sqlite_error(error_path, source))
 }
 
 fn unchanged_by_mtime(stored: &StoredSession, pass_size: i64, file_mtime: Option<i64>) -> bool {
@@ -493,71 +533,105 @@ fn update_skipped_session(tx: &Transaction<'_>, update: SkippedSessionUpdate<'_>
     let file_mtime = checked_file.and_then(|state| state.file_mtime);
     let pass_size = checked_file.map(|state| state.pass_size);
     let content_fingerprint = checked_file.map(|state| state.content_fingerprint);
+    let file_path = update.source_file.path.to_string_lossy();
+    let has_parent_source = update.source_file.parent_source_session_id.is_some();
 
     tx.execute(
         "UPDATE sessions
-         SET file_path = ?1,
-             file_mtime = CASE WHEN ?2 THEN ?3 ELSE file_mtime END,
-             file_size = CASE WHEN ?2 THEN ?4 ELSE file_size END,
-             content_fingerprint = CASE WHEN ?2 THEN ?5 ELSE content_fingerprint END,
+         SET file_path = :file_path,
+             parent_session_id = CASE
+                 WHEN :has_parent_source THEN :parent_session_id
+                 ELSE NULL
+             END,
+             file_mtime = CASE WHEN :has_checked_file THEN :file_mtime ELSE file_mtime END,
+             file_size = CASE WHEN :has_checked_file THEN :pass_size ELSE file_size END,
+             content_fingerprint = CASE
+                 WHEN :has_checked_file THEN :content_fingerprint
+                 ELSE content_fingerprint
+             END,
              last_read_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
              updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-         WHERE id = ?6",
-        params![
-            update.source_file.path.to_string_lossy(),
-            has_checked_file,
-            file_mtime,
-            pass_size,
-            content_fingerprint,
-            update.session_id,
-        ],
+         WHERE id = :session_id",
+        named_params! {
+            ":file_path": file_path,
+            ":has_parent_source": has_parent_source,
+            ":parent_session_id": update.parent_session_id,
+            ":has_checked_file": has_checked_file,
+            ":file_mtime": file_mtime,
+            ":pass_size": pass_size,
+            ":content_fingerprint": content_fingerprint,
+            ":session_id": update.session_id,
+        },
     )
     .map_err(|source| sqlite_error(&update.source_file.path, source))?;
     Ok(())
 }
 
 fn update_session_after_import(tx: &Transaction<'_>, update: SessionUpdate<'_>) -> Result<()> {
+    let file_path = update.source_file.path.to_string_lossy();
+    let has_parent_source = update.source_file.parent_source_session_id.is_some();
+
     tx.execute(
         "UPDATE sessions
-         SET file_path = ?1,
-             cwd = COALESCE(?2, cwd),
+         SET file_path = :file_path,
+             parent_session_id = CASE
+                 WHEN :has_parent_source THEN :parent_session_id
+                 ELSE NULL
+             END,
+             cwd = COALESCE(:cwd, cwd),
              started_at = CASE
-                 WHEN ?3 IS NULL THEN started_at
-                 WHEN started_at IS NULL THEN ?3
-                 WHEN ?3 < started_at THEN ?3
+                 WHEN :started_at IS NULL THEN started_at
+                 WHEN started_at IS NULL THEN :started_at
+                 WHEN :started_at < started_at THEN :started_at
                  ELSE started_at
              END,
              ended_at = CASE
-                 WHEN ?4 IS NULL THEN ended_at
-                 WHEN ended_at IS NULL THEN ?4
-                 WHEN ?4 > ended_at THEN ?4
+                 WHEN :ended_at IS NULL THEN ended_at
+                 WHEN ended_at IS NULL THEN :ended_at
+                 WHEN :ended_at > ended_at THEN :ended_at
                  ELSE ended_at
              END,
-             current_generation = ?5,
-             file_mtime = ?6,
-             file_size = ?7,
-             content_fingerprint = ?8,
-             next_read_offset = ?9,
-             event_count = ?10,
+             current_generation = :current_generation,
+             file_mtime = :file_mtime,
+             file_size = :file_size,
+             content_fingerprint = :content_fingerprint,
+             next_read_offset = :next_read_offset,
+             event_count = :event_count,
              last_read_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
              updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-         WHERE id = ?11",
-        params![
-            update.source_file.path.to_string_lossy(),
-            update.metadata.cwd.as_deref(),
-            update.metadata.started_at.as_deref(),
-            update.metadata.ended_at.as_deref(),
-            update.generation,
-            update.file_mtime,
-            update.pass_size,
-            update.content_fingerprint,
-            update.next_read_offset,
-            update.event_count,
-            update.session_id,
-        ],
+         WHERE id = :session_id",
+        named_params! {
+            ":file_path": file_path,
+            ":has_parent_source": has_parent_source,
+            ":parent_session_id": update.parent_session_id,
+            ":cwd": update.metadata.cwd.as_deref(),
+            ":started_at": update.metadata.started_at.as_deref(),
+            ":ended_at": update.metadata.ended_at.as_deref(),
+            ":current_generation": update.generation,
+            ":file_mtime": update.file_mtime,
+            ":file_size": update.pass_size,
+            ":content_fingerprint": update.content_fingerprint,
+            ":next_read_offset": update.next_read_offset,
+            ":event_count": update.event_count,
+            ":session_id": update.session_id,
+        },
     )
     .map_err(|source| sqlite_error(&update.source_file.path, source))?;
     Ok(())
+}
+
+fn resolve_parent_session_id(conn: &Connection, source_file: &SourceFile) -> Result<Option<i64>> {
+    let Some(parent_source_session_id) = &source_file.parent_source_session_id else {
+        return Ok(None);
+    };
+
+    load_session_by_source_session_id(
+        conn,
+        &source_file.path,
+        source_file.source,
+        parent_source_session_id,
+    )
+    .map(|session| session.map(|session| session.id))
 }
 
 fn record_ingest_error(tx: &Transaction<'_>, record: IngestErrorRecord<'_>) -> Result<()> {
@@ -707,6 +781,23 @@ fn source_session_id_from_path(path: &Path) -> Result<String> {
         .and_then(|stem| stem.to_str())
         .map(str::to_string)
         .ok_or_else(|| invalid_path(path, "session file name is not valid UTF-8"))
+}
+
+fn parent_source_session_id_from_path(path: &Path, source_session_id: &str) -> Option<String> {
+    if !source_session_id.starts_with("agent-") {
+        return None;
+    }
+
+    let subagents_dir = path.parent()?;
+    if subagents_dir.file_name()? != "subagents" {
+        return None;
+    }
+
+    subagents_dir
+        .parent()?
+        .file_name()?
+        .to_str()
+        .map(str::to_string)
 }
 
 fn file_mtime(metadata: &Metadata) -> Option<i64> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -14,6 +14,9 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 const CLAUDE_FIXTURE_SESSION: &str = "claude-cli/projects/-Users-fixture-Workspace-jottrace/00000000-0000-4000-8000-000000000021.jsonl";
 const CLAUDE_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-000000000021";
+const CLAUDE_SIDECHAIN_FIXTURE_SESSION: &str = "claude-cli/projects/-Users-fixture-Workspace-jottrace/00000000-0000-4000-8000-000000000021/subagents/agent-a000000000000021.jsonl";
+const CLAUDE_SIDECHAIN_FIXTURE_META: &str = "claude-cli/projects/-Users-fixture-Workspace-jottrace/00000000-0000-4000-8000-000000000021/subagents/agent-a000000000000021.meta.json";
+const CLAUDE_SIDECHAIN_FIXTURE_SESSION_ID: &str = "agent-a000000000000021";
 const CORRUPT_FIXTURE_SESSION: &str = "edge-cases/corrupt-line.jsonl";
 const CORRUPT_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-000000000000";
 const UNREADABLE_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-000000000001";
@@ -609,6 +612,89 @@ fn ingest_preserves_claude_cli_fixture_and_status_reports_counts() {
     let _ = fs::remove_dir_all(root);
 }
 
+#[test]
+fn ingest_preserves_claude_cli_sidechain_as_child_session() {
+    let root = temp_root("ingest-claude-sidechain");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+    let sidechain_file = install_claude_sidechain_fixture(&root);
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("sessions: 2"));
+    assert!(ingest.contains("events: 19"));
+    assert!(ingest.contains("inserted_events: 19"));
+    assert!(ingest.contains("unresolved_ingest_errors: 0"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let sidechain = sidechain_session(&conn);
+    assert_eq!(
+        sidechain.source_session_id,
+        CLAUDE_SIDECHAIN_FIXTURE_SESSION_ID
+    );
+    assert!(sidechain.parent_session_id.is_some());
+    assert_eq!(
+        sidechain.parent_source_session_id.as_deref(),
+        Some(CLAUDE_FIXTURE_SESSION_ID)
+    );
+    assert_eq!(sidechain.event_count, 7);
+    assert_eq!(
+        sidechain.cwd.as_deref(),
+        Some("/Users/fixture/Workspace/jottrace")
+    );
+    assert_eq!(
+        sidechain.started_at.as_deref(),
+        Some("2026-05-05T01:01:00.000Z")
+    );
+    assert_eq!(
+        sidechain.ended_at.as_deref(),
+        Some("2026-05-05T01:01:06.000Z")
+    );
+    assert_eq!(sidechain.file_path, sidechain_file);
+
+    let second = run_ingest(&root, &data_dir);
+    assert!(second.contains("sessions: 2"));
+    assert!(second.contains("events: 19"));
+    assert!(second.contains("inserted_events: 0"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_preserves_claude_cli_sidechain_without_parent_until_parent_is_available() {
+    let root = temp_root("ingest-claude-sidechain-late-parent");
+    let data_dir = root.join(".jottrace");
+    let sidechain_file = install_claude_sidechain_fixture(&root);
+
+    let first = run_ingest(&root, &data_dir);
+    assert!(first.contains("sessions: 1"));
+    assert!(first.contains("events: 7"));
+    assert!(first.contains("inserted_events: 7"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let sidechain = sidechain_session(&conn);
+    assert_eq!(sidechain.parent_session_id, None);
+    assert_eq!(sidechain.parent_source_session_id, None);
+    assert_eq!(sidechain.event_count, 7);
+    assert_eq!(sidechain.file_path, sidechain_file);
+    drop(conn);
+
+    install_primary_claude_fixture(&root);
+
+    let second = run_ingest(&root, &data_dir);
+    assert!(second.contains("sessions: 2"));
+    assert!(second.contains("events: 19"));
+    assert!(second.contains("inserted_events: 12"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let sidechain = sidechain_session(&conn);
+    assert_eq!(
+        sidechain.parent_source_session_id.as_deref(),
+        Some(CLAUDE_FIXTURE_SESSION_ID)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[cfg(unix)]
 #[test]
 fn doctor_rejects_insecure_existing_data_dir() {
@@ -667,23 +753,77 @@ fn db_path(data_dir: &Path) -> PathBuf {
     data_dir.join(jottrace::storage::DB_FILE_NAME)
 }
 
+struct SidechainSession {
+    source_session_id: String,
+    parent_session_id: Option<i64>,
+    parent_source_session_id: Option<String>,
+    event_count: i64,
+    cwd: Option<String>,
+    started_at: Option<String>,
+    ended_at: Option<String>,
+    file_path: PathBuf,
+}
+
+fn sidechain_session(conn: &Connection) -> SidechainSession {
+    conn.query_row(
+        "SELECT child.source_session_id, child.parent_session_id, parent.source_session_id,
+                child.event_count, child.cwd, child.started_at, child.ended_at, child.file_path
+         FROM sessions child
+         LEFT JOIN sessions parent ON parent.id = child.parent_session_id
+         WHERE child.source = 'claude_cli'
+           AND child.source_session_id = ?1",
+        [CLAUDE_SIDECHAIN_FIXTURE_SESSION_ID],
+        |row| {
+            let file_path: String = row.get(7)?;
+            Ok(SidechainSession {
+                source_session_id: row.get(0)?,
+                parent_session_id: row.get(1)?,
+                parent_source_session_id: row.get(2)?,
+                event_count: row.get(3)?,
+                cwd: row.get(4)?,
+                started_at: row.get(5)?,
+                ended_at: row.get(6)?,
+                file_path: PathBuf::from(file_path),
+            })
+        },
+    )
+    .expect("sidechain session")
+}
+
 fn install_primary_claude_fixture(root: &Path) -> PathBuf {
     install_claude_fixture(root, CLAUDE_FIXTURE_SESSION_ID, CLAUDE_FIXTURE_SESSION)
 }
 
+fn install_claude_sidechain_fixture(root: &Path) -> PathBuf {
+    let sidechain_file = claude_project_dir(root)
+        .join(CLAUDE_FIXTURE_SESSION_ID)
+        .join("subagents")
+        .join(format!("{CLAUDE_SIDECHAIN_FIXTURE_SESSION_ID}.jsonl"));
+    let sidechain_meta = sidechain_file.with_extension("meta.json");
+    copy_reader_fixture(CLAUDE_SIDECHAIN_FIXTURE_SESSION, &sidechain_file);
+    copy_reader_fixture(CLAUDE_SIDECHAIN_FIXTURE_META, &sidechain_meta);
+    sidechain_file
+}
+
 fn install_claude_fixture(root: &Path, session_id: &str, fixture_relative: &str) -> PathBuf {
-    let session_file = root
-        .join(".claude/projects/-Users-fixture-Workspace-jottrace")
-        .join(format!("{session_id}.jsonl"));
-    if let Some(parent) = session_file.parent() {
-        fs::create_dir_all(parent).expect("create fixture destination parent");
-    }
-    fs::copy(reader_fixture(fixture_relative), &session_file).expect("copy fixture");
+    let session_file = claude_project_dir(root).join(format!("{session_id}.jsonl"));
+    copy_reader_fixture(fixture_relative, &session_file);
     session_file
 }
 
 fn replace_with_fixture(path: &Path, fixture_relative: &str) {
-    fs::copy(reader_fixture(fixture_relative), path).expect("replace fixture");
+    copy_reader_fixture(fixture_relative, path);
+}
+
+fn claude_project_dir(root: &Path) -> PathBuf {
+    root.join(".claude/projects/-Users-fixture-Workspace-jottrace")
+}
+
+fn copy_reader_fixture(fixture_relative: &str, destination: &Path) {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).expect("create fixture destination parent");
+    }
+    fs::copy(reader_fixture(fixture_relative), destination).expect("copy fixture");
 }
 
 fn set_modified(path: &Path, unix_seconds: u64) {


### PR DESCRIPTION
## Summary

- Preserve Claude CLI subagent sidechain JSONL files as their own `sessions` rows.
- Derive sidechain `source_session_id` from the `agent-...` filename and link parents from the observed `.../<parent-session-id>/subagents/...` path shape.
- Preserve sidechains safely when the parent row is not imported yet, then resolve the parent link on a later ingest run.
- Document the settled Claude sidechain parent-link rule in the reader design notes.

Fixes #27.

## Validation

- `rtk cargo test`
- `rtk cargo clippy --all-targets -- -D warnings`
- `rtk git diff --check`