### PR TITLE
[codex] Add zstd compaction command

### DIFF
--- a/src/compact.rs
+++ b/src/compact.rs
@@ -1,0 +1,452 @@
+use rusqlite::{Connection, params};
+use std::path::PathBuf;
+
+use crate::storage::{
+    DB_FILE_NAME, RAW_CODEC, ZSTD_CODEC, ZSTD_MIN_PAYLOAD_BYTES, decode_event_payload,
+    encode_event_payload, open_database, sqlite_error,
+    unresolved_ingest_error_count_from_connection,
+};
+use crate::{JottraceError, Result, data_dir_from_env};
+
+pub const DEFAULT_COMPACT_BATCH_SIZE: usize = 1_000;
+pub const MAX_COMPACT_BATCH_SIZE: usize = 10_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactMode {
+    DryRun,
+    Apply,
+    Vacuum,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompactOptions {
+    pub mode: CompactMode,
+    pub batch_size: usize,
+}
+
+impl Default for CompactOptions {
+    fn default() -> Self {
+        Self {
+            mode: CompactMode::DryRun,
+            batch_size: DEFAULT_COMPACT_BATCH_SIZE,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactReport {
+    pub db_path: PathBuf,
+    pub mode: CompactMode,
+    pub batch_size: usize,
+    pub raw_events_before: u64,
+    pub zstd_events_before: u64,
+    pub raw_events_after: u64,
+    pub zstd_events_after: u64,
+    pub unsupported_codec_events: u64,
+    pub eligible_raw_events: u64,
+    pub converted_events: u64,
+    pub skipped_raw_events: u64,
+    pub skipped_small_events: u64,
+    pub skipped_not_smaller_events: u64,
+    pub skipped_round_trip_failed_events: u64,
+    pub stored_bytes_before: u64,
+    pub stored_bytes_after: u64,
+    pub estimated_bytes_saved: u64,
+    pub sqlite_reclaimable_bytes_before: u64,
+    pub sqlite_reclaimable_bytes: u64,
+    pub unresolved_ingest_errors: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EventStorageStats {
+    raw_events: u64,
+    zstd_events: u64,
+    unsupported_codec_events: u64,
+    stored_bytes: u64,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct RawPayloadAnalysis {
+    eligible_events: u64,
+    skipped_small_events: u64,
+    skipped_not_smaller_events: u64,
+    skipped_round_trip_failed_events: u64,
+    estimated_bytes_saved: u64,
+    converted_events: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EventKey {
+    session_id: i64,
+    generation: i64,
+    seq: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RawEvent {
+    key: EventKey,
+    payload: Vec<u8>,
+}
+
+type ApplyBatchFn =
+    fn(&std::path::Path, &mut Connection, Vec<CompactionUpdate>) -> Result<AppliedBatch>;
+
+pub fn run_compact(options: CompactOptions) -> Result<CompactReport> {
+    validate_compact_options(options)?;
+
+    let data_dir = data_dir_from_env()?;
+    let _lock = match options.mode {
+        CompactMode::DryRun => None,
+        CompactMode::Apply | CompactMode::Vacuum => Some(crate::acquire_data_lock(&data_dir)?),
+    };
+    let db_path = data_dir.join(DB_FILE_NAME);
+    let mut conn = open_database(&db_path)?;
+    let before = event_storage_stats(&db_path, &conn)?;
+    let sqlite_reclaimable_bytes_before = sqlite_reclaimable_bytes(&db_path, &conn)?;
+    let (raw_analysis, after) = match options.mode {
+        CompactMode::DryRun => {
+            let analysis =
+                scan_raw_payload_candidates(&db_path, &mut conn, options.batch_size, None)?;
+            let after = EventStorageStats {
+                raw_events: before.raw_events.saturating_sub(analysis.eligible_events),
+                zstd_events: before.zstd_events + analysis.eligible_events,
+                unsupported_codec_events: before.unsupported_codec_events,
+                stored_bytes: before
+                    .stored_bytes
+                    .saturating_sub(analysis.estimated_bytes_saved),
+            };
+            (analysis, after)
+        }
+        CompactMode::Apply => {
+            let analysis = scan_raw_payload_candidates(
+                &db_path,
+                &mut conn,
+                options.batch_size,
+                Some(apply_update_batch),
+            )?;
+            let after = EventStorageStats {
+                raw_events: before.raw_events.saturating_sub(analysis.converted_events),
+                zstd_events: before.zstd_events + analysis.converted_events,
+                unsupported_codec_events: before.unsupported_codec_events,
+                stored_bytes: before
+                    .stored_bytes
+                    .saturating_sub(analysis.estimated_bytes_saved),
+            };
+            (analysis, after)
+        }
+        CompactMode::Vacuum => {
+            conn.execute_batch("VACUUM;")
+                .map_err(|source| sqlite_error(&db_path, source))?;
+            (RawPayloadAnalysis::default(), before)
+        }
+    };
+    let sqlite_reclaimable_bytes = sqlite_reclaimable_bytes(&db_path, &conn)?;
+    let unresolved_ingest_errors = unresolved_ingest_error_count_from_connection(&db_path, &conn)?;
+
+    Ok(CompactReport {
+        db_path,
+        mode: options.mode,
+        batch_size: options.batch_size,
+        raw_events_before: before.raw_events,
+        zstd_events_before: before.zstd_events,
+        raw_events_after: after.raw_events,
+        zstd_events_after: after.zstd_events,
+        unsupported_codec_events: before.unsupported_codec_events,
+        eligible_raw_events: raw_analysis.eligible_events,
+        converted_events: raw_analysis.converted_events,
+        skipped_raw_events: raw_analysis.skipped_events(),
+        skipped_small_events: raw_analysis.skipped_small_events,
+        skipped_not_smaller_events: raw_analysis.skipped_not_smaller_events,
+        skipped_round_trip_failed_events: raw_analysis.skipped_round_trip_failed_events,
+        stored_bytes_before: before.stored_bytes,
+        stored_bytes_after: after.stored_bytes,
+        estimated_bytes_saved: raw_analysis.estimated_bytes_saved,
+        sqlite_reclaimable_bytes_before,
+        sqlite_reclaimable_bytes,
+        unresolved_ingest_errors,
+    })
+}
+
+fn validate_compact_options(options: CompactOptions) -> Result<()> {
+    if (1..=MAX_COMPACT_BATCH_SIZE).contains(&options.batch_size) {
+        return Ok(());
+    }
+
+    Err(JottraceError::InvalidCompactBatchSize {
+        batch_size: options.batch_size,
+        max: MAX_COMPACT_BATCH_SIZE,
+    })
+}
+
+impl RawPayloadAnalysis {
+    fn skipped_events(&self) -> u64 {
+        self.skipped_small_events
+            + self.skipped_not_smaller_events
+            + self.skipped_round_trip_failed_events
+    }
+}
+
+fn scan_raw_payload_candidates(
+    path: &std::path::Path,
+    conn: &mut Connection,
+    batch_size: usize,
+    apply_batch: Option<ApplyBatchFn>,
+) -> Result<RawPayloadAnalysis> {
+    let mut cursor = None;
+    let mut analysis = RawPayloadAnalysis {
+        skipped_small_events: count_small_raw_events(path, conn)?,
+        ..RawPayloadAnalysis::default()
+    };
+
+    loop {
+        let events = raw_event_batch(path, conn, cursor, batch_size)?;
+        let Some(last) = events.last() else {
+            break;
+        };
+        cursor = Some(last.key);
+
+        let mut updates = Vec::new();
+        for event in events {
+            match compact_raw_payload(&event.payload)? {
+                RawPayloadPlan::Compact {
+                    payload,
+                    payload_size,
+                    saved_bytes,
+                } => {
+                    analysis.eligible_events += 1;
+                    updates.push(CompactionUpdate {
+                        key: event.key,
+                        payload,
+                        payload_size,
+                        saved_bytes,
+                    });
+                }
+                RawPayloadPlan::SkipNotSmaller => analysis.skipped_not_smaller_events += 1,
+                RawPayloadPlan::SkipRoundTripFailed => {
+                    analysis.skipped_round_trip_failed_events += 1;
+                }
+            }
+        }
+
+        match apply_batch {
+            Some(apply_batch) => {
+                let applied = apply_batch(path, conn, updates)?;
+                analysis.converted_events += applied.converted_events;
+                analysis.estimated_bytes_saved += applied.saved_bytes;
+            }
+            None => {
+                analysis.estimated_bytes_saved +=
+                    updates.iter().map(|update| update.saved_bytes).sum::<u64>();
+            }
+        }
+    }
+
+    Ok(analysis)
+}
+
+fn apply_update_batch(
+    path: &std::path::Path,
+    conn: &mut Connection,
+    updates: Vec<CompactionUpdate>,
+) -> Result<AppliedBatch> {
+    if updates.is_empty() {
+        return Ok(AppliedBatch::default());
+    }
+
+    let tx = conn
+        .transaction()
+        .map_err(|source| sqlite_error(path, source))?;
+    let mut converted_events = 0;
+    let mut saved_bytes = 0;
+    {
+        let mut statement = tx
+            .prepare(
+                "UPDATE events
+                 SET payload = ?1,
+                     codec = ?2,
+                     payload_size = ?3
+                 WHERE session_id = ?4
+                   AND generation = ?5
+                   AND seq = ?6
+                   AND codec = ?7",
+            )
+            .map_err(|source| sqlite_error(path, source))?;
+        for update in updates {
+            let updated = statement
+                .execute(params![
+                    update.payload,
+                    ZSTD_CODEC,
+                    update.payload_size as i64,
+                    update.key.session_id,
+                    update.key.generation,
+                    update.key.seq,
+                    RAW_CODEC,
+                ])
+                .map_err(|source| sqlite_error(path, source))?;
+            if updated > 0 {
+                converted_events += updated as u64;
+                saved_bytes += update.saved_bytes;
+            }
+        }
+    }
+    tx.commit().map_err(|source| sqlite_error(path, source))?;
+    Ok(AppliedBatch {
+        converted_events,
+        saved_bytes,
+    })
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct AppliedBatch {
+    converted_events: u64,
+    saved_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RawPayloadPlan {
+    Compact {
+        payload: Vec<u8>,
+        payload_size: usize,
+        saved_bytes: u64,
+    },
+    SkipNotSmaller,
+    SkipRoundTripFailed,
+}
+
+fn compact_raw_payload(payload: &[u8]) -> Result<RawPayloadPlan> {
+    let encoded = encode_event_payload(payload)?;
+    if encoded.codec == RAW_CODEC {
+        return Ok(RawPayloadPlan::SkipNotSmaller);
+    }
+
+    if decode_event_payload(&encoded.payload, encoded.codec)? != payload {
+        return Ok(RawPayloadPlan::SkipRoundTripFailed);
+    }
+
+    let saved_bytes = (payload.len() - encoded.payload.len()) as u64;
+    Ok(RawPayloadPlan::Compact {
+        payload: encoded.payload,
+        payload_size: encoded.payload_size,
+        saved_bytes,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CompactionUpdate {
+    key: EventKey,
+    payload: Vec<u8>,
+    payload_size: usize,
+    saved_bytes: u64,
+}
+
+fn raw_event_batch(
+    path: &std::path::Path,
+    conn: &Connection,
+    cursor: Option<EventKey>,
+    batch_size: usize,
+) -> Result<Vec<RawEvent>> {
+    let batch_size = batch_size as i64;
+    let sql = match cursor {
+        Some(_) => {
+            "SELECT session_id, generation, seq, payload
+             FROM events
+             WHERE codec = ?1
+               AND payload_size >= ?2
+               AND (
+                   session_id > ?3
+                   OR (session_id = ?3 AND generation > ?4)
+                   OR (session_id = ?3 AND generation = ?4 AND seq > ?5)
+               )
+             ORDER BY session_id, generation, seq
+             LIMIT ?6"
+        }
+        None => {
+            "SELECT session_id, generation, seq, payload
+             FROM events
+             WHERE codec = ?1
+               AND payload_size >= ?2
+             ORDER BY session_id, generation, seq
+             LIMIT ?3"
+        }
+    };
+    let mut statement = conn
+        .prepare(sql)
+        .map_err(|source| sqlite_error(path, source))?;
+    let mut rows = match cursor {
+        Some(cursor) => statement
+            .query(params![
+                RAW_CODEC,
+                ZSTD_MIN_PAYLOAD_BYTES as i64,
+                cursor.session_id,
+                cursor.generation,
+                cursor.seq,
+                batch_size
+            ])
+            .map_err(|source| sqlite_error(path, source))?,
+        None => statement
+            .query(params![
+                RAW_CODEC,
+                ZSTD_MIN_PAYLOAD_BYTES as i64,
+                batch_size
+            ])
+            .map_err(|source| sqlite_error(path, source))?,
+    };
+    let mut events = Vec::new();
+    while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
+        events.push(RawEvent {
+            key: EventKey {
+                session_id: row.get(0).map_err(|source| sqlite_error(path, source))?,
+                generation: row.get(1).map_err(|source| sqlite_error(path, source))?,
+                seq: row.get(2).map_err(|source| sqlite_error(path, source))?,
+            },
+            payload: row.get(3).map_err(|source| sqlite_error(path, source))?,
+        });
+    }
+    Ok(events)
+}
+
+fn count_small_raw_events(path: &std::path::Path, conn: &Connection) -> Result<u64> {
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM events
+             WHERE codec = ?1
+               AND payload_size < ?2",
+            params![RAW_CODEC, ZSTD_MIN_PAYLOAD_BYTES as i64],
+            |row| row.get(0),
+        )
+        .map_err(|source| sqlite_error(path, source))?;
+    Ok(count as u64)
+}
+
+fn event_storage_stats(path: &std::path::Path, conn: &Connection) -> Result<EventStorageStats> {
+    let (raw_events, zstd_events, unsupported_codec_events, stored_bytes): (i64, i64, i64, i64) =
+        conn.query_row(
+            "SELECT
+                COALESCE(SUM(CASE WHEN codec = ?1 THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN codec = ?2 THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN codec NOT IN (?1, ?2) THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(length(payload)), 0)
+             FROM events",
+            params![RAW_CODEC, ZSTD_CODEC],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .map_err(|source| sqlite_error(path, source))?;
+
+    Ok(EventStorageStats {
+        raw_events: raw_events as u64,
+        zstd_events: zstd_events as u64,
+        unsupported_codec_events: unsupported_codec_events as u64,
+        stored_bytes: stored_bytes as u64,
+    })
+}
+
+fn sqlite_reclaimable_bytes(path: &std::path::Path, conn: &Connection) -> Result<u64> {
+    let page_size: i64 = conn
+        .query_row("PRAGMA page_size", [], |row| row.get(0))
+        .map_err(|source| sqlite_error(path, source))?;
+    let freelist_count: i64 = conn
+        .query_row("PRAGMA freelist_count", [], |row| row.get(0))
+        .map_err(|source| sqlite_error(path, source))?;
+    Ok((page_size as u64).saturating_mul(freelist_count as u64))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(unix)]
 use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
 
+pub mod compact;
 pub mod ingest;
 pub mod storage;
 pub mod web;
+pub use compact::{CompactMode, CompactOptions, CompactReport, run_compact};
 pub use ingest::{IngestReport, run_ingest};
 pub use storage::{IngestErrorSummary, StatusReport, run_status};
 
@@ -68,6 +70,10 @@ pub enum JottraceError {
     },
     InvalidEventLimit {
         limit: i64,
+    },
+    InvalidCompactBatchSize {
+        batch_size: usize,
+        max: usize,
     },
     Output {
         source: io::Error,
@@ -127,6 +133,10 @@ impl fmt::Display for JottraceError {
             Self::InvalidEventLimit { limit } => {
                 write!(f, "event limit must be at least 1; got {limit}")
             }
+            Self::InvalidCompactBatchSize { batch_size, max } => write!(
+                f,
+                "compact batch size must be between 1 and {max}; got {batch_size}"
+            ),
             Self::Output { source } => write!(f, "failed to write output: {source}"),
             Self::LockHeld(path) => write!(
                 f,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ fn main() -> ExitCode {
             println!("jottrace {}", env!("CARGO_PKG_VERSION"));
             ExitCode::SUCCESS
         }
+        Some("compact") => run_compact_command(args),
         Some("doctor") => run_doctor_command(),
         Some("events") => run_events_command(args),
         Some("ingest") => run_ingest_command(),
@@ -60,6 +61,12 @@ struct WebOptions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WebCommand {
     Run(WebOptions),
+    Help,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompactCommand {
+    Run(jottrace::CompactOptions),
     Help,
 }
 
@@ -281,6 +288,144 @@ fn run_ingest_command() -> ExitCode {
     }
 }
 
+fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
+    let options = match parse_compact_command(args) {
+        Ok(CompactCommand::Run(options)) => options,
+        Ok(CompactCommand::Help) => {
+            print_compact_help();
+            return ExitCode::SUCCESS;
+        }
+        Err(message) => {
+            eprintln!("{message}");
+            eprintln!("run `jottrace compact --help` for usage");
+            return ExitCode::from(2);
+        }
+    };
+
+    match jottrace::run_compact(options) {
+        Ok(report) => {
+            println!("jottrace compact");
+            println!("db: {}", report.db_path.display());
+            println!("mode: {}", compact_mode_name(report.mode));
+            if report.mode != jottrace::CompactMode::Vacuum {
+                println!("batch_size: {}", report.batch_size);
+            }
+            println!("raw_events_before: {}", report.raw_events_before);
+            println!("zstd_events_before: {}", report.zstd_events_before);
+            println!("raw_events_after: {}", report.raw_events_after);
+            println!("zstd_events_after: {}", report.zstd_events_after);
+            println!(
+                "unsupported_codec_events: {}",
+                report.unsupported_codec_events
+            );
+            println!("eligible_raw_events: {}", report.eligible_raw_events);
+            println!("converted_events: {}", report.converted_events);
+            println!("skipped_raw_events: {}", report.skipped_raw_events);
+            println!("skipped_small_events: {}", report.skipped_small_events);
+            println!(
+                "skipped_not_smaller_events: {}",
+                report.skipped_not_smaller_events
+            );
+            println!(
+                "skipped_round_trip_failed_events: {}",
+                report.skipped_round_trip_failed_events
+            );
+            println!("stored_bytes_before: {}", report.stored_bytes_before);
+            println!("stored_bytes_after: {}", report.stored_bytes_after);
+            println!("estimated_bytes_saved: {}", report.estimated_bytes_saved);
+            println!(
+                "sqlite_reclaimable_bytes_before: {}",
+                report.sqlite_reclaimable_bytes_before
+            );
+            println!(
+                "sqlite_reclaimable_bytes: {}",
+                report.sqlite_reclaimable_bytes
+            );
+            println!(
+                "unresolved_ingest_errors: {}",
+                report.unresolved_ingest_errors
+            );
+            if report.mode == jottrace::CompactMode::DryRun {
+                println!(
+                    "next: rerun with `jottrace compact --apply` to rewrite eligible payloads"
+                );
+            }
+            println!(
+                "disk_reclaim: after applying, run `jottrace compact --vacuum` to reclaim free SQLite pages"
+            );
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("jottrace compact failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn parse_compact_command(
+    mut args: impl Iterator<Item = String>,
+) -> std::result::Result<CompactCommand, String> {
+    let mut options = jottrace::CompactOptions::default();
+    let mut explicit_mode = false;
+    let mut batch_size_provided = false;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--help" | "-h" => return Ok(CompactCommand::Help),
+            "--apply" => {
+                if explicit_mode {
+                    return Err("compact accepts only one of --apply or --vacuum".to_string());
+                }
+                explicit_mode = true;
+                options.mode = jottrace::CompactMode::Apply;
+            }
+            "--vacuum" => {
+                if explicit_mode {
+                    return Err("compact accepts only one of --apply or --vacuum".to_string());
+                }
+                if batch_size_provided {
+                    return Err("compact --vacuum does not accept --batch-size".to_string());
+                }
+                explicit_mode = true;
+                options.mode = jottrace::CompactMode::Vacuum;
+            }
+            "--batch-size" => {
+                if options.mode == jottrace::CompactMode::Vacuum {
+                    return Err("compact --vacuum does not accept --batch-size".to_string());
+                }
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--batch-size requires a value".to_string())?;
+                let parsed = value
+                    .parse::<usize>()
+                    .map_err(|_| format!("invalid batch size: {value}"))?;
+                if parsed < 1 {
+                    return Err(format!("invalid batch size: {value}; expected at least 1"));
+                }
+                if parsed > jottrace::compact::MAX_COMPACT_BATCH_SIZE {
+                    return Err(format!(
+                        "invalid batch size: {value}; expected at most {}",
+                        jottrace::compact::MAX_COMPACT_BATCH_SIZE
+                    ));
+                }
+                options.batch_size = parsed;
+                batch_size_provided = true;
+            }
+            _ => return Err(format!("unknown compact option: {arg}")),
+        }
+    }
+
+    Ok(CompactCommand::Run(options))
+}
+
+fn compact_mode_name(mode: jottrace::CompactMode) -> &'static str {
+    match mode {
+        jottrace::CompactMode::DryRun => "dry-run",
+        jottrace::CompactMode::Apply => "apply",
+        jottrace::CompactMode::Vacuum => "vacuum",
+    }
+}
+
 fn run_doctor_command() -> ExitCode {
     // Keep the CLI responsible for presentation while the library owns the
     // filesystem checks. That makes future commands easier to test directly.
@@ -358,6 +503,7 @@ fn print_help() {
     println!("Preserve AI coding-session transcripts into a local journal.");
     println!();
     println!("Usage:");
+    println!("  jottrace compact [--apply|--vacuum] [--batch-size <n>]");
     println!("  jottrace doctor");
     println!(
         "  jottrace events --source <source> --session <source_session_id> (--limit <n>|--all)"
@@ -366,6 +512,19 @@ fn print_help() {
     println!("  jottrace status");
     println!("  jottrace web [--port <port>] [--once]");
     println!("  jottrace --version");
+}
+
+fn print_compact_help() {
+    println!("jottrace compact");
+    println!("Report or rewrite eligible raw event payloads as zstd.");
+    println!();
+    println!("Usage:");
+    println!("  jottrace compact [--apply|--vacuum] [--batch-size <n>]");
+    println!();
+    println!("Options:");
+    println!("  --apply           Rewrite eligible raw payload rows in bounded batches");
+    println!("  --vacuum          Reclaim free SQLite pages after compaction");
+    println!("  --batch-size <n>  Raw rows to inspect per batch (default: 1000, max: 10000)");
 }
 
 fn print_events_help() {

--- a/src/migrations/006_raw_event_compaction_index.sql
+++ b/src/migrations/006_raw_event_compaction_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_events_raw_compaction
+    ON events (session_id, generation, seq)
+    WHERE codec = 'raw';

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use crate::{JottraceError, Result, data_dir_from_env, ensure_private_file};
 
 pub const DB_FILE_NAME: &str = "db.sqlite";
-pub const LATEST_SCHEMA_VERSION: i64 = 5;
+pub const LATEST_SCHEMA_VERSION: i64 = 6;
 pub(crate) const RAW_CODEC: &str = "raw";
 pub(crate) const ZSTD_CODEC: &str = "zstd";
 /// Minimum source payload size considered for zstd. Keeping this named makes
@@ -33,6 +33,10 @@ const MIGRATIONS: &[Migration] = &[
     Migration {
         version: 5,
         sql: include_str!("migrations/005_supported_zstd_codec_index.sql"),
+    },
+    Migration {
+        version: 6,
+        sql: include_str!("migrations/006_raw_event_compaction_index.sql"),
     },
 ];
 const UNRESOLVED_INGEST_ERROR_COUNT_SQL: &str =
@@ -504,10 +508,12 @@ mod tests {
         assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved");
         assert_sql_object(&conn, "index", "idx_ingest_errors_unresolved_last_seen");
         assert_sql_object(&conn, "index", "idx_events_unsupported_codec");
+        assert_sql_object(&conn, "index", "idx_events_raw_compaction");
         assert!(
             index_sql(&conn, "idx_events_unsupported_codec")
                 .contains("codec NOT IN ('raw', 'zstd')")
         );
+        assert!(index_sql(&conn, "idx_events_raw_compaction").contains("codec = 'raw'"));
 
         assert!(columns(&conn, "sessions").contains(&"id".to_string()));
         assert!(columns(&conn, "sessions").contains(&"source_session_id".to_string()));
@@ -751,6 +757,53 @@ mod tests {
             index_sql(&conn, "idx_events_unsupported_codec")
                 .contains("codec NOT IN ('raw', 'zstd')")
         );
+        assert!(index_sql(&conn, "idx_events_raw_compaction").contains("codec = 'raw'"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn migrates_v5_database_to_add_raw_compaction_index() {
+        let root = temp_root("storage-upgrade-v5-raw-compaction-index");
+        let db_path = root.join(DB_FILE_NAME);
+        ensure_private_file(&db_path).expect("create db file");
+
+        {
+            let conn = Connection::open(&db_path).expect("open v5 db");
+            conn.execute_batch(include_str!("migrations/001_initial_schema.sql"))
+                .expect("create v1 schema");
+            conn.execute_batch(include_str!(
+                "migrations/002_ingest_error_recency_index.sql"
+            ))
+            .expect("create v2 schema");
+            conn.execute_batch(include_str!(
+                "migrations/003_claude_sidechain_source_ids.sql"
+            ))
+            .expect("create v3 schema");
+            conn.execute_batch(include_str!(
+                "migrations/004_unsupported_event_codec_index.sql"
+            ))
+            .expect("create v4 schema");
+            conn.execute_batch(include_str!(
+                "migrations/005_supported_zstd_codec_index.sql"
+            ))
+            .expect("create v5 schema");
+            assert!(!sql_object_exists(
+                &conn,
+                "index",
+                "idx_events_raw_compaction"
+            ));
+            conn.pragma_update(None, "user_version", 5)
+                .expect("set user_version");
+        }
+
+        let conn = open_database(&db_path).expect("migrate db");
+
+        assert_eq!(
+            user_version(&db_path, &conn).expect("user_version"),
+            LATEST_SCHEMA_VERSION
+        );
+        assert!(index_sql(&conn, "idx_events_raw_compaction").contains("codec = 'raw'"));
 
         let _ = fs::remove_dir_all(root);
     }
@@ -883,6 +936,13 @@ mod tests {
     }
 
     fn assert_sql_object(conn: &Connection, kind: &str, name: &str) {
+        assert!(
+            sql_object_exists(conn, kind, name),
+            "{kind} {name} should exist"
+        );
+    }
+
+    fn sql_object_exists(conn: &Connection, kind: &str, name: &str) -> bool {
         let found: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type = ?1 AND name = ?2",
@@ -890,7 +950,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("query sqlite_master");
-        assert_eq!(found, 1, "{kind} {name} should exist");
+        found == 1
     }
 
     fn columns(conn: &Connection, table: &str) -> Vec<String> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -774,6 +774,218 @@ fn ingest_leaves_existing_raw_rows_unchanged_on_idempotent_rerun() {
 }
 
 #[test]
+fn compact_dry_run_reports_savings_without_mutating_payloads() {
+    let root = temp_root("compact-dry-run");
+    let data_dir = root.join(".jottrace");
+    let line = large_compressible_event_line();
+    let session_file = claude_project_dir(&root).join(format!("{CLAUDE_FIXTURE_SESSION_ID}.jsonl"));
+    write_text_file(&session_file, &format!("{line}\n"));
+    set_modified(&session_file, 1_700_000_000);
+    insert_legacy_raw_session(&data_dir, &session_file, &line);
+
+    let output = Command::new(binary())
+        .arg("compact")
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace compact");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("compact stdout should be utf-8");
+    assert!(stdout.contains("jottrace compact"));
+    assert!(stdout.contains("mode: dry-run"));
+    assert!(stdout.contains("raw_events_before: 1"));
+    assert!(stdout.contains("zstd_events_before: 0"));
+    assert!(stdout.contains("eligible_raw_events: 1"));
+    assert!(stdout.contains("converted_events: 0"));
+    assert!(stdout.contains("unresolved_ingest_errors: 0"));
+    assert!(
+        compact_metric(&stdout, "estimated_bytes_saved") > 0,
+        "{stdout}"
+    );
+    assert!(
+        compact_metric(&stdout, "stored_bytes_after")
+            < compact_metric(&stdout, "stored_bytes_before"),
+        "{stdout}"
+    );
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let (stored_payload, codec): (Vec<u8>, String) = conn
+        .query_row(
+            "SELECT payload, codec FROM events WHERE seq = 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("legacy raw event payload");
+    assert_eq!(codec, "raw");
+    assert_eq!(stored_payload, line.as_bytes());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn compact_apply_rewrites_only_eligible_raw_rows_and_is_idempotent() {
+    let root = temp_root("compact-apply");
+    let data_dir = root.join(".jottrace");
+    let fixture = insert_compaction_fixture(&data_dir);
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let before_identity = event_identity_at_seq(&conn, 0);
+    drop(conn);
+
+    let output = Command::new(binary())
+        .args(["compact", "--apply", "--batch-size", "2"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace compact --apply");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("compact stdout should be utf-8");
+    assert!(stdout.contains("mode: apply"));
+    assert!(stdout.contains("batch_size: 2"));
+    assert!(stdout.contains("raw_events_before: 3"));
+    assert!(stdout.contains("zstd_events_before: 1"));
+    assert!(stdout.contains("unsupported_codec_events: 1"));
+    assert!(stdout.contains("eligible_raw_events: 1"));
+    assert!(stdout.contains("converted_events: 1"));
+    assert!(stdout.contains("skipped_small_events: 1"));
+    assert!(stdout.contains("skipped_not_smaller_events: 1"));
+    assert!(stdout.contains("raw_events_after: 2"));
+    assert!(stdout.contains("zstd_events_after: 2"));
+    assert!(
+        compact_metric(&stdout, "stored_bytes_after")
+            < compact_metric(&stdout, "stored_bytes_before"),
+        "{stdout}"
+    );
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open compacted db");
+    let (stored_payload, codec, payload_size) = event_payload_record(&conn, 0);
+    assert_eq!(codec, "zstd");
+    assert_eq!(payload_size, fixture.eligible_payload.len() as i64);
+    assert_eq!(
+        jottrace::storage::decode_event_payload(&stored_payload, &codec)
+            .expect("decode compacted event"),
+        fixture.eligible_payload
+    );
+    assert_eq!(event_identity_at_seq(&conn, 0), before_identity);
+    assert_eq!(event_payload_record(&conn, 1).1, "raw");
+    assert_eq!(event_payload_record(&conn, 2).1, "raw");
+    assert_eq!(event_payload_record(&conn, 3).1, "zstd");
+    assert_eq!(event_payload_record(&conn, 4).1, "snappy");
+    drop(conn);
+
+    let second = Command::new(binary())
+        .args(["compact", "--apply"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("rerun jottrace compact --apply");
+    assert!(
+        second.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_stdout = String::from_utf8(second.stdout).expect("compact stdout should be utf-8");
+    assert!(second_stdout.contains("converted_events: 0"));
+    assert!(second_stdout.contains("eligible_raw_events: 0"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn compact_vacuum_reclaims_free_sqlite_pages_after_apply() {
+    let root = temp_root("compact-vacuum");
+    let data_dir = root.join(".jottrace");
+    let payload = compressible_event_line_with_len(256 * 1024).into_bytes();
+    insert_single_raw_compaction_session(&data_dir, &payload);
+
+    let apply = Command::new(binary())
+        .args(["compact", "--apply"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace compact --apply");
+    assert!(
+        apply.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let apply_stdout = String::from_utf8(apply.stdout).expect("compact stdout should be utf-8");
+    assert!(
+        compact_metric(&apply_stdout, "sqlite_reclaimable_bytes") > 0,
+        "{apply_stdout}"
+    );
+
+    let vacuum = Command::new(binary())
+        .args(["compact", "--vacuum"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace compact --vacuum");
+    assert!(
+        vacuum.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&vacuum.stdout),
+        String::from_utf8_lossy(&vacuum.stderr)
+    );
+    let vacuum_stdout = String::from_utf8(vacuum.stdout).expect("compact stdout should be utf-8");
+    assert!(vacuum_stdout.contains("mode: vacuum"));
+    assert!(
+        compact_metric(&vacuum_stdout, "sqlite_reclaimable_bytes_before") > 0,
+        "{vacuum_stdout}"
+    );
+    assert_eq!(
+        compact_metric(&vacuum_stdout, "sqlite_reclaimable_bytes"),
+        0
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn compact_rejects_invalid_batch_options_before_opening_database() {
+    let root = temp_root("compact-invalid-batch");
+    let data_dir = root.join(".jottrace");
+
+    let oversized = Command::new(binary())
+        .args(["compact", "--batch-size", "10001"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace compact with oversized batch");
+    assert!(!oversized.status.success());
+    let stderr = String::from_utf8_lossy(&oversized.stderr);
+    assert!(stderr.contains("invalid batch size: 10001; expected at most 10000"));
+    assert!(stderr.contains("jottrace compact --help"));
+    assert!(
+        !db_path(&data_dir).exists(),
+        "usage errors should not initialize the database"
+    );
+
+    let vacuum_batch = Command::new(binary())
+        .args(["compact", "--vacuum", "--batch-size", "2"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace compact --vacuum with batch size");
+    assert!(!vacuum_batch.status.success());
+    let stderr = String::from_utf8_lossy(&vacuum_batch.stderr);
+    assert!(stderr.contains("compact --vacuum does not accept --batch-size"));
+    assert!(stderr.contains("jottrace compact --help"));
+    assert!(
+        !db_path(&data_dir).exists(),
+        "usage errors should not initialize the database"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn events_prints_decoded_payload_jsonl_for_bounded_session() {
     let root = temp_root("events-session-limit");
     let data_dir = root.join(".jottrace");
@@ -1364,6 +1576,171 @@ fn event_codecs(conn: &Connection) -> Vec<(i64, String)> {
         .expect("query event codecs")
         .map(|row| row.expect("event codec"))
         .collect()
+}
+
+fn compact_metric(stdout: &str, name: &str) -> u64 {
+    let prefix = format!("{name}: ");
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix(&prefix))
+        .unwrap_or_else(|| panic!("missing compact metric {name} in:\n{stdout}"))
+        .parse()
+        .unwrap_or_else(|error| panic!("invalid compact metric {name} in:\n{stdout}\n{error}"))
+}
+
+#[derive(Debug)]
+struct CompactionFixture {
+    eligible_payload: Vec<u8>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct EventIdentity {
+    session_id: i64,
+    generation: i64,
+    seq: i64,
+    ts: Option<String>,
+    created_at: String,
+}
+
+fn insert_compaction_fixture(data_dir: &Path) -> CompactionFixture {
+    let conn = jottrace::storage::open_database(&db_path(data_dir)).expect("open database");
+    conn.execute(
+        "INSERT INTO sessions (source, source_session_id, event_count)
+         VALUES ('claude_cli', 'compact-session', 5)",
+        [],
+    )
+    .expect("insert compact session");
+    let session_id = conn.last_insert_rowid();
+
+    let eligible_payload = large_compressible_event_line().into_bytes();
+    let small_payload = compressible_event_line_with_len(512).into_bytes();
+    let incompressible_payload = deterministic_bytes(2048);
+    let existing_zstd_source = compressible_event_line_with_len(1500).into_bytes();
+    let existing_zstd_payload = zstd::stream::encode_all(&existing_zstd_source[..], 0)
+        .expect("compress existing zstd payload");
+    insert_event_payload(
+        &conn,
+        session_id,
+        0,
+        &eligible_payload,
+        "raw",
+        eligible_payload.len(),
+    );
+    insert_event_payload(
+        &conn,
+        session_id,
+        1,
+        &small_payload,
+        "raw",
+        small_payload.len(),
+    );
+    insert_event_payload(
+        &conn,
+        session_id,
+        2,
+        &incompressible_payload,
+        "raw",
+        incompressible_payload.len(),
+    );
+    insert_event_payload(
+        &conn,
+        session_id,
+        3,
+        &existing_zstd_payload,
+        "zstd",
+        existing_zstd_source.len(),
+    );
+    conn.execute("PRAGMA ignore_check_constraints = ON", [])
+        .expect("allow unsupported codec fixture");
+    let unsupported_payload = br#"{"codec":"snappy"}"#;
+    insert_event_payload(
+        &conn,
+        session_id,
+        4,
+        unsupported_payload,
+        "snappy",
+        unsupported_payload.len(),
+    );
+
+    CompactionFixture { eligible_payload }
+}
+
+fn insert_single_raw_compaction_session(data_dir: &Path, payload: &[u8]) {
+    let conn = jottrace::storage::open_database(&db_path(data_dir)).expect("open database");
+    conn.execute(
+        "INSERT INTO sessions (source, source_session_id, event_count)
+         VALUES ('claude_cli', 'compact-vacuum-session', 1)",
+        [],
+    )
+    .expect("insert compact vacuum session");
+    let session_id = conn.last_insert_rowid();
+    insert_event_payload(&conn, session_id, 0, payload, "raw", payload.len());
+}
+
+fn insert_event_payload(
+    conn: &Connection,
+    session_id: i64,
+    seq: i64,
+    payload: &[u8],
+    codec: &str,
+    payload_size: usize,
+) {
+    conn.execute(
+        "INSERT INTO events (session_id, generation, seq, ts, payload, codec, payload_size)
+         VALUES (?1, 0, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![
+            session_id,
+            seq,
+            format!("2026-05-05T01:00:0{seq}.000Z"),
+            payload,
+            codec,
+            payload_size as i64
+        ],
+    )
+    .expect("insert compact event");
+}
+
+fn event_payload_record(conn: &Connection, seq: i64) -> (Vec<u8>, String, i64) {
+    conn.query_row(
+        "SELECT payload, codec, payload_size
+         FROM events
+         WHERE seq = ?1",
+        [seq],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )
+    .expect("event payload record")
+}
+
+fn event_identity_at_seq(conn: &Connection, seq: i64) -> EventIdentity {
+    conn.query_row(
+        "SELECT session_id, generation, seq, ts, created_at
+         FROM events
+         WHERE seq = ?1",
+        [seq],
+        |row| {
+            Ok(EventIdentity {
+                session_id: row.get(0)?,
+                generation: row.get(1)?,
+                seq: row.get(2)?,
+                ts: row.get(3)?,
+                created_at: row.get(4)?,
+            })
+        },
+    )
+    .expect("event identity")
+}
+
+fn deterministic_bytes(len: usize) -> Vec<u8> {
+    let mut state = 0x1234_5678_9abc_def0_u64;
+    let mut bytes = Vec::with_capacity(len);
+    while bytes.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        bytes.extend_from_slice(&state.to_le_bytes());
+    }
+    bytes.truncate(len);
+    bytes
 }
 
 fn insert_legacy_raw_session(data_dir: &Path, session_file: &Path, line: &str) {


### PR DESCRIPTION
## Summary

Adds an explicit `jottrace compact` command for existing raw event payload rows.

- reports dry-run raw/zstd counts, estimated byte savings, skipped rows, unresolved ingest errors, and SQLite reclaimable space
- supports `--apply` to rewrite only eligible `codec = 'raw'` payloads to zstd in bounded batches after exact decode round-trip validation
- supports `--vacuum` as an explicit follow-up disk reclaim step
- adds a raw-event partial index migration for compaction scans
- covers dry-run, apply, idempotent rerun, mixed codec/skipped rows, exact decode, invalid options, and vacuum reporting

## Validation

- `rtk cargo fmt --check`
- `rtk cargo clippy --all-targets -- -D warnings`
- `rtk cargo test` (75 passed)
- `rtk git diff --check`

Closes #46