### PR TITLE
Add first-class update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ design docs, but are not implemented as user-facing ingest sources yet.
   sessions.
 - Browse preserved sessions, events, and unresolved ingest errors locally with
   `jottrace web`.
+- Update the installed binary from GitHub Releases with `jottrace update`.
 
 ## Install
 
@@ -111,7 +112,23 @@ JOTTRACE_HOME=/path/to/private/journal jottrace web
 
 ## Update
 
-To update Jottrace, rerun the installer:
+To update the installed binary in place:
+
+```sh
+jottrace update
+```
+
+`jottrace upgrade` is supported as an alias. The command downloads the matching
+GitHub Release artifact for your OS and CPU, reports the current version,
+target version, install path, and final result. When a newer artifact is
+available, it replaces only the installed binary. It does not read or mutate
+data under `~/.jottrace`.
+
+For deterministic release testing, `jottrace update` honors the same
+`JOTTRACE_VERSION` and `JOTTRACE_RELEASE_BASE_URL` controls as `install.sh`.
+
+If the update command is unavailable or fails before replacing the binary,
+rerun the installer fallback:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/season179/jottrace/main/install.sh | bash

--- a/docs/design.md
+++ b/docs/design.md
@@ -88,6 +88,8 @@ The first executable surface is intentionally small:
 - `jottrace web` — starts a read-only web UI bound to `127.0.0.1` for browsing
   preserved sessions, events, raw payload previews, and unresolved ingest
   errors from the local SQLite journal.
+- `jottrace update` — downloads the matching GitHub Release artifact and
+  replaces the installed binary without touching the local journal.
 
 Processor, writer, scheduler, and recall commands come later.
 
@@ -119,8 +121,9 @@ Implications:
   `install.sh` UX; it is plumbing, not the user-facing install contract.
 - **The binary must be self-contained.** SQLite is statically linked (e.g.,
   `rusqlite` with the `bundled` feature). No runtime library dependencies.
-- **Update path is "re-run the installer."** No `jottrace update`
-  self-replace command in MVP.
+- **Update path is first-class but installer-compatible.** `jottrace update`
+  uses the same GitHub Release artifact contract as `install.sh`; rerunning
+  the curl installer remains the fallback.
 - **Data dir is separate from binary path.** Binary at
   `~/.local/bin/jottrace`; data at `~/.jottrace/` (DB, single-instance
   lockfile, future config). The two are independent.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,12 @@ use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
 pub mod compact;
 pub mod ingest;
 pub mod storage;
+pub mod update;
 pub mod web;
 pub use compact::{CompactMode, CompactOptions, CompactReport, run_compact};
 pub use ingest::{IngestReport, run_ingest};
 pub use storage::{IngestErrorSummary, StatusReport, run_status};
+pub use update::{UpdateReport, run_update};
 
 /// Default per-user data directory name for the current MVP.
 pub const APP_DIR_NAME: &str = ".jottrace";

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ fn main() -> ExitCode {
         Some("events") => run_events_command(args),
         Some("ingest") => run_ingest_command(),
         Some("status") => run_status_command(),
+        Some("update") | Some("upgrade") => run_update_command(args),
         Some("web") => run_web_command(args),
         Some(command) => {
             eprintln!("unknown command: {command}");
@@ -31,6 +32,12 @@ fn main() -> ExitCode {
             ExitCode::from(2)
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpdateCommand {
+    Run,
+    Help,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -288,6 +295,44 @@ fn run_ingest_command() -> ExitCode {
     }
 }
 
+fn run_update_command(args: impl Iterator<Item = String>) -> ExitCode {
+    match parse_update_command(args) {
+        Ok(UpdateCommand::Help) => {
+            print_update_help();
+            ExitCode::SUCCESS
+        }
+        Ok(UpdateCommand::Run) => match jottrace::run_update() {
+            Ok(report) => {
+                println!("jottrace update");
+                println!("current_version: {}", report.current_version);
+                println!("target_version: {}", report.target_version);
+                println!("install_path: {}", report.install_path.display());
+                println!("result: {}", report.result.as_str());
+                ExitCode::SUCCESS
+            }
+            Err(error) => {
+                eprintln!("jottrace update failed: {error}");
+                ExitCode::FAILURE
+            }
+        },
+        Err(message) => {
+            eprintln!("{message}");
+            eprintln!("run `jottrace update --help` for usage");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn parse_update_command(
+    mut args: impl Iterator<Item = String>,
+) -> std::result::Result<UpdateCommand, String> {
+    match args.next() {
+        None => Ok(UpdateCommand::Run),
+        Some(arg) if arg == "--help" || arg == "-h" => Ok(UpdateCommand::Help),
+        Some(arg) => Err(format!("unknown update option: {arg}")),
+    }
+}
+
 fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
     let options = match parse_compact_command(args) {
         Ok(CompactCommand::Run(options)) => options,
@@ -510,6 +555,8 @@ fn print_help() {
     );
     println!("  jottrace ingest");
     println!("  jottrace status");
+    println!("  jottrace update");
+    println!("  jottrace upgrade");
     println!("  jottrace web [--port <port>] [--once]");
     println!("  jottrace --version");
 }
@@ -541,6 +588,15 @@ fn print_events_help() {
     println!("  --source <source>             Stored source, for example claude_cli");
     println!("  --session <source_session_id>  Stored source session id to inspect");
     println!("  --limit <n>                   Maximum number of events to print");
+}
+
+fn print_update_help() {
+    println!("jottrace update");
+    println!("Replace the installed binary with the matching GitHub Release artifact.");
+    println!();
+    println!("Usage:");
+    println!("  jottrace update");
+    println!("  jottrace upgrade");
 }
 
 fn print_web_help() {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,351 @@
+use std::env;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+const REPO: &str = "season179/jottrace";
+const VERSION_ENV: &str = "JOTTRACE_VERSION";
+const RELEASE_BASE_URL_ENV: &str = "JOTTRACE_RELEASE_BASE_URL";
+const UPDATE_INSTALL_PATH_ENV: &str = "JOTTRACE_UPDATE_INSTALL_PATH";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateReport {
+    pub current_version: String,
+    pub target_version: String,
+    pub install_path: PathBuf,
+    pub result: UpdateResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateResult {
+    Updated,
+    UpToDate,
+}
+
+impl UpdateResult {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Updated => "updated",
+            Self::UpToDate => "up-to-date",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum UpdateError {
+    UnsupportedPlatform {
+        os: String,
+        arch: String,
+    },
+    MissingInstallParent(PathBuf),
+    Io {
+        path: PathBuf,
+        source: io::Error,
+    },
+    CommandIo {
+        program: &'static str,
+        source: io::Error,
+    },
+    CommandFailed {
+        program: &'static str,
+        stderr: String,
+    },
+    InvalidArtifact(String),
+    InvalidVersionOutput {
+        path: PathBuf,
+        stdout: String,
+    },
+}
+
+impl fmt::Display for UpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedPlatform { os, arch } => {
+                write!(f, "unsupported platform {os}/{arch}")
+            }
+            Self::MissingInstallParent(path) => {
+                write!(
+                    f,
+                    "install path has no parent directory: {}",
+                    path.display()
+                )
+            }
+            Self::Io { path, source } => write!(f, "{}: {}", path.display(), source),
+            Self::CommandIo { program, source } => write!(f, "failed to run {program}: {source}"),
+            Self::CommandFailed { program, stderr } => {
+                let stderr = stderr.trim();
+                if stderr.is_empty() {
+                    write!(f, "{program} failed")
+                } else {
+                    write!(f, "{program} failed: {stderr}")
+                }
+            }
+            Self::InvalidArtifact(message) => write!(f, "invalid release artifact: {message}"),
+            Self::InvalidVersionOutput { path, stdout } => write!(
+                f,
+                "{} printed an invalid version: {}",
+                path.display(),
+                stdout.trim()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for UpdateError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::CommandIo { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, UpdateError>;
+
+pub fn run_update() -> Result<UpdateReport> {
+    let target = current_release_target()?;
+    let install_path = install_path()?;
+    let current_version = binary_version(&install_path)?;
+    let version = env_value_or_default(VERSION_ENV, "latest");
+    let artifact_url = release_url(target, &version);
+    let temp_dir = TempDir::new("jottrace-update")?;
+    let archive = temp_dir.path.join("jottrace.tar.gz");
+
+    download_archive(&artifact_url, &archive)?;
+    extract_archive(&archive, &temp_dir.path)?;
+
+    let candidate = temp_dir.path.join("jottrace");
+    let target_version = artifact_binary_version(&candidate)?;
+    let result = if current_version == target_version {
+        UpdateResult::UpToDate
+    } else {
+        replace_installed_binary(&candidate, &install_path)?;
+        UpdateResult::Updated
+    };
+
+    Ok(UpdateReport {
+        current_version,
+        target_version,
+        install_path,
+        result,
+    })
+}
+
+fn current_release_target() -> Result<&'static str> {
+    match (env::consts::OS, env::consts::ARCH) {
+        ("linux", "x86_64") => Ok("linux-x86_64"),
+        ("linux", "aarch64") => Ok("linux-arm64"),
+        ("macos", "aarch64") => Ok("darwin-arm64"),
+        ("macos", "x86_64") => Ok("darwin-x86_64"),
+        (os, arch) => Err(UpdateError::UnsupportedPlatform {
+            os: os.to_string(),
+            arch: arch.to_string(),
+        }),
+    }
+}
+
+fn install_path() -> Result<PathBuf> {
+    if let Some(path) = env::var_os(UPDATE_INSTALL_PATH_ENV) {
+        return Ok(PathBuf::from(path));
+    }
+
+    env::current_exe().map_err(|source| UpdateError::Io {
+        path: PathBuf::from("current executable"),
+        source,
+    })
+}
+
+fn release_url(target: &str, version: &str) -> String {
+    let base_url = env_value(RELEASE_BASE_URL_ENV);
+    release_url_for_base(target, version, base_url.as_deref())
+}
+
+fn release_url_for_base(target: &str, version: &str, base_url: Option<&str>) -> String {
+    let artifact = format!("jottrace-{target}.tar.gz");
+    if let Some(base_url) = base_url.filter(|value| !value.is_empty()) {
+        format!("{}/{version}/{artifact}", base_url.trim_end_matches('/'))
+    } else if version == "latest" {
+        format!("https://github.com/{REPO}/releases/latest/download/{artifact}")
+    } else {
+        format!("https://github.com/{REPO}/releases/download/{version}/{artifact}")
+    }
+}
+
+fn env_value(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn env_value_or_default(name: &str, default: &str) -> String {
+    env_value(name).unwrap_or_else(|| default.to_string())
+}
+
+fn download_archive(url: &str, archive: &Path) -> Result<()> {
+    let mut command = Command::new("curl");
+    command.args(["-fsSL", url, "-o"]).arg(archive);
+    run_checked_command("curl", &mut command).map(|_| ())
+}
+
+fn extract_archive(archive: &Path, destination: &Path) -> Result<()> {
+    let mut command = Command::new("tar");
+    command
+        .arg("-xzf")
+        .arg(archive)
+        .arg("-C")
+        .arg(destination)
+        .arg("jottrace");
+    run_checked_command("tar", &mut command)
+        .map(|_| ())
+        .map_err(|error| match error {
+            UpdateError::CommandFailed { program: "tar", .. } => UpdateError::InvalidArtifact(
+                format!("artifact did not contain a runnable jottrace binary ({error})"),
+            ),
+            error => error,
+        })
+}
+
+fn run_checked_command(program: &'static str, command: &mut Command) -> Result<Output> {
+    let output = command
+        .output()
+        .map_err(|source| UpdateError::CommandIo { program, source })?;
+
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(UpdateError::CommandFailed {
+            program,
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+}
+
+fn binary_version(path: &Path) -> Result<String> {
+    let output = Command::new(path)
+        .arg("--version")
+        .output()
+        .map_err(|source| UpdateError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    if !output.status.success() {
+        return Err(UpdateError::InvalidArtifact(format!(
+            "{} did not run successfully with --version",
+            path.display()
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .trim()
+        .strip_prefix("jottrace ")
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| UpdateError::InvalidVersionOutput {
+            path: path.to_path_buf(),
+            stdout: stdout.into_owned(),
+        })
+}
+
+fn artifact_binary_version(path: &Path) -> Result<String> {
+    binary_version(path).map_err(|error| {
+        UpdateError::InvalidArtifact(format!(
+            "artifact did not contain a runnable jottrace binary ({error})"
+        ))
+    })
+}
+
+fn replace_installed_binary(candidate: &Path, install_path: &Path) -> Result<()> {
+    let parent = install_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| UpdateError::MissingInstallParent(install_path.to_path_buf()))?;
+    let staged = parent.join(format!(
+        ".jottrace-update-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+
+    fs::copy(candidate, &staged).map_err(|source| UpdateError::Io {
+        path: staged.clone(),
+        source,
+    })?;
+
+    #[cfg(unix)]
+    fs::set_permissions(&staged, fs::Permissions::from_mode(0o755)).map_err(|source| {
+        let _ = fs::remove_file(&staged);
+        UpdateError::Io {
+            path: staged.clone(),
+            source,
+        }
+    })?;
+
+    fs::rename(&staged, install_path).map_err(|source| {
+        let _ = fs::remove_file(&staged);
+        UpdateError::Io {
+            path: install_path.to_path_buf(),
+            source,
+        }
+    })
+}
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(prefix: &str) -> Result<Self> {
+        let path = env::temp_dir().join(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        fs::create_dir(&path).map_err(|source| UpdateError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn unique_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_url_uses_github_latest_when_base_url_is_unset_or_empty() {
+        assert_eq!(
+            release_url_for_base("linux-x86_64", "latest", None),
+            "https://github.com/season179/jottrace/releases/latest/download/jottrace-linux-x86_64.tar.gz"
+        );
+        assert_eq!(
+            release_url_for_base("linux-x86_64", "latest", Some("")),
+            "https://github.com/season179/jottrace/releases/latest/download/jottrace-linux-x86_64.tar.gz"
+        );
+    }
+
+    #[test]
+    fn release_url_uses_base_url_when_non_empty() {
+        assert_eq!(
+            release_url_for_base("darwin-arm64", "v26.5.5", Some("file:///tmp/releases/")),
+            "file:///tmp/releases/v26.5.5/jottrace-darwin-arm64.tar.gz"
+        );
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,97 @@
+#![allow(dead_code)]
+
+use std::fs;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 pub fn reader_fixture(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/readers")
         .join(relative)
+}
+
+pub struct TempRoot {
+    path: PathBuf,
+}
+
+impl Deref for TempRoot {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
+    }
+}
+
+impl AsRef<Path> for TempRoot {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempRoot {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+pub fn temp_root(name: &str) -> TempRoot {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    TempRoot {
+        path: std::env::temp_dir().join(format!("jottrace-{name}-{}-{unique}", std::process::id())),
+    }
+}
+
+pub fn current_release_target() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => Some("linux-x86_64"),
+        ("linux", "aarch64") => Some("linux-arm64"),
+        ("macos", "aarch64") => Some("darwin-arm64"),
+        ("macos", "x86_64") => Some("darwin-x86_64"),
+        _ => None,
+    }
+}
+
+pub fn create_release_artifact(
+    root: &Path,
+    releases: &Path,
+    tag: &str,
+    target: &str,
+    version: &str,
+    marker: &str,
+) {
+    let release_dir = releases.join(tag);
+    let payload_dir = root.join(format!("payload-{target}"));
+    fs::create_dir_all(&release_dir).expect("create release dir");
+    fs::create_dir_all(&payload_dir).expect("create payload dir");
+
+    write_fake_binary(&payload_dir.join("jottrace"), version, marker);
+
+    let artifact = release_dir.join(format!("jottrace-{target}.tar.gz"));
+    let tar_status = Command::new("tar")
+        .args(["-C", payload_dir.to_str().expect("utf8 payload path")])
+        .args(["-czf", artifact.to_str().expect("utf8 artifact path")])
+        .arg("jottrace")
+        .status()
+        .expect("create release artifact");
+    assert!(tar_status.success(), "tar should create test artifact");
+}
+
+pub fn write_fake_binary(path: &Path, version: &str, marker: &str) {
+    fs::write(
+        path,
+        format!(
+            "#!/usr/bin/env sh\nif [ \"$1\" = \"--version\" ]; then echo 'jottrace {version}'; else echo '{marker}'; fi\n"
+        ),
+    )
+    .expect("write fake binary");
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod fake binary");
 }

--- a/tests/installer.rs
+++ b/tests/installer.rs
@@ -1,13 +1,15 @@
+mod common;
+
+use common::{create_release_artifact, current_release_target, temp_root};
 use std::fs;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::MetadataExt;
 
 #[test]
 fn installer_downloads_matching_release_artifact_to_local_bin() {
-    let Some(target) = current_installer_target() else {
+    let Some(target) = current_release_target() else {
         eprintln!("skipping installer smoke test on unsupported test host");
         return;
     };
@@ -17,7 +19,14 @@ fn installer_downloads_matching_release_artifact_to_local_bin() {
     let releases = root.join("releases");
     let tag = "vtest";
     fs::create_dir_all(&home).expect("create home");
-    create_release_artifact(&root, &releases, tag, target);
+    create_release_artifact(
+        &root,
+        &releases,
+        tag,
+        target,
+        "26.5.0",
+        "installer test binary",
+    );
 
     let install_dir = home.join(".local/bin");
     let output = Command::new("bash")
@@ -66,7 +75,7 @@ fn installer_downloads_matching_release_artifact_to_local_bin() {
 
 #[test]
 fn installer_prints_path_hint_without_editing_shell_rc_files() {
-    let Some(target) = current_installer_target() else {
+    let Some(target) = current_release_target() else {
         eprintln!("skipping installer hint test on unsupported test host");
         return;
     };
@@ -78,7 +87,14 @@ fn installer_prints_path_hint_without_editing_shell_rc_files() {
     fs::create_dir_all(&home).expect("create home");
     fs::write(home.join(".zshrc"), "# existing zsh config\n").expect("write zshrc");
     fs::write(home.join(".bashrc"), "# existing bash config\n").expect("write bashrc");
-    create_release_artifact(&root, &releases, tag, target);
+    create_release_artifact(
+        &root,
+        &releases,
+        tag,
+        target,
+        "26.5.0",
+        "installer test binary",
+    );
 
     let output = Command::new("bash")
         .arg("install.sh")
@@ -111,53 +127,4 @@ fn installer_prints_path_hint_without_editing_shell_rc_files() {
     );
 
     let _ = fs::remove_dir_all(root);
-}
-
-fn create_release_artifact(
-    root: &std::path::Path,
-    releases: &std::path::Path,
-    tag: &str,
-    target: &str,
-) {
-    let release_dir = releases.join(tag);
-    let payload_dir = root.join(format!("payload-{target}"));
-    fs::create_dir_all(&release_dir).expect("create release dir");
-    fs::create_dir_all(&payload_dir).expect("create payload dir");
-
-    let fake_binary = payload_dir.join("jottrace");
-    fs::write(
-        &fake_binary,
-        "#!/usr/bin/env sh\nif [ \"$1\" = \"--version\" ]; then echo 'jottrace 26.5.0'; else exit 64; fi\n",
-    )
-    .expect("write fake binary");
-    #[cfg(unix)]
-    fs::set_permissions(&fake_binary, fs::Permissions::from_mode(0o755))
-        .expect("chmod fake binary");
-
-    let artifact = release_dir.join(format!("jottrace-{target}.tar.gz"));
-    let tar_status = Command::new("tar")
-        .args(["-C", payload_dir.to_str().expect("utf8 payload path")])
-        .args(["-czf", artifact.to_str().expect("utf8 artifact path")])
-        .arg("jottrace")
-        .status()
-        .expect("create release artifact");
-    assert!(tar_status.success(), "tar should create test artifact");
-}
-
-fn current_installer_target() -> Option<&'static str> {
-    match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("linux", "x86_64") => Some("linux-x86_64"),
-        ("linux", "aarch64") => Some("linux-arm64"),
-        ("macos", "aarch64") => Some("darwin-arm64"),
-        ("macos", "x86_64") => Some("darwin-x86_64"),
-        _ => None,
-    }
-}
-
-fn temp_root(name: &str) -> std::path::PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("clock")
-        .as_nanos();
-    std::env::temp_dir().join(format!("jottrace-{name}-{}-{unique}", std::process::id()))
 }

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -1,0 +1,341 @@
+mod common;
+
+use common::{create_release_artifact, current_release_target, temp_root, write_fake_binary};
+use std::fs;
+use std::process::Command;
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+#[test]
+fn update_replaces_installed_binary_from_release_artifact() {
+    let Some(target) = current_release_target() else {
+        eprintln!("skipping update test on unsupported test host");
+        return;
+    };
+
+    let root = temp_root("update-success");
+    let releases = root.join("releases");
+    let install_dir = root.join("bin");
+    let installed = install_dir.join("jottrace");
+    let data_dir = root.join(".jottrace");
+    let data_sentinel = data_dir.join("db.sqlite");
+    let tag = "v26.5.5";
+
+    fs::create_dir_all(&install_dir).expect("create install dir");
+    fs::create_dir_all(&data_dir).expect("create data dir");
+    fs::write(&data_sentinel, "preserved journal data").expect("write data sentinel");
+    write_fake_binary(&installed, "26.5.3", "old binary");
+    create_release_artifact(&root, &releases, tag, target, "26.5.5", "updated binary");
+
+    let output = Command::new(binary())
+        .arg("update")
+        .env("JOTTRACE_UPDATE_INSTALL_PATH", &installed)
+        .env("JOTTRACE_VERSION", tag)
+        .env(
+            "JOTTRACE_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace update");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("jottrace update"));
+    assert!(stdout.contains("current_version: 26.5.3"));
+    assert!(stdout.contains("target_version: 26.5.5"));
+    assert!(stdout.contains(&format!("install_path: {}", installed.display())));
+    assert!(stdout.contains("result: updated"));
+
+    let version = Command::new(&installed)
+        .arg("--version")
+        .output()
+        .expect("run updated jottrace");
+    assert!(version.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).trim(),
+        "jottrace 26.5.5"
+    );
+
+    assert_eq!(
+        fs::read_to_string(&data_sentinel).expect("read data sentinel"),
+        "preserved journal data"
+    );
+
+    #[cfg(unix)]
+    assert_ne!(
+        fs::metadata(&installed).expect("installed metadata").mode() & 0o111,
+        0,
+        "updated jottrace should be executable"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn update_reports_up_to_date_without_replacing_installed_binary() {
+    let Some(target) = current_release_target() else {
+        eprintln!("skipping up-to-date update test on unsupported test host");
+        return;
+    };
+
+    let root = temp_root("update-up-to-date");
+    let releases = root.join("releases");
+    let install_dir = root.join("bin");
+    let installed = install_dir.join("jottrace");
+    let tag = "v26.5.5";
+
+    fs::create_dir_all(&install_dir).expect("create install dir");
+    write_fake_binary(&installed, "26.5.5", "old binary");
+    let before = fs::read_to_string(&installed).expect("read installed binary before update");
+    create_release_artifact(&root, &releases, tag, target, "26.5.5", "new binary");
+
+    let output = Command::new(binary())
+        .arg("update")
+        .env("JOTTRACE_UPDATE_INSTALL_PATH", &installed)
+        .env("JOTTRACE_VERSION", tag)
+        .env(
+            "JOTTRACE_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .output()
+        .expect("run jottrace update for current version");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("current_version: 26.5.5"));
+    assert!(stdout.contains("target_version: 26.5.5"));
+    assert!(stdout.contains("result: up-to-date"));
+    assert_eq!(
+        fs::read_to_string(&installed).expect("read installed binary after update"),
+        before
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn empty_version_env_uses_latest_release_artifact() {
+    let Some(target) = current_release_target() else {
+        eprintln!("skipping empty version update test on unsupported test host");
+        return;
+    };
+
+    let root = temp_root("update-empty-version");
+    let releases = root.join("releases");
+    let install_dir = root.join("bin");
+    let installed = install_dir.join("jottrace");
+
+    fs::create_dir_all(&install_dir).expect("create install dir");
+    write_fake_binary(&installed, "26.5.3", "old binary");
+    create_release_artifact(
+        &root,
+        &releases,
+        "latest",
+        target,
+        "26.5.5",
+        "latest binary",
+    );
+
+    let output = Command::new(binary())
+        .arg("update")
+        .env("JOTTRACE_UPDATE_INSTALL_PATH", &installed)
+        .env("JOTTRACE_VERSION", "")
+        .env(
+            "JOTTRACE_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .output()
+        .expect("run jottrace update with empty version env");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("target_version: 26.5.5"));
+    assert!(stdout.contains("result: updated"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn failed_update_leaves_installed_binary_usable() {
+    let Some(_target) = current_release_target() else {
+        eprintln!("skipping update failure test on unsupported test host");
+        return;
+    };
+
+    let root = temp_root("update-failed-download");
+    let releases = root.join("releases");
+    let install_dir = root.join("bin");
+    let installed = install_dir.join("jottrace");
+
+    fs::create_dir_all(&install_dir).expect("create install dir");
+    fs::create_dir_all(&releases).expect("create empty releases dir");
+    write_fake_binary(&installed, "26.5.3", "old binary");
+
+    let output = Command::new(binary())
+        .arg("update")
+        .env("JOTTRACE_UPDATE_INSTALL_PATH", &installed)
+        .env("JOTTRACE_VERSION", "vmissing")
+        .env(
+            "JOTTRACE_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .output()
+        .expect("run jottrace update with missing artifact");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("jottrace update failed"));
+
+    let version = Command::new(&installed)
+        .arg("--version")
+        .output()
+        .expect("run preserved jottrace");
+    assert!(version.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).trim(),
+        "jottrace 26.5.3"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn invalid_update_artifact_leaves_installed_binary_usable() {
+    let Some(target) = current_release_target() else {
+        eprintln!("skipping invalid update artifact test on unsupported test host");
+        return;
+    };
+
+    let root = temp_root("update-invalid-artifact");
+    let releases = root.join("releases");
+    let install_dir = root.join("bin");
+    let installed = install_dir.join("jottrace");
+    let tag = "vbad";
+
+    fs::create_dir_all(&install_dir).expect("create install dir");
+    write_fake_binary(&installed, "26.5.3", "old binary");
+    create_invalid_release_artifact(&root, &releases, tag, target);
+
+    let output = Command::new(binary())
+        .arg("update")
+        .env("JOTTRACE_UPDATE_INSTALL_PATH", &installed)
+        .env("JOTTRACE_VERSION", tag)
+        .env(
+            "JOTTRACE_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .output()
+        .expect("run jottrace update with invalid artifact");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("jottrace update failed"));
+    assert!(stderr.contains("invalid release artifact"));
+
+    let version = Command::new(&installed)
+        .arg("--version")
+        .output()
+        .expect("run preserved jottrace");
+    assert!(version.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).trim(),
+        "jottrace 26.5.3"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn upgrade_is_an_update_alias() {
+    let Some(target) = current_release_target() else {
+        eprintln!("skipping upgrade alias test on unsupported test host");
+        return;
+    };
+
+    let root = temp_root("upgrade-alias");
+    let releases = root.join("releases");
+    let install_dir = root.join("bin");
+    let installed = install_dir.join("jottrace");
+    let tag = "v26.5.6";
+
+    fs::create_dir_all(&install_dir).expect("create install dir");
+    write_fake_binary(&installed, "26.5.4", "old binary");
+    create_release_artifact(&root, &releases, tag, target, "26.5.6", "upgraded binary");
+
+    let output = Command::new(binary())
+        .arg("upgrade")
+        .env("JOTTRACE_UPDATE_INSTALL_PATH", &installed)
+        .env("JOTTRACE_VERSION", tag)
+        .env(
+            "JOTTRACE_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .output()
+        .expect("run jottrace upgrade");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let version = Command::new(&installed)
+        .arg("--version")
+        .output()
+        .expect("run upgraded jottrace");
+    assert!(version.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).trim(),
+        "jottrace 26.5.6"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+fn create_invalid_release_artifact(
+    root: &std::path::Path,
+    releases: &std::path::Path,
+    tag: &str,
+    target: &str,
+) {
+    let release_dir = releases.join(tag);
+    let payload_dir = root.join(format!("invalid-payload-{target}"));
+    fs::create_dir_all(&release_dir).expect("create release dir");
+    fs::create_dir_all(&payload_dir).expect("create payload dir");
+    fs::write(payload_dir.join("not-jottrace"), "not the binary").expect("write invalid payload");
+
+    let artifact = release_dir.join(format!("jottrace-{target}.tar.gz"));
+    let tar_status = Command::new("tar")
+        .args(["-C", payload_dir.to_str().expect("utf8 payload path")])
+        .args(["-czf", artifact.to_str().expect("utf8 artifact path")])
+        .arg("not-jottrace")
+        .status()
+        .expect("create invalid release artifact");
+    assert!(
+        tar_status.success(),
+        "tar should create invalid test artifact"
+    );
+}
+
+fn binary() -> &'static str {
+    env!("CARGO_BIN_EXE_jottrace")
+}


### PR DESCRIPTION
## Summary

- add `jottrace update` and `jottrace upgrade` for installer-compatible binary updates
- validate downloaded release artifacts before replacing the installed binary
- keep failed or invalid updates from breaking the existing binary
- document the update command and keep installer fallback guidance

Closes #41

## Validation

- `rtk cargo fmt --check`
- `rtk cargo clippy --all-targets -- -D warnings`
- `rtk cargo test`
- `rtk git diff --check`