### PR TITLE
Make CLI help discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,16 @@ download step.
 After installing, run:
 
 ```sh
+jottrace -h
 jottrace --version
 jottrace doctor
 jottrace ingest
 jottrace status
 jottrace web
 ```
+
+`jottrace -h` is the fastest CLI discovery path. It prints the top-level
+commands and points to `jottrace <command> --help` for command-specific usage.
 
 `jottrace doctor` creates or checks the local data directory at `~/.jottrace`
 and reports whether its permissions are private. On Unix systems, the directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,10 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Some("compact") => run_compact_command(args),
-        Some("doctor") => run_doctor_command(),
+        Some("doctor") => run_doctor_command(args),
         Some("events") => run_events_command(args),
-        Some("ingest") => run_ingest_command(),
-        Some("status") => run_status_command(),
+        Some("ingest") => run_ingest_command(args),
+        Some("status") => run_status_command(args),
         Some("update") | Some("upgrade") => run_update_command(args),
         Some("web") => run_web_command(args),
         Some(command) => {
@@ -32,12 +32,6 @@ fn main() -> ExitCode {
             ExitCode::from(2)
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum UpdateCommand {
-    Run,
-    Help,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -74,6 +68,12 @@ enum WebCommand {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CompactCommand {
     Run(jottrace::CompactOptions),
+    Help,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SimpleCommand {
+    Run,
     Help,
 }
 
@@ -273,7 +273,20 @@ fn parse_web_command(
     Ok(WebCommand::Run(options))
 }
 
-fn run_ingest_command() -> ExitCode {
+fn run_ingest_command(args: impl Iterator<Item = String>) -> ExitCode {
+    match parse_simple_command("ingest", args) {
+        Ok(SimpleCommand::Help) => {
+            print_ingest_help();
+            return ExitCode::SUCCESS;
+        }
+        Ok(SimpleCommand::Run) => {}
+        Err(message) => {
+            eprintln!("{message}");
+            eprintln!("run `jottrace ingest --help` for usage");
+            return ExitCode::from(2);
+        }
+    }
+
     match jottrace::run_ingest() {
         Ok(report) => {
             println!("jottrace ingest");
@@ -295,13 +308,24 @@ fn run_ingest_command() -> ExitCode {
     }
 }
 
+fn parse_simple_command(
+    command: &str,
+    mut args: impl Iterator<Item = String>,
+) -> std::result::Result<SimpleCommand, String> {
+    match args.next() {
+        None => Ok(SimpleCommand::Run),
+        Some(arg) if arg == "--help" || arg == "-h" => Ok(SimpleCommand::Help),
+        Some(arg) => Err(format!("unknown {command} option: {arg}")),
+    }
+}
+
 fn run_update_command(args: impl Iterator<Item = String>) -> ExitCode {
-    match parse_update_command(args) {
-        Ok(UpdateCommand::Help) => {
+    match parse_simple_command("update", args) {
+        Ok(SimpleCommand::Help) => {
             print_update_help();
             ExitCode::SUCCESS
         }
-        Ok(UpdateCommand::Run) => match jottrace::run_update() {
+        Ok(SimpleCommand::Run) => match jottrace::run_update() {
             Ok(report) => {
                 println!("jottrace update");
                 println!("current_version: {}", report.current_version);
@@ -320,16 +344,6 @@ fn run_update_command(args: impl Iterator<Item = String>) -> ExitCode {
             eprintln!("run `jottrace update --help` for usage");
             ExitCode::from(2)
         }
-    }
-}
-
-fn parse_update_command(
-    mut args: impl Iterator<Item = String>,
-) -> std::result::Result<UpdateCommand, String> {
-    match args.next() {
-        None => Ok(UpdateCommand::Run),
-        Some(arg) if arg == "--help" || arg == "-h" => Ok(UpdateCommand::Help),
-        Some(arg) => Err(format!("unknown update option: {arg}")),
     }
 }
 
@@ -471,7 +485,20 @@ fn compact_mode_name(mode: jottrace::CompactMode) -> &'static str {
     }
 }
 
-fn run_doctor_command() -> ExitCode {
+fn run_doctor_command(args: impl Iterator<Item = String>) -> ExitCode {
+    match parse_simple_command("doctor", args) {
+        Ok(SimpleCommand::Help) => {
+            print_doctor_help();
+            return ExitCode::SUCCESS;
+        }
+        Ok(SimpleCommand::Run) => {}
+        Err(message) => {
+            eprintln!("{message}");
+            eprintln!("run `jottrace doctor --help` for usage");
+            return ExitCode::from(2);
+        }
+    }
+
     // Keep the CLI responsible for presentation while the library owns the
     // filesystem checks. That makes future commands easier to test directly.
     match jottrace::run_doctor() {
@@ -520,7 +547,20 @@ fn run_doctor_command() -> ExitCode {
     }
 }
 
-fn run_status_command() -> ExitCode {
+fn run_status_command(args: impl Iterator<Item = String>) -> ExitCode {
+    match parse_simple_command("status", args) {
+        Ok(SimpleCommand::Help) => {
+            print_status_help();
+            return ExitCode::SUCCESS;
+        }
+        Ok(SimpleCommand::Run) => {}
+        Err(message) => {
+            eprintln!("{message}");
+            eprintln!("run `jottrace status --help` for usage");
+            return ExitCode::from(2);
+        }
+    }
+
     match jottrace::run_status() {
         Ok(report) => {
             println!("jottrace status");
@@ -559,6 +599,7 @@ fn print_help() {
     println!("  jottrace upgrade");
     println!("  jottrace web [--port <port>] [--once]");
     println!("  jottrace --version");
+    println!("  jottrace <command> --help");
 }
 
 fn print_compact_help() {
@@ -588,6 +629,30 @@ fn print_events_help() {
     println!("  --source <source>             Stored source, for example claude_cli");
     println!("  --session <source_session_id>  Stored source session id to inspect");
     println!("  --limit <n>                   Maximum number of events to print");
+}
+
+fn print_doctor_help() {
+    println!("jottrace doctor");
+    println!("Check the journal directory, database, permissions, and ingest errors.");
+    println!();
+    println!("Usage:");
+    println!("  jottrace doctor");
+}
+
+fn print_ingest_help() {
+    println!("jottrace ingest");
+    println!("Preserve Claude and Codex JSONL sessions into the local journal.");
+    println!();
+    println!("Usage:");
+    println!("  jottrace ingest");
+}
+
+fn print_status_help() {
+    println!("jottrace status");
+    println!("Print journal schema, session, event, and ingest-error counts.");
+    println!();
+    println!("Usage:");
+    println!("  jottrace status");
 }
 
 fn print_update_help() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -44,6 +44,154 @@ fn version_prints_package_version() {
 }
 
 #[test]
+fn top_level_help_aliases_print_the_same_usage() {
+    let long = Command::new(binary())
+        .arg("--help")
+        .output()
+        .expect("run jottrace --help");
+    let short = Command::new(binary())
+        .arg("-h")
+        .output()
+        .expect("run jottrace -h");
+
+    assert!(long.status.success());
+    assert!(short.status.success());
+    assert!(long.stderr.is_empty());
+    assert!(short.stderr.is_empty());
+    assert_eq!(long.stdout, short.stdout);
+
+    let stdout = String::from_utf8_lossy(&long.stdout);
+    assert!(stdout.contains("Usage:"));
+    assert!(stdout.contains("jottrace doctor"));
+    assert!(stdout.contains("jottrace web [--port <port>] [--once]"));
+    assert!(stdout.contains("jottrace <command> --help"));
+}
+
+#[test]
+fn doctor_help_aliases_print_command_help_without_initializing_database() {
+    let root = temp_root("doctor-help");
+    let data_dir = root.join(".jottrace");
+
+    for help_arg in ["-h", "--help"] {
+        let output = Command::new(binary())
+            .args(["doctor", help_arg])
+            .env("JOTTRACE_HOME", &data_dir)
+            .output()
+            .expect("run jottrace doctor help");
+
+        assert!(
+            output.status.success(),
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("jottrace doctor"));
+        assert!(stdout.contains("Usage:"));
+        assert!(stdout.contains("Check the journal directory"));
+        assert!(
+            !db_path(&data_dir).exists(),
+            "help should not initialize the local database"
+        );
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn subcommand_help_aliases_print_command_specific_usage() {
+    let cases = [
+        ("doctor", "Check the journal directory"),
+        ("ingest", "Preserve Claude and Codex JSONL sessions"),
+        ("status", "Print journal schema"),
+        ("compact", "--batch-size <n>"),
+        ("events", "--source <source>"),
+        ("web", "--port <port>"),
+    ];
+
+    for (command, expected_detail) in cases {
+        let long = Command::new(binary())
+            .args([command, "--help"])
+            .output()
+            .unwrap_or_else(|error| panic!("run jottrace {command} --help: {error}"));
+        let short = Command::new(binary())
+            .args([command, "-h"])
+            .output()
+            .unwrap_or_else(|error| panic!("run jottrace {command} -h: {error}"));
+
+        assert!(
+            long.status.success(),
+            "{command} --help stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&long.stdout),
+            String::from_utf8_lossy(&long.stderr)
+        );
+        assert!(
+            short.status.success(),
+            "{command} -h stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&short.stdout),
+            String::from_utf8_lossy(&short.stderr)
+        );
+        assert_eq!(
+            long.stdout, short.stdout,
+            "{command} help aliases should match"
+        );
+        assert!(long.stderr.is_empty(), "{command} help should not warn");
+
+        let stdout = String::from_utf8_lossy(&long.stdout);
+        assert!(stdout.contains(&format!("jottrace {command}")));
+        assert!(stdout.contains("Usage:"));
+        assert!(
+            stdout.contains(expected_detail),
+            "{command} help:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn unknown_subcommand_options_exit_with_targeted_help_hint() {
+    for command in ["doctor", "ingest", "status", "compact", "events", "web"] {
+        let root = temp_root(&format!("{command}-unknown-option"));
+        let data_dir = root.join(".jottrace");
+        let output = Command::new(binary())
+            .args([command, "--definitely-not-an-option"])
+            .env("JOTTRACE_HOME", &data_dir)
+            .output()
+            .unwrap_or_else(|error| {
+                panic!("run jottrace {command} --definitely-not-an-option: {error}")
+            });
+
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{command} unknown option stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "{command} should not print stdout"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(&format!(
+                "unknown {command} option: --definitely-not-an-option"
+            )),
+            "{command} stderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(&format!("jottrace {command} --help")),
+            "{command} stderr:\n{stderr}"
+        );
+        assert!(
+            !db_path(&data_dir).exists(),
+            "usage errors should not initialize the database"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+}
+
+#[test]
 fn doctor_creates_private_data_dir() {
     let root = temp_root("doctor-ok");
     let data_dir = root.join(".jottrace");

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -311,6 +311,63 @@ fn upgrade_is_an_update_alias() {
     let _ = fs::remove_dir_all(root);
 }
 
+#[test]
+fn update_help_aliases_print_usage_without_update_environment() {
+    for command in ["update", "upgrade"] {
+        let long = Command::new(binary())
+            .args([command, "--help"])
+            .output()
+            .unwrap_or_else(|error| panic!("run jottrace {command} --help: {error}"));
+        let short = Command::new(binary())
+            .args([command, "-h"])
+            .output()
+            .unwrap_or_else(|error| panic!("run jottrace {command} -h: {error}"));
+
+        assert!(
+            long.status.success(),
+            "{command} --help stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&long.stdout),
+            String::from_utf8_lossy(&long.stderr)
+        );
+        assert!(
+            short.status.success(),
+            "{command} -h stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&short.stdout),
+            String::from_utf8_lossy(&short.stderr)
+        );
+        assert_eq!(
+            long.stdout, short.stdout,
+            "{command} help aliases should match"
+        );
+        assert!(long.stderr.is_empty(), "{command} help should not warn");
+
+        let stdout = String::from_utf8_lossy(&long.stdout);
+        assert!(stdout.contains("jottrace update"));
+        assert!(stdout.contains("Usage:"));
+        assert!(stdout.contains("jottrace upgrade"));
+    }
+}
+
+#[test]
+fn update_rejects_unknown_options_before_running_update() {
+    let output = Command::new(binary())
+        .args(["update", "--definitely-not-an-option"])
+        .output()
+        .expect("run jottrace update with unknown option");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown update option: --definitely-not-an-option"));
+    assert!(stderr.contains("jottrace update --help"));
+}
+
 fn create_invalid_release_artifact(
     root: &std::path::Path,
     releases: &std::path::Path,


### PR DESCRIPTION
## Summary
- add -h/--help support for doctor, ingest, status, plus shared simple-command parsing
- keep unknown subcommand options on exit code 2 with targeted help hints
- document jottrace -h as the fastest CLI discovery path

## Tests
- cargo fmt --check
- TMPDIR=/private/tmp cargo clippy --all-targets -- -D warnings
- TMPDIR=/private/tmp cargo test

Closes #56