### PR TITLE
Record ignored and deferred local agent sources

### DIFF
--- a/docs/reader-source-inventory.md
+++ b/docs/reader-source-inventory.md
@@ -3,7 +3,9 @@ title: "Reader source inventory"
 status: DRAFT
 updated: 2026-05-06
 parent_issue: "#54"
-issue: "#59"
+issues:
+  - "#59"
+  - "#69"
 ---
 
 # Reader Source Inventory
@@ -64,6 +66,26 @@ ordered session content:
   tool, and result events from generic app state.
 - Manual backup/reference copies such as `~/Downloads/CodexSessionBackup-*`;
   they may seed fixtures but are not automatic scan roots.
+
+### Ignored By Default
+
+| Source class | Examples | Why it is out of reader scope |
+| --- | --- | --- |
+| Aider home startup history | Aider home startup history, command history, model/auth/config traces | Thin histories and startup traces do not prove an ordered user/assistant/tool/result session stream. |
+| Electron browser session storage | Browser or Electron `Session Storage`, `Local Storage`, `IndexedDB`, profile cache, and cookie-like state | Browser persistence is app/runtime state, not a transcript contract. It can contain opaque keys, partial UI state, credentials, or cache entries without deterministic session ordering. |
+| skills-manager app state | Skills-manager app state, installed-skill cache, plugin metadata, and generated registry files | These files describe tooling configuration, not preserved coding-agent conversations. |
+| sidecar/cache outputs | Sidecar/cache outputs, MCP/plugin logs, temporary payload mirrors, downloaded model/cache artifacts, and derived indexes | Sidecars may be useful for diagnostics, but they are not authoritative transcript stores and can duplicate or redact the real source. |
+
+### Deferred Until Fixture Proof
+
+These sources stay out of default ingest scope until a future reader issue
+includes sanitized fixtures and the fixture proof required to reconsider them:
+
+| Source class | Fixture proof required to reconsider |
+| --- | --- |
+| Windsurf | A stable session id, ordered event/message rows, role/content/tool/result payloads, and in-place update detection for its VS Code-derived state. |
+| VS Code/Copilot/ChatGPT extension state | Proof that extension state contains intelligible coding-agent sessions rather than editor UI state, account cache, prompts without responses, or partial browser/app persistence. |
+| Antigravity app/protobuf/browser state | A safe textual or decoded fixture showing stable session identity, deterministic ordering, and recoverable event payloads from app/protobuf/browser state without committing opaque private data. |
 
 ## Fixture Requirements And Privacy
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1816,6 +1816,64 @@ fn ingest_ignores_claude_flat_root_non_session_jsonl() {
 }
 
 #[test]
+fn ingest_ignores_issue_69_ignored_and_deferred_source_paths_by_default() {
+    let root = temp_root("ingest-ignore-non-scope-sources");
+    let data_dir = root.join(".jottrace");
+
+    for (path, content) in [
+        (
+            root.join(".aider.chat.history.md"),
+            "Model: test\nCommand: /clear\n",
+        ),
+        (
+            root.join("Library/Application Support/Claude/Session Storage/000003.log"),
+            "{\"role\":\"assistant\",\"content\":\"cached browser state\"}\n",
+        ),
+        (
+            root.join("Library/Application Support/Codex/Session Storage/000003.log"),
+            "{\"role\":\"assistant\",\"content\":\"cached browser state\"}\n",
+        ),
+        (
+            root.join(".agents/skills-manager/state.db"),
+            "skills-manager app state",
+        ),
+        (
+            root.join("Library/Caches/claude-cli-nodejs/mcp-output.jsonl"),
+            "{\"role\":\"tool\",\"content\":\"sidecar cache output\"}\n",
+        ),
+        (
+            root.join("Library/Application Support/Windsurf/User/globalStorage/state.vscdb"),
+            "vscode-derived app state",
+        ),
+        (
+            root.join("Library/Application Support/Code/User/globalStorage/state.vscdb"),
+            "copilot/chatgpt extension app state",
+        ),
+        (
+            root.join(".gemini/antigravity/brain/state.pbtxt"),
+            "protobuf/app/browser state",
+        ),
+    ] {
+        write_text_file(&path, content);
+    }
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("files: 0"));
+    assert!(ingest.contains("sessions: 0"));
+    assert!(ingest.contains("events: 0"));
+    assert!(ingest.contains("inserted_events: 0"));
+    assert!(ingest.contains("unresolved_ingest_errors: 0"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let session_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .expect("session count");
+    assert_eq!(session_count, 0);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn ingest_preserves_uuid_named_claude_flat_root_session() {
     let root = temp_root("ingest-flat-root-uuid");
     let data_dir = root.join(".jottrace");

--- a/tests/fixture_corpus.rs
+++ b/tests/fixture_corpus.rs
@@ -79,6 +79,27 @@ fn reader_source_inventory_documents_deferred_and_privacy_boundaries() {
     }
 }
 
+#[test]
+fn reader_source_inventory_names_issue_69_ignored_and_deferred_sources() {
+    let inventory = reader_source_inventory();
+
+    for required in [
+        "Aider home startup history",
+        "Electron browser session storage",
+        "skills-manager app state",
+        "sidecar/cache outputs",
+        "Windsurf",
+        "VS Code/Copilot/ChatGPT extension state",
+        "Antigravity app/protobuf/browser state",
+        "fixture proof required to reconsider",
+    ] {
+        assert!(
+            inventory.contains(required),
+            "inventory note should explicitly name issue #69 source boundary: {required}"
+        );
+    }
+}
+
 fn reader_source_inventory() -> String {
     fs::read_to_string("docs/reader-source-inventory.md")
         .expect("reader source inventory design note should exist")


### PR DESCRIPTION
## Summary

- document issue #69 ignored and deferred source classes in the reader inventory
- add doc coverage for the explicit source-boundary list
- add an ingest guardrail proving ignored/deferred local paths are not scanned by default

## Verification

- cargo test
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- git diff --check

Closes #69