### PR TITLE
[codex] Document reader fixture gate

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,7 +1,7 @@
 ---
 title: "Jottrace architecture"
 status: DRAFT
-updated: 2026-05-05
+updated: 2026-05-06
 repo: github.com/season179/jottrace
 ---
 
@@ -60,9 +60,9 @@ triggers the others.
 4. **Scheduler** — orchestrates reader, processor, and writer runs.
 
 The Claude CLI reader is the first one to ship. Codex CLI follows
-immediately after. Cursor and OpenCode are designed at stub level so the
-schema decisions they expose (in-place SQLite edits, JSON-file iteration
-order) are not surprises later.
+immediately after. Cursor, OpenCode, and other local-agent stores are tracked
+at inventory level so the schema decisions they expose (in-place SQLite edits,
+JSON-file iteration order, parent/child linkage) are not surprises later.
 
 ## Implementation
 
@@ -198,6 +198,11 @@ Readers do **not** interpret content. They preserve raw source events plus
 cheap deterministic metadata. Anything that requires meaning extraction
 (topics, decisions, dead ends, summaries) is processor work. The reader stays
 dumb on purpose.
+
+New local coding-agent sources must pass the reader fixture gate before they
+enter implementation scope. The current source inventory, deferred-source
+rules, and fixture privacy requirements live in
+`docs/reader-source-inventory.md`.
 
 ### Shared JSONL ingest core
 
@@ -514,38 +519,44 @@ aren't visible from this distance. Goal of including it here: validate
 that the events-table schema and the reader contract handle a non-JSONL
 source without modification.
 
-## Reader: OpenCode (JSON-files shape, designed stub)
+## Reader: OpenCode (SQLite shape, inventory candidate)
 
 ### Source
 
-- macOS CLI: `~/Library/Application Support/opencode/storage/`
-- Linux CLI: `~/.local/share/opencode/storage/`
-- Desktop variants: same parent directory but `ai.opencode.app` instead
-  of `opencode`.
-- Storage format is a directory tree of JSON files (not JSONL). Each
-  session is a subdirectory containing separate files for sessions,
-  messages, and parts, plus Tauri `.dat` files for the desktop variant.
-- Sessions can have parent/child relationships (similar to Claude CLI's
-  subagent sidechains, but folded into the storage tree shape rather
-  than expressed via filenames). The shared `parent_session_id` column
-  on `sessions` carries the link.
+- CLI/XDG path observed on this machine:
+  `~/.local/share/opencode/opencode.db`
+- This machine also has a coexisting JSON storage tree at
+  `~/.local/share/opencode/storage/{session,message,part,project,session_diff}/`.
+- SQLite appears to be the complete current store in the 2026-05-06
+  metadata-only check. The observed database has `session`, `message`, `part`,
+  `session_entry`, `project`, `workspace`, `event`, and `event_sequence`
+  tables; local counts were 62 sessions, 766 messages, and 3,325 parts.
+- The JSON storage tree exists and is source-shaped, but it should stay out of
+  reader scope until sanitized fixtures prove whether it is authoritative,
+  mirrored legacy data, or cache/reference material.
+- Parent/child session relationships live on `session.parent_id`; this machine
+  had 14 parent-linked OpenCode sessions in the metadata check. The shared
+  `parent_session_id` column on Jottrace `sessions` carries the link once a
+  fixture proves the deterministic derivation.
 
 ### Change-detection
 
-Per-file `mtime` over the session's subdirectory is the cheap signal.
-The reader can compute it directly on the relevant subdirectory rather
-than scanning the entire tree.
+SQLite databases can be edited in place, so file metadata is not enough. Use a
+per-session content hash, reliable updated timestamp, or last-seen row strategy
+once fixtures settle the table contract.
 
 ### Ordering key
 
-`seq` is the iteration order over the session's message/part files,
-sorted by some stable key (filename, creation order, or an explicit
-sequence field in the JSON). To be confirmed against a real fixture.
+`seq` derives from `message`, `part`, or `event` ordering. Candidate keys are
+`message.time_created` plus `message.id`, `part.message_id` plus `part.id`, or
+`event.seq` if the source starts populating that event-sourcing table. The
+choice must be stable across re-reads.
 
 ### Status
 
-Designed-stub. Full implementation needs a real fixture to settle the
-file-iteration order question and the parent/child session linkage.
+Inventory candidate. Full implementation needs a sanitized fixture to settle
+whether the SQLite DB or JSON storage tree is authoritative, plus the session
+id, event ordering key, parent/child linkage, and in-place update detection.
 
 ## Other readers (named, not designed)
 
@@ -554,7 +565,7 @@ readers" claim is honest. Each will get its own designed section when
 the user starts using that source or when implementation begins.
 
 - **Continue.** JSON files at `~/.continue/sessions/`. One file per
-  session. Similar to OpenCode's shape, simpler.
+  session. Similar to the JSON-file reader shape, simpler.
 - **Gemini CLI.** JSON files at `~/.gemini/tmp/<hash>/chats/`.
   Workspace-bucketed by hash. Includes "thoughts" (reasoning steps with
   timestamps) alongside conversation.

--- a/docs/reader-source-inventory.md
+++ b/docs/reader-source-inventory.md
@@ -1,0 +1,86 @@
+---
+title: "Reader source inventory"
+status: DRAFT
+updated: 2026-05-06
+parent_issue: "#54"
+issue: "#59"
+---
+
+# Reader Source Inventory
+
+This note is the gate before Jottrace adds another local coding-agent
+reader. Source discovery is not enough. A source enters reader scope only
+when sanitized fixture review proves it has an intelligible ordered
+session/event stream that can be preserved without writing to the source.
+
+## Reader Fixture Gate
+
+A discovered file, database, cache, or app-state key is reader-scope only
+when sanitized fixtures confirm all of the following:
+
+- Stable `source_session_id`, or a deterministic equivalent that stays stable
+  across repeated reads of the same source artifact.
+- Ordered messages/events with enough timestamp, sequence, row id, line
+  number, array order, or parent chain data to produce deterministic `seq`.
+- Raw role/content/tool/reasoning/result payloads, or equivalent source events
+  worth preserving losslessly.
+- Enough metadata for read-only change detection, so the reader can avoid
+  mutating source files while still detecting append, rewrite, or in-place
+  update cases.
+
+Sources that fail this gate stay out of implementation issues until fixture
+review proves otherwise.
+
+## Known Source Inventory
+
+| Source | Path shape | Storage format | Stable session identity | Ordering strategy | Parent/child linkage | Change-detection questions |
+| --- | --- | --- | --- | --- | --- | --- |
+| Claude CLI / Claude Code | `~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`, alternate Claude install roots with the same `projects/` shape, plus legacy flat UUID JSONL files | JSONL, one event per line | Filename UUID for normal sessions; parent-qualified `<parent-session-uuid>/subagents/agent-<id>` for sidechains | JSONL line number per generation | Subagent sidechains live under `<parent-session-uuid>/subagents/`; link to parent session when the parent row exists | Existing JSONL generation logic applies: file size, mtime, fingerprint, next read offset, truncation, and same-size rewrite handling |
+| Claude Desktop / local agent mode | `~/Library/Application Support/Claude/local-agent-mode-sessions/` with session metadata JSON and `audit.jsonl` files | Metadata JSON plus ordered audit JSONL | Fixture must confirm whether `session_id` or metadata UUID is canonical | Audit JSONL line order, with timestamps as metadata | Unknown until sanitized fixture review | Confirm whether metadata and audit files update append-only or can rewrite in place |
+| Codex CLI | `~/.codex/sessions/YYYY/MM/DD/*.jsonl`, `~/.codex/archived_sessions/*.jsonl`, and same shapes under alternate Codex roots | JSONL rollout files | `session_meta.payload.id`, not filename | JSONL line number per generation | No separate sidechain file shape observed | Existing JSONL generation logic applies; file moves from `sessions/` to `archived_sessions/` should update `file_path` without duplicating the session |
+| Hermes native SessionDB | `~/.hermes/state.db` | SQLite | Session table primary key, exact column to confirm from fixture schema | Message table row id, created timestamp, or explicit sequence column if present | Schema includes sessions and messages; parent/thread linkage must be confirmed from fixtures | In-place SQLite updates need per-session content hash, message updated timestamp, or last-seen row strategy |
+| Pi agent | `~/.pi/agent/sessions/*.jsonl` | JSONL session files | Session event id or filename, to confirm from fixture | JSONL line number, with parent ids available on message events | Message parent ids exist; decide whether they are event-chain metadata or first-class session linkage | Confirm append-only behavior and whether same-size rewrites occur |
+| Factory / Droid-style agent sessions | `~/.factory/sessions/*.jsonl` plus matching `.settings.json` files | JSONL plus per-session settings JSON | Session start id or filename, to confirm from fixture | JSONL line number; message/todo/compaction events carry timestamps | Parent ids may exist inside message payloads; first-class linkage not yet proven | Confirm whether encrypted OpenAI payload fields are useful to preserve as opaque raw events and whether settings changes should affect change detection |
+| OpenCode | `~/.local/share/opencode/opencode.db`, with a coexisting `~/.local/share/opencode/storage/{session,message,part,project,session_diff}/` JSON tree on this machine | SQLite appears to be the complete current store in the 2026-05-06 metadata check; JSON storage exists but needs fixture proof before reader scope | `session.id`, with `ses_*` ids visible in JSON storage paths to cross-check by fixture | `message.time_created` + `message.id`, `part.message_id` + `part.id`, or `event.seq` if populated by the source | `session.parent_id` exists; this machine had 14 parent-linked sessions in the metadata check | In-place SQLite updates need per-session content hash or reliable `time_updated`; JSON storage would need file metadata plus content fingerprint if a fixture proves it is authoritative |
+| Gemini CLI | `~/.gemini/tmp/<project-or-hash>/chats/*.json` plus `logs.json` sidecars | JSON session files with ordered `messages[]` | `sessionId` inside chat JSON | Array order within `messages[]`, with timestamps as metadata | No first-class child session shape confirmed | Whole-file JSON change detection needs file metadata plus content fingerprint; sidecar logs are reference material unless fixture review proves they add transcript events |
+
+This inventory is metadata-only until each source has a sanitized fixture set
+reviewed by a human. The existing Claude CLI and Codex CLI fixtures are the
+only committed fixture baseline today.
+
+## Deferred And Ignored Sources
+
+Ignore by default, or hold until a sanitized fixture proves intelligible
+ordered session content:
+
+- Browser and Electron `Session Storage`, browser profile data, app caches,
+  extension state, opaque state, protobuf/app-state blobs, and MCP/plugin
+  sidecar logs.
+- Thin command histories, startup logs, auth/model selection histories, and
+  other files that do not preserve meaningful coding-session content.
+- VS Code, Copilot, ChatGPT extension, Windsurf, Antigravity, Claude app
+  browser storage, Codex app browser storage, Claude CLI node caches, and
+  skills-manager state until fixture review can distinguish user, assistant,
+  tool, and result events from generic app state.
+- Manual backup/reference copies such as `~/Downloads/CodexSessionBackup-*`;
+  they may seed fixtures but are not automatic scan roots.
+
+## Fixture Requirements And Privacy
+
+Future source-reader issues must include sanitized fixtures before
+implementation. Fixtures must:
+
+- Preserve source shape, ordering cues, and metadata fields needed for stable
+  ids, deterministic `seq`, parent/child linkage, and read-only change
+  detection.
+- Replace real prompts, tool outputs, reasoning, project names, usernames,
+  repository owners, private paths, process ids, session ids, credentials, and
+  token-like values.
+- Use fixture-only paths such as `/Users/fixture/Workspace/jottrace`.
+- Keep encrypted, opaque, or binary payloads as short placeholders unless the
+  source exposes a safe textual shape that matters to preservation.
+- Receive human review before they become the baseline for reader tests.
+
+No reader issue should commit raw private transcripts, credentials,
+proprietary project text, browser profile contents, or unsanitized local
+paths.

--- a/tests/fixture_corpus.rs
+++ b/tests/fixture_corpus.rs
@@ -5,6 +5,86 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 #[test]
+fn reader_source_inventory_documents_fixture_gate() {
+    let inventory = reader_source_inventory();
+
+    for required in [
+        "## Reader Fixture Gate",
+        "Stable `source_session_id`",
+        "deterministic `seq`",
+        "Raw role/content/tool/reasoning/result payloads",
+        "read-only change detection",
+    ] {
+        assert!(
+            inventory.contains(required),
+            "inventory note should document fixture gate requirement: {required}"
+        );
+    }
+}
+
+#[test]
+fn architecture_links_reader_source_inventory_gate() {
+    let design = fs::read_to_string("docs/design.md").expect("read architecture design doc");
+
+    assert!(
+        design.contains("docs/reader-source-inventory.md"),
+        "architecture doc should link to the reader source inventory gate"
+    );
+}
+
+#[test]
+fn reader_source_inventory_documents_known_sources_in_inventory_table() {
+    let inventory = reader_source_inventory();
+    let table = inventory
+        .split("## Known Source Inventory")
+        .nth(1)
+        .and_then(|tail| tail.split("## Deferred And Ignored Sources").next())
+        .expect("reader source inventory note should contain a known source inventory section");
+
+    for source in [
+        "Claude CLI / Claude Code",
+        "Claude Desktop / local agent mode",
+        "Codex CLI",
+        "Hermes native SessionDB",
+        "Pi agent",
+        "Factory / Droid-style agent sessions",
+        "OpenCode",
+        "Gemini CLI",
+    ] {
+        assert!(
+            table.contains(source),
+            "known source inventory table should document source: {source}"
+        );
+    }
+}
+
+#[test]
+fn reader_source_inventory_documents_deferred_and_privacy_boundaries() {
+    let inventory = reader_source_inventory();
+
+    for required in [
+        "## Deferred And Ignored Sources",
+        "Browser and Electron `Session Storage`",
+        "app caches",
+        "opaque state",
+        "Thin command histories",
+        "## Fixture Requirements And Privacy",
+        "human review",
+        "No reader issue should commit raw private transcripts",
+    ] {
+        assert!(
+            inventory.contains(required),
+            "inventory note should document source boundary or privacy requirement: {required}"
+        );
+    }
+}
+
+fn reader_source_inventory() -> String {
+    fs::read_to_string("docs/reader-source-inventory.md")
+        .expect("reader source inventory design note should exist")
+}
+
+#[test]
 fn reader_fixture_corpus_has_issue_21_required_shapes() {
     for path in [
         "claude-cli/projects/-Users-fixture-Workspace-jottrace/00000000-0000-4000-8000-000000000021.jsonl",


### PR DESCRIPTION
## Summary

- Add a reader source inventory note that defines the fixture gate before new local coding-agent sources enter reader scope.
- Document known source shapes, deferred/ignored source classes, and fixture privacy requirements for future reader work.
- Update the architecture doc with machine-checked OpenCode storage facts and add doc-facing tests that keep the gate discoverable.

## Validation

- `rtk cargo test`
- `rtk cargo fmt --check`
- `rtk git diff --check`

Closes #59