### PR TITLE
[codex] Add decoded session event export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,19 @@ pub enum JottraceError {
         actual: i64,
         supported: i64,
     },
+    UnsupportedEventPayloadCodec {
+        codec: String,
+    },
+    SessionNotFound {
+        source: String,
+        source_session_id: String,
+    },
+    InvalidEventLimit {
+        limit: i64,
+    },
+    Output {
+        source: io::Error,
+    },
     /// A DB-mutating command is already active in this data directory.
     LockHeld(PathBuf),
     Sqlite {
@@ -94,6 +107,20 @@ impl fmt::Display for JottraceError {
                 actual,
                 supported
             ),
+            Self::UnsupportedEventPayloadCodec { codec } => {
+                write!(f, "unsupported event payload codec: {codec}")
+            }
+            Self::SessionNotFound {
+                source,
+                source_session_id,
+            } => write!(
+                f,
+                "session not found: source={source} source_session_id={source_session_id}"
+            ),
+            Self::InvalidEventLimit { limit } => {
+                write!(f, "event limit must be at least 1; got {limit}")
+            }
+            Self::Output { source } => write!(f, "failed to write output: {source}"),
             Self::LockHeld(path) => write!(
                 f,
                 "another jottrace DB-mutating command is already running; lock: {}",
@@ -108,6 +135,7 @@ impl std::error::Error for JottraceError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io { source, .. } => Some(source),
+            Self::Output { source } => Some(source),
             Self::Sqlite { source, .. } => Some(source),
             _ => None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Some("doctor") => run_doctor_command(),
+        Some("events") => run_events_command(args),
         Some("ingest") => run_ingest_command(),
         Some("status") => run_status_command(),
         Some("web") => run_web_command(args),
@@ -31,6 +32,25 @@ fn main() -> ExitCode {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EventsOptions {
+    source: String,
+    source_session_id: String,
+    selection: EventsSelection,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum EventsSelection {
+    All,
+    Limit(i64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum EventsCommand {
+    Run(EventsOptions),
+    Help,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct WebOptions {
     port: u16,
@@ -41,6 +61,125 @@ struct WebOptions {
 enum WebCommand {
     Run(WebOptions),
     Help,
+}
+
+fn run_events_command(args: impl Iterator<Item = String>) -> ExitCode {
+    let options = match parse_events_command(args) {
+        Ok(EventsCommand::Run(options)) => options,
+        Ok(EventsCommand::Help) => {
+            print_events_help();
+            return ExitCode::SUCCESS;
+        }
+        Err(message) => {
+            eprintln!("{message}");
+            eprintln!("run `jottrace events --help` for usage");
+            return ExitCode::from(2);
+        }
+    };
+
+    let db_path = match jottrace::storage::db_path_from_env() {
+        Ok(db_path) => db_path,
+        Err(error) => {
+            eprintln!("jottrace events failed: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let limit = match options.selection {
+        EventsSelection::All => None,
+        EventsSelection::Limit(limit) => Some(limit),
+    };
+    let stdout = io::stdout();
+    let mut stdout = io::BufWriter::new(stdout.lock());
+    let result = jottrace::storage::for_each_decoded_event_payload_for_session(
+        &db_path,
+        &options.source,
+        &options.source_session_id,
+        limit,
+        |payload| {
+            stdout
+                .write_all(payload)
+                .and_then(|()| stdout.write_all(b"\n"))
+                .map_err(|source| jottrace::JottraceError::Output { source })
+        },
+    );
+
+    let result = result.and_then(|()| {
+        stdout
+            .flush()
+            .map_err(|source| jottrace::JottraceError::Output { source })
+    });
+    if let Err(error) = result {
+        if matches!(
+            &error,
+            jottrace::JottraceError::Output { source }
+                if source.kind() == io::ErrorKind::BrokenPipe
+        ) {
+            return ExitCode::SUCCESS;
+        }
+        eprintln!("jottrace events failed: {error}");
+        return ExitCode::FAILURE;
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn parse_events_command(
+    mut args: impl Iterator<Item = String>,
+) -> std::result::Result<EventsCommand, String> {
+    let mut source_session_id = None;
+    let mut source = None;
+    let mut limit = None;
+    let mut all = false;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--help" | "-h" => return Ok(EventsCommand::Help),
+            "--all" => all = true,
+            "--source" => {
+                source = Some(
+                    args.next()
+                        .ok_or_else(|| "--source requires a value".to_string())?,
+                );
+            }
+            "--session" => {
+                source_session_id = Some(
+                    args.next()
+                        .ok_or_else(|| "--session requires a value".to_string())?,
+                );
+            }
+            "--limit" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--limit requires a value".to_string())?;
+                let parsed = value
+                    .parse::<i64>()
+                    .map_err(|_| format!("invalid limit: {value}"))?;
+                if parsed < 1 {
+                    return Err(format!("invalid limit: {value}; expected at least 1"));
+                }
+                limit = Some(parsed);
+            }
+            _ => return Err(format!("unknown events option: {arg}")),
+        }
+    }
+
+    let source = source.ok_or_else(|| "events requires --source <source>".to_string())?;
+    let source_session_id = source_session_id
+        .ok_or_else(|| "events requires --session <source_session_id>".to_string())?;
+    let selection = match (all, limit) {
+        (true, Some(_)) => {
+            return Err("events accepts either --limit <n> or --all, not both".to_string());
+        }
+        (true, None) => EventsSelection::All,
+        (false, Some(limit)) => EventsSelection::Limit(limit),
+        (false, None) => return Err("events requires --limit <n> or --all".to_string()),
+    };
+
+    Ok(EventsCommand::Run(EventsOptions {
+        source,
+        source_session_id,
+        selection,
+    }))
 }
 
 fn run_web_command(args: impl Iterator<Item = String>) -> ExitCode {
@@ -220,10 +359,29 @@ fn print_help() {
     println!();
     println!("Usage:");
     println!("  jottrace doctor");
+    println!(
+        "  jottrace events --source <source> --session <source_session_id> (--limit <n>|--all)"
+    );
     println!("  jottrace ingest");
     println!("  jottrace status");
     println!("  jottrace web [--port <port>] [--once]");
     println!("  jottrace --version");
+}
+
+fn print_events_help() {
+    println!("jottrace events");
+    println!("Print decoded event JSONL for one stored session.");
+    println!();
+    println!("Usage:");
+    println!(
+        "  jottrace events --source <source> --session <source_session_id> (--limit <n>|--all)"
+    );
+    println!();
+    println!("Options:");
+    println!("  --all                         Print every event in the selected session");
+    println!("  --source <source>             Stored source, for example claude_cli");
+    println!("  --session <source_session_id>  Stored source session id to inspect");
+    println!("  --limit <n>                   Maximum number of events to print");
 }
 
 fn print_web_help() {

--- a/src/migrations/004_unsupported_event_codec_index.sql
+++ b/src/migrations/004_unsupported_event_codec_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_events_unsupported_codec
+    ON events (session_id, generation, seq)
+    WHERE codec != 'raw';

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,11 +1,11 @@
-use rusqlite::{Connection, Row, params};
+use rusqlite::{Connection, OptionalExtension, Row, params};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::{JottraceError, Result, data_dir_from_env, ensure_private_file};
 
 pub const DB_FILE_NAME: &str = "db.sqlite";
-pub const LATEST_SCHEMA_VERSION: i64 = 3;
+pub const LATEST_SCHEMA_VERSION: i64 = 4;
 pub(crate) const RAW_CODEC: &str = "raw";
 
 const MIGRATIONS: &[Migration] = &[
@@ -20,6 +20,10 @@ const MIGRATIONS: &[Migration] = &[
     Migration {
         version: 3,
         sql: include_str!("migrations/003_claude_sidechain_source_ids.sql"),
+    },
+    Migration {
+        version: 4,
+        sql: include_str!("migrations/004_unsupported_event_codec_index.sql"),
     },
 ];
 const UNRESOLVED_INGEST_ERROR_COUNT_SQL: &str =
@@ -75,6 +79,14 @@ pub fn unresolved_ingest_errors_for_path(
 ) -> Result<Vec<IngestErrorSummary>> {
     let conn = open_database(path)?;
     unresolved_ingest_errors_from_connection(path, &conn, limit)
+}
+
+pub fn decode_event_payload(payload: &[u8], codec: &str) -> Result<Vec<u8>> {
+    if codec == RAW_CODEC {
+        return Ok(payload.to_vec());
+    }
+
+    Err(unsupported_event_payload_codec(codec))
 }
 
 pub fn open_database(path: &Path) -> Result<Connection> {
@@ -169,6 +181,177 @@ pub(crate) fn unresolved_ingest_errors_from_connection(
         .map_err(|source| sqlite_error(path, source))
 }
 
+pub fn for_each_decoded_event_payload_for_session(
+    path: &Path,
+    source: &str,
+    source_session_id: &str,
+    limit: Option<i64>,
+    visit: impl FnMut(&[u8]) -> Result<()>,
+) -> Result<()> {
+    let conn = open_database(path)?;
+    let session_id =
+        event_session_id(path, &conn, source, source_session_id)?.ok_or_else(|| {
+            JottraceError::SessionNotFound {
+                source: source.to_string(),
+                source_session_id: source_session_id.to_string(),
+            }
+        })?;
+    for_each_decoded_event_payload_from_connection(path, &conn, session_id, limit, visit)
+}
+
+fn event_session_id(
+    path: &Path,
+    conn: &Connection,
+    source: &str,
+    source_session_id: &str,
+) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT id
+         FROM sessions
+         WHERE source = ?1
+           AND source_session_id = ?2",
+        params![source, source_session_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(|source| sqlite_error(path, source))
+}
+
+fn for_each_decoded_event_payload_from_connection(
+    path: &Path,
+    conn: &Connection,
+    session_id: i64,
+    limit: Option<i64>,
+    mut visit: impl FnMut(&[u8]) -> Result<()>,
+) -> Result<()> {
+    if let Some(limit) = limit {
+        validate_decoded_event_limit(limit)?;
+    }
+    reject_unsupported_event_codecs(
+        path,
+        conn,
+        session_id,
+        selected_event_upper_bound(path, conn, session_id, limit)?,
+    )?;
+
+    let sql = match limit {
+        Some(_) => {
+            "SELECT events.payload
+             FROM events
+             WHERE events.session_id = ?1
+             ORDER BY events.generation, events.seq
+             LIMIT ?2"
+        }
+        None => {
+            "SELECT events.payload
+             FROM events
+             WHERE events.session_id = ?1
+             ORDER BY events.generation, events.seq"
+        }
+    };
+    let mut statement = conn
+        .prepare(sql)
+        .map_err(|source| sqlite_error(path, source))?;
+    let mut rows = match limit {
+        Some(limit) => statement
+            .query(params![session_id, limit])
+            .map_err(|source| sqlite_error(path, source))?,
+        None => statement
+            .query(params![session_id])
+            .map_err(|source| sqlite_error(path, source))?,
+    };
+
+    while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
+        let payload: Vec<u8> = row.get(0).map_err(|source| sqlite_error(path, source))?;
+        visit(&payload)?;
+    }
+
+    Ok(())
+}
+
+fn reject_unsupported_event_codecs(
+    path: &Path,
+    conn: &Connection,
+    session_id: i64,
+    upper_bound: Option<(i64, i64)>,
+) -> Result<()> {
+    let codec: Option<String> = match upper_bound {
+        Some((generation, seq)) => conn
+            .query_row(
+                "SELECT events.codec
+                 FROM events
+                 WHERE events.session_id = ?1
+                   AND events.codec != 'raw'
+                   AND (
+                       events.generation < ?2
+                       OR (events.generation = ?2 AND events.seq <= ?3)
+                   )
+                 ORDER BY events.generation, events.seq
+                 LIMIT 1",
+                params![session_id, generation, seq],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|source| sqlite_error(path, source))?,
+        None => conn
+            .query_row(
+                "SELECT events.codec
+                 FROM events
+                 WHERE events.session_id = ?1
+                   AND events.codec != 'raw'
+                 ORDER BY events.generation, events.seq
+                 LIMIT 1",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|source| sqlite_error(path, source))?,
+    };
+
+    match codec {
+        Some(codec) => Err(unsupported_event_payload_codec(&codec)),
+        None => Ok(()),
+    }
+}
+
+fn selected_event_upper_bound(
+    path: &Path,
+    conn: &Connection,
+    session_id: i64,
+    limit: Option<i64>,
+) -> Result<Option<(i64, i64)>> {
+    let Some(limit) = limit else {
+        return Ok(None);
+    };
+
+    let offset = limit - 1;
+    conn.query_row(
+        "SELECT generation, seq
+         FROM events
+         WHERE session_id = ?1
+         ORDER BY generation, seq
+         LIMIT 1 OFFSET ?2",
+        params![session_id, offset],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .optional()
+    .map_err(|source| sqlite_error(path, source))
+}
+
+fn unsupported_event_payload_codec(codec: &str) -> JottraceError {
+    JottraceError::UnsupportedEventPayloadCodec {
+        codec: codec.to_string(),
+    }
+}
+
+fn validate_decoded_event_limit(limit: i64) -> Result<()> {
+    if limit >= 1 {
+        return Ok(());
+    }
+
+    Err(JottraceError::InvalidEventLimit { limit })
+}
+
 fn ingest_error_summary_from_row(row: &Row<'_>) -> rusqlite::Result<IngestErrorSummary> {
     let file_path: String = row.get("file_path")?;
     let occurrence_count: i64 = row.get("occurrence_count")?;
@@ -231,6 +414,7 @@ mod tests {
         assert_sql_object(&conn, "index", "idx_events_session_ts");
         assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved");
         assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved_last_seen");
+        assert_sql_object(&conn, "index", "idx_events_unsupported_codec");
 
         assert!(columns(&conn, "sessions").contains(&"id".to_string()));
         assert!(columns(&conn, "sessions").contains(&"source_session_id".to_string()));
@@ -475,6 +659,23 @@ mod tests {
         assert_eq!(report.unresolved_ingest_error_count, 1);
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn decode_event_payload_returns_raw_payload_bytes() {
+        let payload = br#"{"type":"event_msg"}"#;
+
+        let decoded = decode_event_payload(payload, RAW_CODEC).expect("decode raw payload");
+
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn decode_event_payload_rejects_unknown_codec() {
+        let error =
+            decode_event_payload(br#"{"type":"event_msg"}"#, "zstd").expect_err("codec error");
+
+        assert_eq!(error.to_string(), "unsupported event payload codec: zstd");
     }
 
     fn assert_sql_object(conn: &Connection, kind: &str, name: &str) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -614,6 +614,321 @@ fn ingest_preserves_claude_cli_fixture_and_status_reports_counts() {
 }
 
 #[test]
+fn events_prints_decoded_payload_jsonl_for_bounded_session() {
+    let root = temp_root("events-session-limit");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+
+    run_ingest(&root, &data_dir);
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--limit",
+            "2",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("events stdout should be utf-8"),
+        fixture_lines(CLAUDE_FIXTURE_SESSION, 2)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn events_prints_all_decoded_payload_jsonl_for_session() {
+    let root = temp_root("events-session-all");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+
+    run_ingest(&root, &data_dir);
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--all",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events --all");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("events stdout should be utf-8"),
+        fixture_lines(CLAUDE_FIXTURE_SESSION, 12)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn events_filters_by_source_and_session_identity() {
+    let root = temp_root("events-source-session-identity");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+
+    run_ingest(&root, &data_dir);
+    insert_same_session_id_other_source(&data_dir);
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--limit",
+            "2",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("events stdout should be utf-8"),
+        fixture_lines(CLAUDE_FIXTURE_SESSION, 2)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn events_reports_unsupported_payload_codec() {
+    let root = temp_root("events-unsupported-codec");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+
+    run_ingest(&root, &data_dir);
+    set_event_codec(&data_dir, 1, "zstd");
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--limit",
+            "2",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("jottrace events failed"));
+    assert!(stderr.contains("unsupported event payload codec: zstd"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn events_limit_ignores_unsupported_codec_outside_selected_range() {
+    let root = temp_root("events-limit-codec-range");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+
+    run_ingest(&root, &data_dir);
+    set_event_codec(&data_dir, 2, "zstd");
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--limit",
+            "2",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("events stdout should be utf-8"),
+        fixture_lines(CLAUDE_FIXTURE_SESSION, 2)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn events_reports_missing_session_identity() {
+    let root = temp_root("events-missing-session");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+
+    run_ingest(&root, &data_dir);
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            "missing-session",
+            "--limit",
+            "2",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("jottrace events failed"));
+    assert!(
+        stderr.contains("session not found: source=claude_cli source_session_id=missing-session")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn events_requires_an_explicit_source() {
+    let root = temp_root("events-requires-source");
+    let data_dir = root.join(".jottrace");
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--limit",
+            "1",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events without source");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("events requires --source <source>"));
+    assert!(stderr.contains("jottrace events --help"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn events_requires_an_explicit_limit() {
+    let root = temp_root("events-requires-limit");
+    let data_dir = root.join(".jottrace");
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events without limit");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("events requires --limit <n> or --all"));
+    assert!(stderr.contains("jottrace events --help"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn events_rejects_non_positive_limit() {
+    let root = temp_root("events-rejects-non-positive-limit");
+    let data_dir = root.join(".jottrace");
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--limit",
+            "0",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events with zero limit");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid limit: 0; expected at least 1"));
+    assert!(stderr.contains("jottrace events --help"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn events_rejects_limit_and_all_together() {
+    let root = temp_root("events-rejects-limit-and-all");
+    let data_dir = root.join(".jottrace");
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--limit",
+            "1",
+            "--all",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events with limit and all");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("events accepts either --limit <n> or --all, not both"));
+    assert!(stderr.contains("jottrace events --help"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn ingest_preserves_claude_cli_sidechain_as_child_session() {
     let root = temp_root("ingest-claude-sidechain");
     let data_dir = root.join(".jottrace");
@@ -855,6 +1170,51 @@ fn first_fixture_line() -> Vec<u8> {
         .next()
         .expect("first line")
         .to_vec()
+}
+
+fn fixture_lines(fixture_relative: &str, count: usize) -> String {
+    let contents = fs::read_to_string(reader_fixture(fixture_relative)).expect("read fixture");
+    let mut selected = contents.lines().take(count).collect::<Vec<_>>().join("\n");
+    selected.push('\n');
+    selected
+}
+
+fn insert_same_session_id_other_source(data_dir: &Path) {
+    let conn = Connection::open(db_path(data_dir)).expect("open preserved db");
+    let payload = br#"{"source":"codex_cli"}"#;
+    conn.execute(
+        "INSERT INTO sessions (source, source_session_id, event_count)
+         VALUES ('codex_cli', ?1, 1)",
+        [CLAUDE_FIXTURE_SESSION_ID],
+    )
+    .expect("insert same source_session_id for another source");
+    conn.execute(
+        "INSERT INTO events (session_id, generation, seq, payload, codec, payload_size)
+         VALUES (last_insert_rowid(), 0, 0, ?1, 'raw', ?2)",
+        rusqlite::params![payload, payload.len() as i64],
+    )
+    .expect("insert other source event");
+}
+
+fn set_event_codec(data_dir: &Path, seq: i64, codec: &str) {
+    let conn = Connection::open(db_path(data_dir)).expect("open preserved db");
+    let updated = conn
+        .execute(
+            "UPDATE events
+         SET codec = ?1
+         WHERE session_id = (
+             SELECT id FROM sessions
+             WHERE source = 'claude_cli' AND source_session_id = ?2
+         )
+           AND generation = 0
+           AND seq = ?3",
+            rusqlite::params![codec, CLAUDE_FIXTURE_SESSION_ID, seq],
+        )
+        .expect("set event codec");
+    assert_eq!(
+        updated, 1,
+        "expected to update one fixture event at seq {seq}"
+    )
 }
 
 fn run_ingest(home: &Path, data_dir: &Path) -> String {


### PR DESCRIPTION
## Summary

Adds `jottrace events` for exporting decoded JSONL payloads from a selected preserved session. The command requires `--source` plus `--session`, and requires either `--limit <n>` or `--all` so full-session exports are explicit without imposing a hard size ceiling.

## Notes

- Streams payloads through a buffered writer so large sessions do not need to be collected in memory.
- Resolves the session once and uses a partial codec index to keep unsupported-codec checks cheap.
- Reports missing sessions and unsupported payload codecs clearly.

## Validation

- `rtk cargo fmt --check`
- `rtk cargo clippy --all-targets -- -D warnings`
- `rtk cargo test`

Closes #43