### PR TITLE
[codex] Display decoded payloads in web UI

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::storage::{
-    IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload_prefix,
-    sqlite_error, unresolved_ingest_errors_from_connection,
+    IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload,
+    decode_event_payload_prefix, sqlite_error, unresolved_ingest_errors_from_connection,
 };
 use crate::{JottraceError, Result};
 
@@ -77,6 +77,7 @@ pub struct JournalEvent {
     pub codec: String,
     pub payload_size: u64,
     pub payload_preview: String,
+    pub payload_error: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,7 +90,6 @@ struct LoadedSession {
 struct SearchPattern {
     like: Option<String>,
     payload_needle: Option<String>,
-    include_payload: bool,
     decoded_payload_session_ids: Vec<i64>,
 }
 
@@ -167,21 +167,35 @@ impl WebServer {
             );
         }
 
-        if target_path(target) != "/" {
-            return self.write_response(
-                stream,
+        let (status, content_type, body) = match target_path(target) {
+            "/" => {
+                let query = journal_query_from_target(target);
+                let body = match journal_view_for_path(&self.db_path, &query) {
+                    Ok(view) => render_home_page(&view, &query),
+                    Err(error) => render_error_page(&self.db_path, &error),
+                };
+                ("200 OK", "text/html; charset=utf-8", body)
+            }
+            "/payload" => match event_payload_text_for_path(&self.db_path, target) {
+                Ok(Some(payload)) => ("200 OK", "text/plain; charset=utf-8", payload),
+                Ok(None) => (
+                    "404 Not Found",
+                    "text/plain; charset=utf-8",
+                    "payload not found".to_string(),
+                ),
+                Err(error) => (
+                    "500 Internal Server Error",
+                    "text/plain; charset=utf-8",
+                    error.to_string(),
+                ),
+            },
+            _ => (
                 "404 Not Found",
                 "text/plain; charset=utf-8",
-                "not found",
-            );
-        }
-
-        let query = journal_query_from_target(target);
-        let body = match journal_view_for_path(&self.db_path, &query) {
-            Ok(view) => render_home_page(&view, &query),
-            Err(error) => render_error_page(&self.db_path, &error),
+                "not found".to_string(),
+            ),
         };
-        self.write_response(stream, "200 OK", "text/html; charset=utf-8", &body)
+        self.write_response(stream, status, content_type, &body)
     }
 
     fn write_response(
@@ -232,7 +246,7 @@ impl WebServer {
 pub fn journal_view_for_path(path: &Path, query: &JournalQuery) -> Result<JournalView> {
     let conn = open_web_database(path)?;
     let mut search = search_pattern(query.search.as_deref(), query.include_payload_search);
-    if search.include_payload {
+    if search.payload_needle.is_some() {
         search.decoded_payload_session_ids =
             decoded_payload_matching_session_ids(path, &conn, &search)?;
     }
@@ -380,7 +394,7 @@ pub fn render_home_page(view: &JournalView, query: &JournalQuery) -> String {
             html.push_str("</dl><h2>Events</h2>");
             render_events(&mut html, &view.events, query, session);
             if let Some(event) = &view.expanded_event {
-                render_payload_panel(&mut html, event);
+                render_payload_panel(&mut html, event, session);
             }
             if let Some(page) = view.event_page {
                 render_event_pagination(&mut html, page, query, session);
@@ -413,6 +427,29 @@ fn open_web_database(path: &Path) -> Result<Connection> {
     Ok(conn)
 }
 
+fn event_payload_text_for_path(path: &Path, target: &str) -> Result<Option<String>> {
+    let query = journal_query_from_target(target);
+    let Some(source_session_id) = query.selected_source_session_id.as_deref() else {
+        return Ok(None);
+    };
+    let Some(key) = query.expanded_event else {
+        return Ok(None);
+    };
+
+    let conn = open_web_database(path)?;
+    let Some(session) = load_session_by_source_session_id(
+        path,
+        &conn,
+        query.selected_source.as_deref(),
+        source_session_id,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    load_event_payload_text(path, &conn, session.id, key)
+}
+
 fn load_sessions(
     path: &Path,
     conn: &Connection,
@@ -430,14 +467,7 @@ fn load_sessions(
             OR sessions.source LIKE ?1 ESCAPE '\\'
             OR sessions.source_session_id LIKE ?1 ESCAPE '\\'
             OR COALESCE(sessions.cwd, '') LIKE ?1 ESCAPE '\\'
-            OR COALESCE(sessions.file_path, '') LIKE ?1 ESCAPE '\\'
-            OR (?2 = 1 AND EXISTS (
-                SELECT 1
-                FROM events
-                WHERE events.session_id = sessions.id
-                  AND events.codec = ?3
-                  AND CAST(substr(events.payload, 1, ?4) AS TEXT) LIKE ?1 ESCAPE '\\'
-            ))",
+            OR COALESCE(sessions.file_path, '') LIKE ?1 ESCAPE '\\'",
     );
     if !search.decoded_payload_session_ids.is_empty() {
         sql.push_str(" OR sessions.id IN (");
@@ -453,7 +483,7 @@ fn load_sessions(
     sql.push_str(
         " ORDER BY COALESCE(sessions.started_at, sessions.updated_at) DESC,
                   sessions.id DESC
-          LIMIT ?5 OFFSET ?6",
+          LIMIT ?2 OFFSET ?3",
     );
 
     let mut statement = conn
@@ -462,14 +492,7 @@ fn load_sessions(
 
     let mut sessions = statement
         .query_map(
-            params![
-                search.like.as_deref(),
-                search.include_payload as i64,
-                RAW_CODEC,
-                PAYLOAD_PREVIEW_BYTES as i64,
-                (limit + 1) as i64,
-                offset as i64,
-            ],
+            params![search.like.as_deref(), (limit + 1) as i64, offset as i64],
             loaded_session_from_row,
         )
         .map_err(|source| sqlite_error(path, source))?
@@ -489,6 +512,33 @@ fn load_sessions(
             has_next,
         },
     ))
+}
+
+fn load_event_payload_text(
+    path: &Path,
+    conn: &Connection,
+    session_id: i64,
+    key: EventKey,
+) -> Result<Option<String>> {
+    let row = conn
+        .query_row(
+            "SELECT payload, codec
+             FROM events
+             WHERE session_id = ?1
+               AND generation = ?2
+               AND seq = ?3
+             LIMIT 1",
+            params![session_id, key.generation, key.seq],
+            |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()
+        .map_err(|source| sqlite_error(path, source))?;
+
+    row.map(|(payload, codec)| {
+        decode_event_payload(&payload, &codec)
+            .map(|decoded| String::from_utf8_lossy(&decoded).into_owned())
+    })
+    .transpose()
 }
 
 fn select_session(
@@ -666,6 +716,7 @@ fn journal_event_from_row(
         seq: row.get("seq")?,
         ts: row.get("ts")?,
         payload_preview: payload_preview_from(&codec, payload_size),
+        payload_error: None,
         codec,
         payload_size,
     })
@@ -677,13 +728,32 @@ fn journal_event_with_payload(
     ts: Option<String>,
     codec: String,
     payload_size: u64,
-    payload_preview: Vec<u8>,
+    payload: Vec<u8>,
 ) -> Result<JournalEvent> {
+    let payload_preview = match decode_event_payload_prefix(&payload, &codec, PAYLOAD_PREVIEW_BYTES)
+    {
+        Ok(decoded) => String::from_utf8_lossy(&decoded)
+            .chars()
+            .take(PAYLOAD_PREVIEW_CHARS)
+            .collect(),
+        Err(error) => {
+            return Ok(JournalEvent {
+                generation,
+                seq,
+                ts,
+                payload_preview: String::new(),
+                payload_error: Some(error.to_string()),
+                codec,
+                payload_size,
+            });
+        }
+    };
     Ok(JournalEvent {
         generation,
         seq,
         ts,
-        payload_preview: payload_preview_for_codec(&codec, &payload_preview)?,
+        payload_preview,
+        payload_error: None,
         codec,
         payload_size,
     })
@@ -694,7 +764,6 @@ fn search_pattern(search: Option<&str>, include_payload_search: bool) -> SearchP
         return SearchPattern {
             like: None,
             payload_needle: None,
-            include_payload: false,
             decoded_payload_session_ids: Vec::new(),
         };
     };
@@ -703,7 +772,6 @@ fn search_pattern(search: Option<&str>, include_payload_search: bool) -> SearchP
     SearchPattern {
         like: Some(like_contains_pattern(search)),
         payload_needle: include_payload.then(|| search.to_lowercase()),
-        include_payload,
         decoded_payload_session_ids: Vec::new(),
     }
 }
@@ -742,37 +810,40 @@ fn decoded_payload_matching_session_ids(
 
     let mut statement = conn
         .prepare(
-            "SELECT session_id, payload
+            "SELECT session_id,
+                    CASE
+                        WHEN codec = ?1 THEN substr(payload, 1, ?3)
+                        ELSE payload
+                    END AS payload_prefix,
+                    codec
              FROM events
-             WHERE codec = ?1
+             WHERE codec IN (?1, ?2)
              ORDER BY session_id, generation, seq",
         )
         .map_err(|source| sqlite_error(path, source))?;
     let mut rows = statement
-        .query(params![ZSTD_CODEC])
+        .query(params![RAW_CODEC, ZSTD_CODEC, PAYLOAD_PREVIEW_BYTES as i64])
         .map_err(|source| sqlite_error(path, source))?;
     let mut session_ids = Vec::new();
+    let mut matched_session_id = None;
     while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
         let session_id: i64 = row.get(0).map_err(|source| sqlite_error(path, source))?;
-        if session_ids.contains(&session_id) {
+        if matched_session_id == Some(session_id) {
             continue;
         }
         let payload: Vec<u8> = row.get(1).map_err(|source| sqlite_error(path, source))?;
-        let decoded = decode_event_payload_prefix(&payload, ZSTD_CODEC, PAYLOAD_PREVIEW_BYTES)?;
+        let codec: String = row.get(2).map_err(|source| sqlite_error(path, source))?;
+        let Ok(decoded) = decode_event_payload_prefix(&payload, &codec, PAYLOAD_PREVIEW_BYTES)
+        else {
+            continue;
+        };
         let preview = String::from_utf8_lossy(&decoded).to_lowercase();
         if preview.contains(needle) {
+            matched_session_id = Some(session_id);
             session_ids.push(session_id);
         }
     }
     Ok(session_ids)
-}
-
-fn payload_preview_for_codec(codec: &str, payload: &[u8]) -> Result<String> {
-    let decoded = decode_event_payload_prefix(payload, codec, PAYLOAD_PREVIEW_BYTES)?;
-    Ok(String::from_utf8_lossy(&decoded)
-        .chars()
-        .take(PAYLOAD_PREVIEW_CHARS)
-        .collect())
 }
 
 fn render_events(
@@ -804,7 +875,7 @@ fn render_events(
     html.push_str("</tbody></table></div>");
 }
 
-fn render_payload_panel(html: &mut String, event: &JournalEvent) {
+fn render_payload_panel(html: &mut String, event: &JournalEvent, session: &JournalSession) {
     html.push_str(
         "<div class=\"payload-panel\"><h3>Payload preview</h3><div class=\"muted\">generation ",
     );
@@ -814,9 +885,21 @@ fn render_payload_panel(html: &mut String, event: &JournalEvent) {
     html.push_str(" / ");
     write!(html, "{} bytes ", event.payload_size).expect("write html");
     html_escape_into(html, &event.codec);
-    html.push_str("</div><pre>");
+    html.push_str("</div>");
+    if let Some(error) = &event.payload_error {
+        html.push_str("<p class=\"error\">Payload unavailable</p><pre>");
+        html_escape_into(html, error);
+        html.push_str("</pre></div>");
+        return;
+    }
+
+    html.push_str("<pre>");
     html_escape_into(html, &event.payload_preview);
-    html.push_str("</pre></div>");
+    html.push_str("</pre>");
+    html.push_str("<p><a class=\"inspect\" href=\"");
+    html_escape_into(html, &event_payload_export_href(session, event));
+    html.push_str("\">Export full decoded payload</a></p>");
+    html.push_str("</div>");
 }
 
 fn render_ingest_errors(html: &mut String, ingest_errors: &[IngestErrorSummary]) {
@@ -980,6 +1063,21 @@ fn event_payload_href(
             seq: event.seq,
         }),
     )
+}
+
+fn event_payload_export_href(session: &JournalSession, event: &JournalEvent) -> String {
+    let mut href = String::from("/payload");
+    let mut first = true;
+    append_url_param(&mut href, &mut first, "source", &session.source);
+    append_url_param(&mut href, &mut first, "session", &session.source_session_id);
+    append_url_param(
+        &mut href,
+        &mut first,
+        "event_generation",
+        &event.generation.to_string(),
+    );
+    append_url_param(&mut href, &mut first, "event_seq", &event.seq.to_string());
+    href
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -3,7 +3,7 @@ mod common;
 use common::reader_fixture;
 use std::fs;
 use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
-use std::net::{Shutdown, TcpStream};
+use std::net::{Shutdown, SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
@@ -129,6 +129,10 @@ fn web_home_page_renders_journal_data_and_search_controls() {
     assert!(html.contains("/Users/fixture/Workspace/jottrace"));
     assert!(html.contains("event count"));
     assert!(html.contains("Please implement the sanitized reader fixture corpus."));
+    assert!(html.contains("Export full decoded payload"));
+    assert!(html.contains(&format!(
+        "/payload?source=claude_cli&amp;session={CLAUDE_FIXTURE_SESSION_ID}&amp;event_generation=0&amp;event_seq=2"
+    )));
     assert!(html.contains("Unresolved ingest errors"));
     assert!(html.contains("invalid_json"));
     assert!(!html.contains("<script"));
@@ -206,6 +210,57 @@ fn web_journal_view_searches_and_previews_zstd_payloads() {
             .payload_preview
             .contains("zstd searchable phrase for the web journal")
     );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn web_journal_view_searches_decoded_payloads_without_failing_on_corrupt_payloads() {
+    let root = temp_root("web-payload-search-decode-errors");
+    let data_dir = root.join(".jottrace");
+    let db_path = db_path(&data_dir);
+    jottrace::storage::status_for_path(&db_path).expect("initialize database");
+    insert_raw_payload_session(&db_path);
+    insert_zstd_session(&db_path);
+    insert_corrupt_zstd_session(&db_path);
+
+    assert_eq!(
+        payload_matching_session_ids(&db_path, "raw decoded search phrase"),
+        vec!["raw-payload-session".to_string()]
+    );
+    assert_eq!(
+        payload_matching_session_ids(&db_path, "zstd searchable phrase"),
+        vec!["zstd-session".to_string()]
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn web_home_page_renders_payload_decode_errors_without_hiding_session() {
+    let root = temp_root("web-payload-error");
+    let data_dir = root.join(".jottrace");
+    let db_path = db_path(&data_dir);
+    jottrace::storage::status_for_path(&db_path).expect("initialize database");
+    insert_unsupported_codec_session(&db_path);
+
+    let query = jottrace::web::JournalQuery {
+        selected_source: Some("claude_cli".to_string()),
+        selected_source_session_id: Some("unsupported-codec-session".to_string()),
+        expanded_event: Some(jottrace::web::EventKey {
+            generation: 0,
+            seq: 0,
+        }),
+        ..Default::default()
+    };
+    let view = jottrace::web::journal_view_for_path(&db_path, &query)
+        .expect("load web journal view with unsupported payload codec");
+    let html = jottrace::web::render_home_page(&view, &query);
+
+    assert!(html.contains("unsupported-codec-session"));
+    assert!(html.contains("Inspect 25 bytes snappy"));
+    assert!(html.contains("Payload unavailable"));
+    assert!(html.contains("unsupported event payload codec: snappy"));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -418,27 +473,13 @@ fn web_server_serves_local_journal_html() {
     let address = server.local_addr().expect("local address");
     let handle = thread::spawn(move || server.serve_once().expect("serve one request"));
 
-    let mut stream = TcpStream::connect(address).expect("connect to web server");
-    write!(
-        stream,
-        "GET /?session={CLAUDE_FIXTURE_SESSION_ID}&q=sanitized%20reader&payload=1&event_generation=0&event_seq=2 HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
-    )
-    .expect("write http request");
-    stream
-        .shutdown(Shutdown::Write)
-        .expect("finish http request");
-    let mut response_bytes = Vec::new();
-    let mut buffer = [0; 1024];
-    loop {
-        match stream.read(&mut buffer) {
-            Ok(0) => break,
-            Ok(len) => response_bytes.extend_from_slice(&buffer[..len]),
-            Err(error) if error.kind() == ErrorKind::ConnectionReset => break,
-            Err(error) => panic!("read http response: {error}"),
-        }
-    }
+    let response = read_http_response(
+        address,
+        &format!(
+            "/?session={CLAUDE_FIXTURE_SESSION_ID}&q=sanitized%20reader&payload=1&event_generation=0&event_seq=2"
+        ),
+    );
     handle.join().expect("web server thread");
-    let response = String::from_utf8(response_bytes).expect("response should be utf-8");
 
     assert!(response.starts_with("HTTP/1.1 200 OK"));
     assert!(response.contains("Content-Type: text/html; charset=utf-8"));
@@ -447,6 +488,33 @@ fn web_server_serves_local_journal_html() {
         "response:\n{response}"
     );
     assert!(response.contains("Please implement the sanitized reader fixture corpus."));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn web_server_exports_full_decoded_payload_text() {
+    let root = temp_root("web-server-payload-export");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+    run_ingest(&root, &data_dir);
+
+    let server = jottrace::web::WebServer::bind(db_path(&data_dir), 0).expect("bind web server");
+    let address = server.local_addr().expect("local address");
+    let handle = thread::spawn(move || server.serve_once().expect("serve one request"));
+
+    let response = read_http_response(
+        address,
+        &format!(
+            "/payload?source=claude_cli&session={CLAUDE_FIXTURE_SESSION_ID}&event_generation=0&event_seq=2"
+        ),
+    );
+    handle.join().expect("web server thread");
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    assert!(response.contains("Content-Type: text/plain; charset=utf-8"));
+    assert!(response.contains("Please implement the sanitized reader fixture corpus."));
+    assert!(!response.contains("<!doctype html>"));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -540,6 +608,29 @@ fn payload_matching_session_ids(db_path: &Path, search: &str) -> Vec<String> {
         .collect()
 }
 
+fn read_http_response(address: SocketAddr, target: &str) -> String {
+    let mut stream = TcpStream::connect(address).expect("connect to web server");
+    write!(
+        stream,
+        "GET {target} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    )
+    .expect("write http request");
+    stream
+        .shutdown(Shutdown::Write)
+        .expect("finish http request");
+    let mut response_bytes = Vec::new();
+    let mut buffer = [0; 1024];
+    loop {
+        match stream.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(len) => response_bytes.extend_from_slice(&buffer[..len]),
+            Err(error) if error.kind() == ErrorKind::ConnectionReset => break,
+            Err(error) => panic!("read http response: {error}"),
+        }
+    }
+    String::from_utf8(response_bytes).expect("response should be utf-8")
+}
+
 fn run_ingest(home: &Path, data_dir: &Path) {
     let output = Command::new(binary())
         .arg("ingest")
@@ -628,22 +719,80 @@ fn populate_large_journal(db_path: &Path) {
 }
 
 fn insert_zstd_session(db_path: &Path) {
-    let conn = Connection::open(db_path).expect("open zstd web database");
     let payload =
         r#"{"message":"zstd searchable phrase for the web journal with decoded preview"}"#;
     let compressed = zstd::stream::encode_all(payload.as_bytes(), 0).expect("compress payload");
+    insert_payload_session(
+        db_path,
+        "zstd-session",
+        &compressed,
+        "zstd",
+        payload.len(),
+        false,
+    );
+}
+
+fn insert_raw_payload_session(db_path: &Path) {
+    let payload = r#"{"message":"raw decoded search phrase for the web journal"}"#;
+    insert_payload_session(
+        db_path,
+        "raw-payload-session",
+        payload.as_bytes(),
+        "raw",
+        payload.len(),
+        false,
+    );
+}
+
+fn insert_corrupt_zstd_session(db_path: &Path) {
+    let payload = b"not a zstd frame";
+    insert_payload_session(
+        db_path,
+        "corrupt-zstd-session",
+        payload.as_slice(),
+        "zstd",
+        payload.len(),
+        false,
+    );
+}
+
+fn insert_unsupported_codec_session(db_path: &Path) {
+    let payload = br#"{"message":"unsupported"}"#;
+    insert_payload_session(
+        db_path,
+        "unsupported-codec-session",
+        payload.as_slice(),
+        "snappy",
+        payload.len(),
+        true,
+    );
+}
+
+fn insert_payload_session(
+    db_path: &Path,
+    source_session_id: &str,
+    payload: &[u8],
+    codec: &str,
+    payload_size: usize,
+    ignore_check_constraints: bool,
+) {
+    let conn = Connection::open(db_path).expect("open payload fixture database");
+    if ignore_check_constraints {
+        conn.execute("PRAGMA ignore_check_constraints = ON", [])
+            .expect("allow unsupported codec fixture");
+    }
     conn.execute(
         "INSERT INTO sessions (source, source_session_id, event_count, started_at)
-         VALUES ('claude_cli', 'zstd-session', 1, '2026-05-05T01:00:00Z')",
-        [],
+         VALUES ('claude_cli', ?1, 1, '2026-05-05T01:00:00Z')",
+        [source_session_id],
     )
-    .expect("insert zstd session");
+    .expect("insert payload fixture session");
     conn.execute(
         "INSERT INTO events (session_id, generation, seq, ts, payload, codec, payload_size)
-         VALUES (last_insert_rowid(), 0, 0, '2026-05-05T01:00:00Z', ?1, 'zstd', ?2)",
-        params![compressed, payload.len() as i64],
+         VALUES (last_insert_rowid(), 0, 0, '2026-05-05T01:00:00Z', ?1, ?2, ?3)",
+        params![payload, codec, payload_size as i64],
     )
-    .expect("insert zstd event");
+    .expect("insert payload fixture event");
 }
 
 fn fixture_timestamp(start_hour: usize, index: usize, second: usize) -> String {


### PR DESCRIPTION
## Summary

- Render decoded event payload previews in the local web UI through Jottrace's shared payload decode helpers.
- Add an explicit `/payload` text export route for full decoded event JSON instead of embedding full payloads into the page.
- Make payload search use decoded raw/zstd text and tolerate corrupt per-event payloads without breaking the session view.
- Show a clear per-event payload error when a codec cannot be decoded.

## Validation

- `rtk cargo fmt --check`
- `rtk cargo clippy --all-targets -- -D warnings`
- `rtk cargo test`
- `rtk git diff --check`

Closes #45