### PR TITLE
[codex] Use zstd for large event payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -55,6 +57,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,12 +84,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "jottrace"
 version = "26.5.3"
 dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "zstd",
 ]
 
 [[package]]
@@ -88,6 +113,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -135,6 +166,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rsqlite-vfs"
@@ -277,6 +314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,7 +368,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ description = "Preserve AI coding-session transcripts into a local journal"
 rusqlite = { version = "0.39.0", default-features = false, features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+zstd = { version = "0.13.3", default-features = false }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use crate::storage::{
-    DB_FILE_NAME, RAW_CODEC, open_database, sqlite_error, status_from_connection,
+    DB_FILE_NAME, encode_event_payload, open_database, sqlite_error, status_from_connection,
 };
 use crate::{JottraceError, Result};
 
@@ -384,15 +384,16 @@ fn import_committed_lines(
             Ok(header) => {
                 capture_metadata(&mut metadata, &header);
                 let ts = event_timestamp(&header);
+                let encoded = encode_event_payload(line)?;
                 let inserted = event_insert
                     .execute(params![
                         session_id,
                         generation,
                         seq,
                         ts,
-                        line,
-                        RAW_CODEC,
-                        i64_from_usize(line.len(), &source_file.path)?,
+                        encoded.payload,
+                        encoded.codec,
+                        i64_from_usize(encoded.payload_size, &source_file.path)?,
                     ])
                     .map_err(|source| sqlite_error(&source_file.path, source))?;
                 inserted_event_count += inserted as u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,10 @@ pub enum JottraceError {
     UnsupportedEventPayloadCodec {
         codec: String,
     },
+    EventPayloadCodec {
+        codec: String,
+        source: io::Error,
+    },
     SessionNotFound {
         source: String,
         source_session_id: String,
@@ -110,6 +114,9 @@ impl fmt::Display for JottraceError {
             Self::UnsupportedEventPayloadCodec { codec } => {
                 write!(f, "unsupported event payload codec: {codec}")
             }
+            Self::EventPayloadCodec { codec, source } => {
+                write!(f, "failed to process event payload codec {codec}: {source}")
+            }
             Self::SessionNotFound {
                 source,
                 source_session_id,
@@ -135,6 +142,7 @@ impl std::error::Error for JottraceError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io { source, .. } => Some(source),
+            Self::EventPayloadCodec { source, .. } => Some(source),
             Self::Output { source } => Some(source),
             Self::Sqlite { source, .. } => Some(source),
             _ => None,

--- a/src/migrations/005_supported_zstd_codec_index.sql
+++ b/src/migrations/005_supported_zstd_codec_index.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_events_unsupported_codec;
+
+CREATE INDEX idx_events_unsupported_codec
+    ON events (session_id, generation, seq)
+    WHERE codec NOT IN ('raw', 'zstd');

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,12 +1,17 @@
 use rusqlite::{Connection, OptionalExtension, Row, params};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::{JottraceError, Result, data_dir_from_env, ensure_private_file};
 
 pub const DB_FILE_NAME: &str = "db.sqlite";
-pub const LATEST_SCHEMA_VERSION: i64 = 4;
+pub const LATEST_SCHEMA_VERSION: i64 = 5;
 pub(crate) const RAW_CODEC: &str = "raw";
+pub(crate) const ZSTD_CODEC: &str = "zstd";
+/// Minimum source payload size considered for zstd. Keeping this named makes
+/// future corpus/fixture tuning deliberate instead of hidden in insert logic.
+pub(crate) const ZSTD_MIN_PAYLOAD_BYTES: usize = 1024;
 
 const MIGRATIONS: &[Migration] = &[
     Migration {
@@ -24,6 +29,10 @@ const MIGRATIONS: &[Migration] = &[
     Migration {
         version: 4,
         sql: include_str!("migrations/004_unsupported_event_codec_index.sql"),
+    },
+    Migration {
+        version: 5,
+        sql: include_str!("migrations/005_supported_zstd_codec_index.sql"),
     },
 ];
 const UNRESOLVED_INGEST_ERROR_COUNT_SQL: &str =
@@ -59,6 +68,13 @@ pub struct IngestErrorSummary {
     pub occurrence_count: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EncodedEventPayload {
+    pub payload: Vec<u8>,
+    pub codec: &'static str,
+    pub payload_size: usize,
+}
+
 pub fn db_path_from_env() -> Result<PathBuf> {
     Ok(data_dir_from_env()?.join(DB_FILE_NAME))
 }
@@ -85,8 +101,75 @@ pub fn decode_event_payload(payload: &[u8], codec: &str) -> Result<Vec<u8>> {
     if codec == RAW_CODEC {
         return Ok(payload.to_vec());
     }
+    if codec == ZSTD_CODEC {
+        return zstd::stream::decode_all(payload).map_err(|source| {
+            JottraceError::EventPayloadCodec {
+                codec: ZSTD_CODEC.to_string(),
+                source,
+            }
+        });
+    }
 
     Err(unsupported_event_payload_codec(codec))
+}
+
+pub(crate) fn decode_event_payload_prefix(
+    payload: &[u8],
+    codec: &str,
+    byte_limit: usize,
+) -> Result<Vec<u8>> {
+    if codec == RAW_CODEC {
+        return Ok(payload[..payload.len().min(byte_limit)].to_vec());
+    }
+    if codec == ZSTD_CODEC {
+        let decoder = zstd::stream::read::Decoder::new(payload).map_err(|source| {
+            JottraceError::EventPayloadCodec {
+                codec: ZSTD_CODEC.to_string(),
+                source,
+            }
+        })?;
+        let mut decoder = decoder.take(byte_limit as u64);
+        let mut decoded = Vec::with_capacity(byte_limit);
+        decoder
+            .read_to_end(&mut decoded)
+            .map_err(|source| JottraceError::EventPayloadCodec {
+                codec: ZSTD_CODEC.to_string(),
+                source,
+            })?;
+        return Ok(decoded);
+    }
+
+    Err(unsupported_event_payload_codec(codec))
+}
+
+pub(crate) fn encode_event_payload(payload: &[u8]) -> Result<EncodedEventPayload> {
+    if payload.len() < ZSTD_MIN_PAYLOAD_BYTES {
+        return Ok(raw_event_payload(payload));
+    }
+
+    let compressed = zstd::stream::encode_all(payload, 0).map_err(|source| {
+        JottraceError::EventPayloadCodec {
+            codec: ZSTD_CODEC.to_string(),
+            source,
+        }
+    })?;
+    if compressed.len() < payload.len() {
+        return Ok(EncodedEventPayload {
+            payload: compressed,
+            codec: ZSTD_CODEC,
+            payload_size: payload.len(),
+        });
+    }
+
+    Ok(raw_event_payload(payload))
+}
+
+fn raw_event_payload(payload: &[u8]) -> EncodedEventPayload {
+    EncodedEventPayload {
+        payload: payload.to_vec(),
+        codec: RAW_CODEC,
+        payload_size: payload.len(),
+    }
 }
 
 pub fn open_database(path: &Path) -> Result<Connection> {
@@ -236,14 +319,14 @@ fn for_each_decoded_event_payload_from_connection(
 
     let sql = match limit {
         Some(_) => {
-            "SELECT events.payload
+            "SELECT events.payload, events.codec
              FROM events
              WHERE events.session_id = ?1
              ORDER BY events.generation, events.seq
              LIMIT ?2"
         }
         None => {
-            "SELECT events.payload
+            "SELECT events.payload, events.codec
              FROM events
              WHERE events.session_id = ?1
              ORDER BY events.generation, events.seq"
@@ -263,7 +346,13 @@ fn for_each_decoded_event_payload_from_connection(
 
     while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
         let payload: Vec<u8> = row.get(0).map_err(|source| sqlite_error(path, source))?;
-        visit(&payload)?;
+        let codec: String = row.get(1).map_err(|source| sqlite_error(path, source))?;
+        if codec == RAW_CODEC {
+            visit(&payload)?;
+        } else {
+            let decoded = decode_event_payload(&payload, &codec)?;
+            visit(&decoded)?;
+        }
     }
 
     Ok(())
@@ -281,14 +370,14 @@ fn reject_unsupported_event_codecs(
                 "SELECT events.codec
                  FROM events
                  WHERE events.session_id = ?1
-                   AND events.codec != 'raw'
+                   AND events.codec NOT IN (?4, ?5)
                    AND (
                        events.generation < ?2
                        OR (events.generation = ?2 AND events.seq <= ?3)
                    )
                  ORDER BY events.generation, events.seq
                  LIMIT 1",
-                params![session_id, generation, seq],
+                params![session_id, generation, seq, RAW_CODEC, ZSTD_CODEC],
                 |row| row.get(0),
             )
             .optional()
@@ -298,10 +387,10 @@ fn reject_unsupported_event_codecs(
                 "SELECT events.codec
                  FROM events
                  WHERE events.session_id = ?1
-                   AND events.codec != 'raw'
+                   AND events.codec NOT IN (?2, ?3)
                  ORDER BY events.generation, events.seq
                  LIMIT 1",
-                params![session_id],
+                params![session_id, RAW_CODEC, ZSTD_CODEC],
                 |row| row.get(0),
             )
             .optional()
@@ -415,6 +504,10 @@ mod tests {
         assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved");
         assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved_last_seen");
         assert_sql_object(&conn, "index", "idx_events_unsupported_codec");
+        assert!(
+            index_sql(&conn, "idx_events_unsupported_codec")
+                .contains("codec NOT IN ('raw', 'zstd')")
+        );
 
         assert!(columns(&conn, "sessions").contains(&"id".to_string()));
         assert!(columns(&conn, "sessions").contains(&"source_session_id".to_string()));
@@ -622,6 +715,47 @@ mod tests {
     }
 
     #[test]
+    fn migrates_v4_unsupported_codec_index_to_exclude_supported_zstd_rows() {
+        let root = temp_root("storage-upgrade-v4-codec-index");
+        let db_path = root.join(DB_FILE_NAME);
+        ensure_private_file(&db_path).expect("create db file");
+
+        {
+            let conn = Connection::open(&db_path).expect("open v4 db");
+            conn.execute_batch(include_str!("migrations/001_initial_schema.sql"))
+                .expect("create v1 schema");
+            conn.execute_batch(include_str!(
+                "migrations/002_ingest_error_recency_index.sql"
+            ))
+            .expect("create v2 schema");
+            conn.execute_batch(include_str!(
+                "migrations/003_claude_sidechain_source_ids.sql"
+            ))
+            .expect("create v3 schema");
+            conn.execute_batch(include_str!(
+                "migrations/004_unsupported_event_codec_index.sql"
+            ))
+            .expect("create v4 schema");
+            assert!(index_sql(&conn, "idx_events_unsupported_codec").contains("codec != 'raw'"));
+            conn.pragma_update(None, "user_version", 4)
+                .expect("set user_version");
+        }
+
+        let conn = open_database(&db_path).expect("migrate db");
+
+        assert_eq!(
+            user_version(&db_path, &conn).expect("user_version"),
+            LATEST_SCHEMA_VERSION
+        );
+        assert!(
+            index_sql(&conn, "idx_events_unsupported_codec")
+                .contains("codec NOT IN ('raw', 'zstd')")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn status_counts_unresolved_ingest_errors_only() {
         let root = temp_root("storage-status");
         let db_path = root.join(DB_FILE_NAME);
@@ -671,11 +805,81 @@ mod tests {
     }
 
     #[test]
+    fn decode_event_payload_returns_zstd_payload_bytes() {
+        let payload = br#"{"type":"event_msg","message":"compressible payload"}"#;
+        let encoded = zstd::stream::encode_all(&payload[..], 0).expect("encode zstd payload");
+
+        let decoded = decode_event_payload(&encoded, ZSTD_CODEC).expect("decode zstd payload");
+
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn decode_event_payload_prefix_returns_bounded_zstd_payload_bytes() {
+        let payload = vec![b'x'; 4096];
+        let encoded = zstd::stream::encode_all(&payload[..], 0).expect("encode zstd payload");
+
+        let decoded =
+            decode_event_payload_prefix(&encoded, ZSTD_CODEC, 1024).expect("decode zstd prefix");
+
+        assert_eq!(decoded, payload[..1024]);
+    }
+
+    #[test]
     fn decode_event_payload_rejects_unknown_codec() {
         let error =
-            decode_event_payload(br#"{"type":"event_msg"}"#, "zstd").expect_err("codec error");
+            decode_event_payload(br#"{"type":"event_msg"}"#, "snappy").expect_err("codec error");
 
-        assert_eq!(error.to_string(), "unsupported event payload codec: zstd");
+        assert_eq!(error.to_string(), "unsupported event payload codec: snappy");
+    }
+
+    #[test]
+    fn encode_event_payload_keeps_subthreshold_payload_raw() {
+        let payload = vec![b'x'; ZSTD_MIN_PAYLOAD_BYTES - 1];
+
+        let encoded = encode_event_payload(&payload).expect("encode event payload");
+
+        assert_eq!(encoded.codec, RAW_CODEC);
+        assert_eq!(encoded.payload, payload);
+        assert_eq!(encoded.payload_size, ZSTD_MIN_PAYLOAD_BYTES - 1);
+    }
+
+    #[test]
+    fn encode_event_payload_uses_zstd_when_compressed_payload_is_smaller() {
+        let payload = vec![b'x'; ZSTD_MIN_PAYLOAD_BYTES];
+
+        let encoded = encode_event_payload(&payload).expect("encode event payload");
+
+        assert_eq!(encoded.codec, ZSTD_CODEC);
+        assert!(encoded.payload.len() < payload.len());
+        assert_eq!(encoded.payload_size, payload.len());
+        assert_eq!(
+            decode_event_payload(&encoded.payload, encoded.codec).expect("decode event payload"),
+            payload
+        );
+    }
+
+    #[test]
+    fn encode_event_payload_keeps_incompressible_payload_raw() {
+        let payload = pseudo_random_bytes(4096);
+
+        let encoded = encode_event_payload(&payload).expect("encode event payload");
+
+        assert_eq!(encoded.codec, RAW_CODEC);
+        assert_eq!(encoded.payload, payload);
+        assert_eq!(encoded.payload_size, 4096);
+    }
+
+    fn pseudo_random_bytes(len: usize) -> Vec<u8> {
+        let mut state = 0x4d59_5df4_d0f3_3173_u64;
+        let mut output = Vec::with_capacity(len);
+        for _ in 0..len {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            output.push(state as u8);
+        }
+        output
     }
 
     fn assert_sql_object(conn: &Connection, kind: &str, name: &str) {
@@ -698,6 +902,15 @@ mod tests {
             .expect("query columns")
             .map(|row| row.expect("column name"))
             .collect()
+    }
+
+    fn index_sql(conn: &Connection, name: &str) -> String {
+        conn.query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
+            [name],
+            |row| row.get(0),
+        )
+        .expect("index sql")
     }
 
     fn temp_root(name: &str) -> PathBuf {

--- a/src/web.rs
+++ b/src/web.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::storage::{
-    IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, sqlite_error,
-    unresolved_ingest_errors_from_connection,
+    IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload_prefix,
+    sqlite_error, unresolved_ingest_errors_from_connection,
 };
 use crate::{JottraceError, Result};
 
@@ -88,7 +88,9 @@ struct LoadedSession {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SearchPattern {
     like: Option<String>,
+    payload_needle: Option<String>,
     include_payload: bool,
+    decoded_payload_session_ids: Vec<i64>,
 }
 
 pub struct WebServer {
@@ -229,7 +231,11 @@ impl WebServer {
 
 pub fn journal_view_for_path(path: &Path, query: &JournalQuery) -> Result<JournalView> {
     let conn = open_web_database(path)?;
-    let search = search_pattern(query.search.as_deref(), query.include_payload_search);
+    let mut search = search_pattern(query.search.as_deref(), query.include_payload_search);
+    if search.include_payload {
+        search.decoded_payload_session_ids =
+            decoded_payload_matching_session_ids(path, &conn, &search)?;
+    }
     let session_offset = bounded_offset(query.session_offset);
     let event_offset = bounded_offset(query.event_offset);
     let (loaded_sessions, session_page) = load_sessions(path, &conn, &search, session_offset)?;
@@ -414,29 +420,44 @@ fn load_sessions(
     offset: usize,
 ) -> Result<(Vec<LoadedSession>, PageInfo)> {
     let limit = SESSION_PAGE_SIZE;
+    let mut sql = String::from(
+        "SELECT sessions.id, sessions.source, sessions.source_session_id,
+                sessions.file_path, sessions.cwd, parent.source_session_id,
+                sessions.started_at, sessions.ended_at, sessions.event_count
+         FROM sessions
+         LEFT JOIN sessions AS parent ON parent.id = sessions.parent_session_id
+         WHERE ?1 IS NULL
+            OR sessions.source LIKE ?1 ESCAPE '\\'
+            OR sessions.source_session_id LIKE ?1 ESCAPE '\\'
+            OR COALESCE(sessions.cwd, '') LIKE ?1 ESCAPE '\\'
+            OR COALESCE(sessions.file_path, '') LIKE ?1 ESCAPE '\\'
+            OR (?2 = 1 AND EXISTS (
+                SELECT 1
+                FROM events
+                WHERE events.session_id = sessions.id
+                  AND events.codec = ?3
+                  AND CAST(substr(events.payload, 1, ?4) AS TEXT) LIKE ?1 ESCAPE '\\'
+            ))",
+    );
+    if !search.decoded_payload_session_ids.is_empty() {
+        sql.push_str(" OR sessions.id IN (");
+        for index in 0..search.decoded_payload_session_ids.len() {
+            if index > 0 {
+                sql.push_str(", ");
+            }
+            write!(sql, "{}", search.decoded_payload_session_ids[index])
+                .expect("write SQL session id");
+        }
+        sql.push(')');
+    }
+    sql.push_str(
+        " ORDER BY COALESCE(sessions.started_at, sessions.updated_at) DESC,
+                  sessions.id DESC
+          LIMIT ?5 OFFSET ?6",
+    );
+
     let mut statement = conn
-        .prepare(
-            "SELECT sessions.id, sessions.source, sessions.source_session_id,
-                    sessions.file_path, sessions.cwd, parent.source_session_id,
-                    sessions.started_at, sessions.ended_at, sessions.event_count
-             FROM sessions
-             LEFT JOIN sessions AS parent ON parent.id = sessions.parent_session_id
-             WHERE ?1 IS NULL
-                OR sessions.source LIKE ?1 ESCAPE '\\'
-                OR sessions.source_session_id LIKE ?1 ESCAPE '\\'
-                OR COALESCE(sessions.cwd, '') LIKE ?1 ESCAPE '\\'
-                OR COALESCE(sessions.file_path, '') LIKE ?1 ESCAPE '\\'
-                OR (?2 = 1 AND EXISTS (
-                    SELECT 1
-                    FROM events
-                    WHERE events.session_id = sessions.id
-                      AND events.codec = ?3
-                      AND CAST(substr(events.payload, 1, ?4) AS TEXT) LIKE ?1 ESCAPE '\\'
-                ))
-             ORDER BY COALESCE(sessions.started_at, sessions.updated_at) DESC,
-                      sessions.id DESC
-             LIMIT ?5 OFFSET ?6",
-        )
+        .prepare(&sql)
         .map_err(|source| sqlite_error(path, source))?;
 
     let mut sessions = statement
@@ -570,28 +591,46 @@ fn load_event_payload(
     session_id: i64,
     key: EventKey,
 ) -> Result<Option<JournalEvent>> {
-    conn.query_row(
-        "SELECT generation, seq, ts, codec, payload_size,
+    let row = conn
+        .query_row(
+            "SELECT generation, seq, ts, codec, payload_size,
                 CASE
                     WHEN codec = ?4 THEN substr(payload, 1, ?5)
-                    ELSE x''
+                    ELSE payload
                 END AS payload_preview
          FROM events
          WHERE session_id = ?1
            AND generation = ?2
            AND seq = ?3
          LIMIT 1",
-        params![
-            session_id,
-            key.generation,
-            key.seq,
-            RAW_CODEC,
-            PAYLOAD_PREVIEW_BYTES as i64,
-        ],
-        journal_event_with_payload_from_row,
+            params![
+                session_id,
+                key.generation,
+                key.seq,
+                RAW_CODEC,
+                PAYLOAD_PREVIEW_BYTES as i64,
+            ],
+            |row| {
+                let payload_size: i64 = row.get("payload_size")?;
+                Ok((
+                    row.get("generation")?,
+                    row.get("seq")?,
+                    row.get("ts")?,
+                    row.get("codec")?,
+                    payload_size as u64,
+                    row.get("payload_preview")?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|source| sqlite_error(path, source))?;
+
+    row.map(
+        |(generation, seq, ts, codec, payload_size, payload_preview)| {
+            journal_event_with_payload(generation, seq, ts, codec, payload_size, payload_preview)
+        },
     )
-    .optional()
-    .map_err(|source| sqlite_error(path, source))
+    .transpose()
 }
 
 fn loaded_session_from_row(row: &Row<'_>) -> rusqlite::Result<LoadedSession> {
@@ -615,13 +654,6 @@ fn journal_event_metadata_from_row(row: &Row<'_>) -> rusqlite::Result<JournalEve
     journal_event_from_row(row, |_, _| String::new())
 }
 
-fn journal_event_with_payload_from_row(row: &Row<'_>) -> rusqlite::Result<JournalEvent> {
-    let preview_bytes: Vec<u8> = row.get("payload_preview")?;
-    journal_event_from_row(row, |codec, payload_size| {
-        payload_preview(codec, payload_size, &preview_bytes)
-    })
-}
-
 fn journal_event_from_row(
     row: &Row<'_>,
     payload_preview_from: impl FnOnce(&str, u64) -> String,
@@ -639,17 +671,40 @@ fn journal_event_from_row(
     })
 }
 
+fn journal_event_with_payload(
+    generation: i64,
+    seq: i64,
+    ts: Option<String>,
+    codec: String,
+    payload_size: u64,
+    payload_preview: Vec<u8>,
+) -> Result<JournalEvent> {
+    Ok(JournalEvent {
+        generation,
+        seq,
+        ts,
+        payload_preview: payload_preview_for_codec(&codec, &payload_preview)?,
+        codec,
+        payload_size,
+    })
+}
+
 fn search_pattern(search: Option<&str>, include_payload_search: bool) -> SearchPattern {
     let Some(search) = search.map(str::trim).filter(|search| !search.is_empty()) else {
         return SearchPattern {
             like: None,
+            payload_needle: None,
             include_payload: false,
+            decoded_payload_session_ids: Vec::new(),
         };
     };
+    let include_payload =
+        include_payload_search && search.chars().count() >= MIN_PAYLOAD_SEARCH_CHARS;
     SearchPattern {
         like: Some(like_contains_pattern(search)),
-        include_payload: include_payload_search
-            && search.chars().count() >= MIN_PAYLOAD_SEARCH_CHARS,
+        payload_needle: include_payload.then(|| search.to_lowercase()),
+        include_payload,
+        decoded_payload_session_ids: Vec::new(),
     }
 }
 
@@ -676,15 +731,48 @@ fn like_contains_pattern(search: &str) -> String {
     pattern
 }
 
-fn payload_preview(codec: &str, payload_size: u64, payload: &[u8]) -> String {
-    if codec != RAW_CODEC {
-        return format!("[{codec} payload: {payload_size} bytes]");
-    }
+fn decoded_payload_matching_session_ids(
+    path: &Path,
+    conn: &Connection,
+    search: &SearchPattern,
+) -> Result<Vec<i64>> {
+    let Some(needle) = search.payload_needle.as_deref() else {
+        return Ok(Vec::new());
+    };
 
-    String::from_utf8_lossy(payload)
+    let mut statement = conn
+        .prepare(
+            "SELECT session_id, payload
+             FROM events
+             WHERE codec = ?1
+             ORDER BY session_id, generation, seq",
+        )
+        .map_err(|source| sqlite_error(path, source))?;
+    let mut rows = statement
+        .query(params![ZSTD_CODEC])
+        .map_err(|source| sqlite_error(path, source))?;
+    let mut session_ids = Vec::new();
+    while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
+        let session_id: i64 = row.get(0).map_err(|source| sqlite_error(path, source))?;
+        if session_ids.contains(&session_id) {
+            continue;
+        }
+        let payload: Vec<u8> = row.get(1).map_err(|source| sqlite_error(path, source))?;
+        let decoded = decode_event_payload_prefix(&payload, ZSTD_CODEC, PAYLOAD_PREVIEW_BYTES)?;
+        let preview = String::from_utf8_lossy(&decoded).to_lowercase();
+        if preview.contains(needle) {
+            session_ids.push(session_id);
+        }
+    }
+    Ok(session_ids)
+}
+
+fn payload_preview_for_codec(codec: &str, payload: &[u8]) -> Result<String> {
+    let decoded = decode_event_payload_prefix(payload, codec, PAYLOAD_PREVIEW_BYTES)?;
+    Ok(String::from_utf8_lossy(&decoded)
         .chars()
         .take(PAYLOAD_PREVIEW_CHARS)
-        .collect()
+        .collect())
 }
 
 fn render_events(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -614,6 +614,166 @@ fn ingest_preserves_claude_cli_fixture_and_status_reports_counts() {
 }
 
 #[test]
+fn ingest_compresses_large_payloads_and_events_decodes_original_jsonl() {
+    let root = temp_root("ingest-zstd-large-payload");
+    let data_dir = root.join(".jottrace");
+    let large_line = large_compressible_event_line();
+    let session_file = claude_project_dir(&root).join(format!("{CLAUDE_FIXTURE_SESSION_ID}.jsonl"));
+    write_text_file(&session_file, &format!("{large_line}\n"));
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("events: 1"));
+    assert!(ingest.contains("inserted_events: 1"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let (stored_payload, codec, payload_size): (Vec<u8>, String, i64) = conn
+        .query_row(
+            "SELECT payload, codec, payload_size
+             FROM events
+             WHERE seq = 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("stored zstd event payload");
+    assert_eq!(codec, "zstd");
+    assert_eq!(payload_size, large_line.len() as i64);
+    assert!(
+        stored_payload.len() < large_line.len(),
+        "compressed payload should be smaller than source line"
+    );
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--limit",
+            "1",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("events stdout should be utf-8"),
+        format!("{large_line}\n")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_uses_zstd_threshold_and_events_decodes_mixed_raw_and_zstd_rows() {
+    let root = temp_root("ingest-zstd-threshold");
+    let data_dir = root.join(".jottrace");
+    let below_threshold = compressible_event_line_with_len(1023);
+    let at_threshold = compressible_event_line_with_len(1024);
+    let session_file = claude_project_dir(&root).join(format!("{CLAUDE_FIXTURE_SESSION_ID}.jsonl"));
+    write_text_file(
+        &session_file,
+        &format!("{below_threshold}\n{at_threshold}\n"),
+    );
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("events: 2"));
+    assert!(ingest.contains("inserted_events: 2"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let codecs = event_codecs(&conn);
+    assert_eq!(
+        codecs,
+        vec![(0, "raw".to_string()), (1, "zstd".to_string())]
+    );
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--all",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events --all");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("events stdout should be utf-8"),
+        format!("{below_threshold}\n{at_threshold}\n")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_leaves_existing_raw_rows_unchanged_on_idempotent_rerun() {
+    let root = temp_root("ingest-existing-raw-idempotent");
+    let data_dir = root.join(".jottrace");
+    let line = large_compressible_event_line();
+    let session_file = claude_project_dir(&root).join(format!("{CLAUDE_FIXTURE_SESSION_ID}.jsonl"));
+    write_text_file(&session_file, &format!("{line}\n"));
+    set_modified(&session_file, 1_700_000_000);
+    insert_legacy_raw_session(&data_dir, &session_file, &line);
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("events: 1"));
+    assert!(ingest.contains("inserted_events: 0"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let (stored_payload, codec): (Vec<u8>, String) = conn
+        .query_row(
+            "SELECT payload, codec FROM events WHERE seq = 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("legacy raw event payload");
+    assert_eq!(codec, "raw");
+    assert_eq!(stored_payload, line.as_bytes());
+
+    let output = Command::new(binary())
+        .args([
+            "events",
+            "--source",
+            "claude_cli",
+            "--session",
+            CLAUDE_FIXTURE_SESSION_ID,
+            "--limit",
+            "1",
+        ])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace events");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("events stdout should be utf-8"),
+        format!("{line}\n")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn events_prints_decoded_payload_jsonl_for_bounded_session() {
     let root = temp_root("events-session-limit");
     let data_dir = root.join(".jottrace");
@@ -728,7 +888,7 @@ fn events_reports_unsupported_payload_codec() {
     install_primary_claude_fixture(&root);
 
     run_ingest(&root, &data_dir);
-    set_event_codec(&data_dir, 1, "zstd");
+    set_event_codec(&data_dir, 1, "snappy");
 
     let output = Command::new(binary())
         .args([
@@ -748,7 +908,7 @@ fn events_reports_unsupported_payload_codec() {
     assert!(output.stdout.is_empty());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("jottrace events failed"));
-    assert!(stderr.contains("unsupported event payload codec: zstd"));
+    assert!(stderr.contains("unsupported event payload codec: snappy"));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -760,7 +920,7 @@ fn events_limit_ignores_unsupported_codec_outside_selected_range() {
     install_primary_claude_fixture(&root);
 
     run_ingest(&root, &data_dir);
-    set_event_codec(&data_dir, 2, "zstd");
+    set_event_codec(&data_dir, 2, "snappy");
 
     let output = Command::new(binary())
         .args([
@@ -1179,6 +1339,59 @@ fn fixture_lines(fixture_relative: &str, count: usize) -> String {
     selected
 }
 
+fn large_compressible_event_line() -> String {
+    compressible_event_line_with_len(1600)
+}
+
+fn compressible_event_line_with_len(len: usize) -> String {
+    let prefix = r#"{"type":"assistant","timestamp":"2026-05-05T01:00:00.000Z","cwd":"/Users/fixture/Workspace/jottrace","message":""#;
+    let suffix = r#""}"#;
+    assert!(len >= prefix.len() + suffix.len());
+    let line = format!(
+        "{prefix}{}{suffix}",
+        "x".repeat(len - prefix.len() - suffix.len())
+    );
+    assert_eq!(line.len(), len);
+    line
+}
+
+fn event_codecs(conn: &Connection) -> Vec<(i64, String)> {
+    let mut statement = conn
+        .prepare("SELECT seq, codec FROM events ORDER BY seq")
+        .expect("prepare event codecs");
+    statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .expect("query event codecs")
+        .map(|row| row.expect("event codec"))
+        .collect()
+}
+
+fn insert_legacy_raw_session(data_dir: &Path, session_file: &Path, line: &str) {
+    let conn = jottrace::storage::open_database(&db_path(data_dir)).expect("open database");
+    let file_size = fs::metadata(session_file)
+        .expect("legacy session metadata")
+        .len() as i64;
+    conn.execute(
+        "INSERT INTO sessions
+            (source, source_session_id, file_path, current_generation, file_mtime,
+             file_size, content_fingerprint, next_read_offset, event_count)
+         VALUES ('claude_cli', ?1, ?2, 0, ?3, ?4, 'legacy-raw', ?4, 1)",
+        rusqlite::params![
+            CLAUDE_FIXTURE_SESSION_ID,
+            session_file.to_string_lossy(),
+            1_700_000_000_i64,
+            file_size,
+        ],
+    )
+    .expect("insert legacy raw session");
+    conn.execute(
+        "INSERT INTO events (session_id, generation, seq, ts, payload, codec, payload_size)
+         VALUES (last_insert_rowid(), 0, 0, '2026-05-05T01:00:00.000Z', ?1, 'raw', ?2)",
+        rusqlite::params![line.as_bytes(), line.len() as i64],
+    )
+    .expect("insert legacy raw event");
+}
+
 fn insert_same_session_id_other_source(data_dir: &Path) {
     let conn = Connection::open(db_path(data_dir)).expect("open preserved db");
     let payload = br#"{"source":"codex_cli"}"#;
@@ -1198,6 +1411,8 @@ fn insert_same_session_id_other_source(data_dir: &Path) {
 
 fn set_event_codec(data_dir: &Path, seq: i64, codec: &str) {
     let conn = Connection::open(db_path(data_dir)).expect("open preserved db");
+    conn.execute("PRAGMA ignore_check_constraints = ON", [])
+        .expect("allow unsupported codec fixture");
     let updated = conn
         .execute(
             "UPDATE events

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -171,6 +171,46 @@ fn web_journal_view_filters_sessions_by_metadata_and_payload_text() {
 }
 
 #[test]
+fn web_journal_view_searches_and_previews_zstd_payloads() {
+    let root = temp_root("web-zstd-payload");
+    let data_dir = root.join(".jottrace");
+    let db_path = db_path(&data_dir);
+    jottrace::storage::status_for_path(&db_path).expect("initialize database");
+    insert_zstd_session(&db_path);
+
+    let query = jottrace::web::JournalQuery {
+        selected_source: Some("claude_cli".to_string()),
+        selected_source_session_id: Some("zstd-session".to_string()),
+        search: Some("zstd searchable phrase".to_string()),
+        include_payload_search: true,
+        expanded_event: Some(jottrace::web::EventKey {
+            generation: 0,
+            seq: 0,
+        }),
+        ..Default::default()
+    };
+    let view =
+        jottrace::web::journal_view_for_path(&db_path, &query).expect("load zstd web journal");
+
+    assert_eq!(
+        view.sessions
+            .iter()
+            .map(|session| session.source_session_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["zstd-session"]
+    );
+    let event = view.expanded_event.expect("expanded zstd event");
+    assert_eq!(event.codec, "zstd");
+    assert!(
+        event
+            .payload_preview
+            .contains("zstd searchable phrase for the web journal")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn web_journal_view_treats_search_wildcards_as_literal_text() {
     let root = temp_root("web-literal-search");
     let data_dir = root.join(".jottrace");
@@ -585,6 +625,25 @@ fn populate_large_journal(db_path: &Path) {
         }
     }
     tx.commit().expect("commit large journal transaction");
+}
+
+fn insert_zstd_session(db_path: &Path) {
+    let conn = Connection::open(db_path).expect("open zstd web database");
+    let payload =
+        r#"{"message":"zstd searchable phrase for the web journal with decoded preview"}"#;
+    let compressed = zstd::stream::encode_all(payload.as_bytes(), 0).expect("compress payload");
+    conn.execute(
+        "INSERT INTO sessions (source, source_session_id, event_count, started_at)
+         VALUES ('claude_cli', 'zstd-session', 1, '2026-05-05T01:00:00Z')",
+        [],
+    )
+    .expect("insert zstd session");
+    conn.execute(
+        "INSERT INTO events (session_id, generation, seq, ts, payload, codec, payload_size)
+         VALUES (last_insert_rowid(), 0, 0, '2026-05-05T01:00:00Z', ?1, 'zstd', ?2)",
+        params![compressed, payload.len() as i64],
+    )
+    .expect("insert zstd event");
 }
 
 fn fixture_timestamp(start_hour: usize, index: usize, second: usize) -> String {


### PR DESCRIPTION
## Summary

- store newly ingested large compressible JSONL event payloads as `codec = 'zstd'` using a named 1024-byte threshold
- keep small, incompressible, and existing raw rows readable without rewriting them
- decode zstd payloads through `jottrace events` and bounded web preview/search paths
- add migration coverage so the unsupported-codec index excludes supported zstd rows

## Validation

- `cargo clippy --all-targets -- -D warnings`
- `cargo test` outside the sandbox
- `git diff --check`

Closes #44