### PR TITLE
[codex] Capture Gemini CLI chat sessions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ description = "Preserve AI coding-session transcripts into a local journal"
 [dependencies]
 rusqlite = { version = "0.39.0", default-features = false, features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["raw_value"] }
 zstd = { version = "0.13.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Jottrace preserves local AI coding-session transcripts into a private SQLite
 journal you control.
 
 Today it can ingest Claude CLI / Claude Code and Codex CLI JSONL session files,
-including Claude subagent sidechain sessions, and report the local journal
-status from the command line. Cursor, OpenCode, and other readers are tracked
-in the design docs, but are not implemented as user-facing ingest sources yet.
+plus Gemini CLI chat JSON files. It also preserves Claude subagent sidechain
+sessions and reports the local journal status from the command line. Cursor,
+OpenCode, and other readers are tracked in the design docs, but are not
+implemented as user-facing ingest sources yet.
 
 ## Features
 
@@ -14,7 +15,7 @@ in the design docs, but are not implemented as user-facing ingest sources yet.
 - Keep local state in `~/.jottrace/db.sqlite`, or another directory via
   `JOTTRACE_HOME`.
 - Check the data directory and database with `jottrace doctor`.
-- Ingest Claude and Codex session JSONL with `jottrace ingest`.
+- Ingest Claude, Codex, and Gemini session files with `jottrace ingest`.
 - Inspect stored session, event, schema, and ingest-error counts with
   `jottrace status`.
 - Preserve Claude subagent sidechains as distinct child sessions linked to the
@@ -91,9 +92,14 @@ For Codex, Jottrace reads session files under `sessions/` and
 `archived_sessions/`, using each file's committed `session_meta` id as the
 stable session id.
 
-The ingest command stores raw JSONL event payloads and cheap deterministic
-session metadata, then prints the database path, discovered file count, total
-session/event counts, inserted event count, and unresolved ingest-error count.
+For Gemini CLI, Jottrace reads chat JSON files under
+`~/.gemini/tmp/<project-or-hash>/chats/*.json`, using each file's `sessionId`
+as the stable session id and preserving the ordered `messages[]` entries.
+
+The ingest command stores raw source event/message payloads and cheap
+deterministic session metadata, then prints the database path, discovered file
+count, total session/event counts, inserted event count, and unresolved
+ingest-error count.
 
 `jottrace status` initializes `~/.jottrace/db.sqlite` if needed and reports
 the schema version plus session, event, and unresolved ingest-error counts.

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,5 +1,6 @@
 use rusqlite::{Connection, OptionalExtension, Transaction, named_params, params};
 use serde::Deserialize;
+use serde_json::value::RawValue;
 use std::collections::HashSet;
 use std::env;
 use std::fs::{self, File, Metadata};
@@ -16,6 +17,7 @@ const CLAUDE_SOURCE: &str = "claude_cli";
 const CLAUDE_LOCAL_AGENT_SOURCE: &str = "claude_local_agent";
 const CODEX_SOURCE: &str = "codex_cli";
 const PI_AGENT_SOURCE: &str = "pi_agent";
+const GEMINI_SOURCE: &str = "gemini_cli";
 const CLAUDE_INSTALL_DIRS: &[&str] = &[
     ".claude",
     ".claude-code",
@@ -28,6 +30,7 @@ const PI_AGENT_SESSIONS_DIR: &str = ".pi/agent/sessions";
 const CLAUDE_LOCAL_AGENT_SESSIONS_DIR: &str =
     "Library/Application Support/Claude/local-agent-mode-sessions";
 const CLAUDE_LOCAL_AGENT_AUDIT_FILE_NAME: &str = "audit.jsonl";
+const GEMINI_TMP_DIR: &str = ".gemini/tmp";
 const MAX_SESSION_HEADER_BYTES: u64 = 64 * 1024;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
@@ -37,6 +40,9 @@ const READ_ERROR_KIND: &str = "read_error";
 const NOT_FILE_ERROR_KIND: &str = "not_file";
 const SOURCE_FILE_INGESTED_SUCCESSFULLY_NOTE: &str = "source file ingested successfully";
 const EMPTY_CODEX_SESSION_FILE_SKIPPED_NOTE: &str = "empty Codex session file skipped";
+const INSERT_EVENT_SQL: &str = "INSERT OR IGNORE INTO events
+    (session_id, generation, seq, ts, payload, codec, payload_size)
+ VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IngestReport {
@@ -60,6 +66,7 @@ struct SourceFile {
     source_session_id_kind: SourceSessionIdKind,
     parent_source_session_id: Option<String>,
     metadata_path: Option<PathBuf>,
+    source_format: SourceFormat,
     path: PathBuf,
 }
 
@@ -68,6 +75,13 @@ enum SourceSessionIdKind {
     Known,
     ClaudeLocalAgentAudit,
     CodexSessionMeta,
+    GeminiChatJson,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceFormat {
+    Jsonl,
+    GeminiChatJson,
 }
 
 #[derive(Debug, Clone)]
@@ -127,6 +141,11 @@ struct IngestErrorRecord<'a> {
     line_number: Option<i64>,
     error_kind: &'a str,
     message: &'a str,
+}
+
+struct ResolvedSourceFile {
+    source_file: SourceFile,
+    buffer: Option<Vec<u8>>,
 }
 
 struct SkippedSessionUpdate<'a> {
@@ -217,6 +236,34 @@ struct ClaudeLocalAgentMetadata<'a> {
     ended_at: Option<&'a str>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiChatFile<'a> {
+    #[serde(borrow)]
+    session_id: &'a str,
+    #[serde(default, borrow)]
+    project_hash: Option<&'a str>,
+    #[serde(default, borrow)]
+    start_time: Option<&'a str>,
+    #[serde(default, borrow)]
+    last_updated: Option<&'a str>,
+    #[serde(borrow)]
+    messages: Vec<&'a RawValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiChatIdentity<'a> {
+    #[serde(borrow)]
+    session_id: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiMessageHeader<'a> {
+    #[serde(default, borrow)]
+    timestamp: Option<&'a str>,
+}
+
 pub fn run_ingest() -> Result<IngestReport> {
     let data_dir = crate::data_dir_from_env()?;
     let _lock = crate::acquire_data_lock(&data_dir)?;
@@ -233,7 +280,7 @@ pub fn run_ingest() -> Result<IngestReport> {
     let mut inserted_event_count = 0;
 
     for source_file in &source_files {
-        match ingest_jsonl_file(&mut conn, &mut ingest_state, source_file) {
+        match ingest_source_file(&mut conn, &mut ingest_state, source_file) {
             Ok(inserted) => inserted_event_count += inserted,
             Err(error) if is_source_file_ingest_error(&error) => {
                 record_source_file_ingest_error(&mut conn, source_file, &error)?;
@@ -259,6 +306,7 @@ fn discover_session_files() -> Result<Vec<SourceFile>> {
     source_files.extend(discover_claude_local_agent_session_files()?);
     source_files.extend(discover_codex_session_files()?);
     source_files.extend(discover_pi_agent_session_files()?);
+    source_files.extend(discover_gemini_session_files()?);
     Ok(source_files)
 }
 
@@ -286,6 +334,7 @@ fn discover_claude_session_files() -> Result<Vec<SourceFile>> {
                 source_session_id_kind: SourceSessionIdKind::Known,
                 parent_source_session_id,
                 metadata_path: None,
+                source_format: SourceFormat::Jsonl,
                 path,
             })
         })
@@ -315,6 +364,7 @@ fn discover_claude_local_agent_session_files() -> Result<Vec<SourceFile>> {
                 source_session_id_kind: SourceSessionIdKind::ClaudeLocalAgentAudit,
                 parent_source_session_id: None,
                 metadata_path: claude_local_agent_metadata_path(&path),
+                source_format: SourceFormat::Jsonl,
                 path,
             })
         })
@@ -344,6 +394,53 @@ fn discover_codex_session_files() -> Result<Vec<SourceFile>> {
                 source_session_id_kind: SourceSessionIdKind::CodexSessionMeta,
                 parent_source_session_id: None,
                 metadata_path: None,
+                source_format: SourceFormat::Jsonl,
+                path,
+            })
+        })
+        .collect()
+}
+
+fn discover_gemini_session_files() -> Result<Vec<SourceFile>> {
+    let root = home_dir()?.join(GEMINI_TMP_DIR);
+    let entries = match fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(JottraceError::Io { path: root, source });
+        }
+    };
+
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| JottraceError::Io {
+            path: root.clone(),
+            source,
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|source| JottraceError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        if file_type.is_dir() {
+            collect_json_files(&path.join("chats"), false, &mut paths)?;
+        }
+    }
+
+    paths.sort();
+    paths.dedup();
+
+    paths
+        .into_iter()
+        .map(|path| {
+            let (source_session_id, _) = source_session_ids_from_path(&path)?;
+            Ok(SourceFile {
+                source: GEMINI_SOURCE,
+                source_session_id,
+                source_session_id_kind: SourceSessionIdKind::GeminiChatJson,
+                parent_source_session_id: None,
+                metadata_path: None,
+                source_format: SourceFormat::GeminiChatJson,
                 path,
             })
         })
@@ -368,6 +465,7 @@ fn discover_pi_agent_session_files() -> Result<Vec<SourceFile>> {
                 source_session_id_kind: SourceSessionIdKind::Known,
                 parent_source_session_id: None,
                 metadata_path: None,
+                source_format: SourceFormat::Jsonl,
                 path,
             })
         })
@@ -439,6 +537,19 @@ fn push_claude_local_agent_audit_file(session_dir: &Path, paths: &mut Vec<PathBu
 }
 
 fn collect_jsonl_files(root: &Path, recursive: bool, paths: &mut Vec<PathBuf>) -> Result<()> {
+    collect_files_with_extension(root, "jsonl", recursive, paths)
+}
+
+fn collect_json_files(root: &Path, recursive: bool, paths: &mut Vec<PathBuf>) -> Result<()> {
+    collect_files_with_extension(root, "json", recursive, paths)
+}
+
+fn collect_files_with_extension(
+    root: &Path,
+    extension: &str,
+    recursive: bool,
+    paths: &mut Vec<PathBuf>,
+) -> Result<()> {
     let entries = match fs::read_dir(root) {
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
@@ -462,12 +573,12 @@ fn collect_jsonl_files(root: &Path, recursive: bool, paths: &mut Vec<PathBuf>) -
         })?;
         if file_type.is_dir() {
             if recursive {
-                collect_jsonl_files(&path, true, paths)?;
+                collect_files_with_extension(&path, extension, true, paths)?;
             }
         } else if file_type.is_file()
             && path
                 .extension()
-                .is_some_and(|extension| extension == "jsonl")
+                .is_some_and(|path_extension| path_extension == extension)
         {
             paths.push(path);
         }
@@ -487,7 +598,7 @@ fn collect_flat_session_files(root: &Path, paths: &mut Vec<PathBuf>) -> Result<(
     Ok(())
 }
 
-fn ingest_jsonl_file(
+fn ingest_source_file(
     conn: &mut Connection,
     ingest_state: &mut IngestState,
     source_file: &SourceFile,
@@ -504,12 +615,15 @@ fn ingest_jsonl_file(
     let pass_size = i64_from_u64(pass_size_bytes, &source_file.path)?;
     let file_mtime = file_mtime(&metadata);
 
-    let source_file = if source_file.source == CODEX_SOURCE && pass_size_bytes == 0 {
+    let resolved_source_file = if source_file.source == CODEX_SOURCE && pass_size_bytes == 0 {
         match load_session_by_source_file_path(conn, source_file)? {
-            Some(stored) if !is_empty_source_file_placeholder(&stored) => SourceFile {
-                source_session_id: stored.source_session_id,
-                source_session_id_kind: SourceSessionIdKind::Known,
-                ..source_file.clone()
+            Some(stored) if !is_empty_source_file_placeholder(&stored) => ResolvedSourceFile {
+                source_file: SourceFile {
+                    source_session_id: stored.source_session_id,
+                    source_session_id_kind: SourceSessionIdKind::Known,
+                    ..source_file.clone()
+                },
+                buffer: None,
             },
             stored => {
                 resolve_invalid_session_meta_error(
@@ -523,8 +637,12 @@ fn ingest_jsonl_file(
             }
         }
     } else {
-        resolve_source_file(conn, source_file, pass_size, file_mtime)?
+        resolve_source_file(conn, source_file, pass_size, pass_size_bytes, file_mtime)?
     };
+    let ResolvedSourceFile {
+        source_file,
+        buffer: preloaded_buffer,
+    } = resolved_source_file;
 
     if let Some(stored) = load_session(conn, &source_file)?
         && unchanged_by_mtime(&stored, pass_size, file_mtime)
@@ -566,9 +684,11 @@ fn ingest_jsonl_file(
     }
 
     validate_source_file_header(&source_file)?;
-    let buffer = read_bounded(&source_file.path, pass_size_bytes)?;
+    let buffer = match preloaded_buffer {
+        Some(buffer) => buffer,
+        None => read_bounded(&source_file.path, pass_size_bytes)?,
+    };
     let content_fingerprint = fingerprint(&buffer);
-    let committed_len = committed_len(&buffer);
     let source_metadata = source_metadata(&source_file)?;
 
     let tx = conn
@@ -576,7 +696,7 @@ fn ingest_jsonl_file(
         .map_err(|source| sqlite_error(&source_file.path, source))?;
     insert_session_if_missing(&tx, &source_file)?;
     let stored = load_session(&tx, &source_file)?.expect("session row should exist after insert");
-    let import_mode = import_mode(&stored, pass_size, &content_fingerprint);
+    let import_mode = import_mode(&source_file, &stored, pass_size, &content_fingerprint);
 
     if import_mode == ImportMode::Skip {
         let parent_session_id = resolve_parent_session_id(&tx, &source_file)?;
@@ -608,21 +728,29 @@ fn ingest_jsonl_file(
         ImportMode::Append | ImportMode::Skip => stored.current_generation,
         ImportMode::Rewrite => stored.current_generation + 1,
     };
-    let start_offset = match import_mode {
-        ImportMode::Append => stored.next_read_offset.max(0) as usize,
-        ImportMode::Rewrite | ImportMode::Skip => 0,
-    }
-    .min(committed_len);
+    let imported = match source_file.source_format {
+        SourceFormat::Jsonl => {
+            let committed_len = committed_len(&buffer);
+            let start_offset = match import_mode {
+                ImportMode::Append => stored.next_read_offset.max(0) as usize,
+                ImportMode::Rewrite | ImportMode::Skip => 0,
+            }
+            .min(committed_len);
 
-    let imported = import_committed_lines(
-        &tx,
-        &source_file,
-        stored.id,
-        generation,
-        &buffer,
-        start_offset,
-        committed_len,
-    )?;
+            import_committed_lines(
+                &tx,
+                &source_file,
+                stored.id,
+                generation,
+                &buffer,
+                start_offset,
+                committed_len,
+            )?
+        }
+        SourceFormat::GeminiChatJson => {
+            import_gemini_chat_json(&tx, &source_file, stored.id, generation, &buffer)?
+        }
+    };
 
     let mut metadata = imported.metadata;
     metadata.fill_missing_from(source_metadata);
@@ -659,31 +787,46 @@ fn resolve_source_file(
     conn: &Connection,
     source_file: &SourceFile,
     pass_size: i64,
+    pass_size_bytes: u64,
     file_mtime: Option<i64>,
-) -> Result<SourceFile> {
+) -> Result<ResolvedSourceFile> {
     if source_file.source_session_id_kind == SourceSessionIdKind::Known {
-        return Ok(source_file.clone());
+        return Ok(ResolvedSourceFile {
+            source_file: source_file.clone(),
+            buffer: None,
+        });
     }
 
     let stored_by_path = load_session_by_source_file_path(conn, source_file)?;
     if let Some(stored) = &stored_by_path
         && unchanged_by_mtime(stored, pass_size, file_mtime)
     {
-        return Ok(SourceFile {
-            source_session_id: stored.source_session_id.clone(),
-            source_session_id_kind: SourceSessionIdKind::Known,
-            ..source_file.clone()
+        return Ok(ResolvedSourceFile {
+            source_file: SourceFile {
+                source_session_id: stored.source_session_id.clone(),
+                source_session_id_kind: SourceSessionIdKind::Known,
+                ..source_file.clone()
+            },
+            buffer: None,
         });
     }
 
-    let source_session_id = match source_file.source_session_id_kind {
-        SourceSessionIdKind::Known => unreachable!("known source file returned above"),
-        SourceSessionIdKind::ClaudeLocalAgentAudit => {
-            claude_local_agent_source_session_id_from_file(&source_file.path)?
-        }
+    let (source_session_id, buffer) = match source_file.source_session_id_kind {
+        SourceSessionIdKind::ClaudeLocalAgentAudit => (
+            claude_local_agent_source_session_id_from_file(&source_file.path)?,
+            None,
+        ),
         SourceSessionIdKind::CodexSessionMeta => {
-            codex_source_session_id_from_file(&source_file.path)?
+            (codex_source_session_id_from_file(&source_file.path)?, None)
         }
+        SourceSessionIdKind::GeminiChatJson => {
+            let buffer = read_bounded(&source_file.path, pass_size_bytes)?;
+            (
+                gemini_source_session_id_from_buffer(&source_file.path, &buffer)?,
+                Some(buffer),
+            )
+        }
+        SourceSessionIdKind::Known => unreachable!("known source files return early"),
     };
     reuse_source_file_session_identity(
         conn,
@@ -692,10 +835,13 @@ fn resolve_source_file(
         &source_session_id,
     )?;
 
-    Ok(SourceFile {
-        source_session_id,
-        source_session_id_kind: SourceSessionIdKind::Known,
-        ..source_file.clone()
+    Ok(ResolvedSourceFile {
+        source_file: SourceFile {
+            source_session_id,
+            source_session_id_kind: SourceSessionIdKind::Known,
+            ..source_file.clone()
+        },
+        buffer,
     })
 }
 
@@ -721,11 +867,7 @@ fn import_committed_lines(
     let mut byte_offset = start_offset;
     let mut seq = line_number_at(buffer, start_offset);
     let mut event_insert = tx
-        .prepare(
-            "INSERT OR IGNORE INTO events
-                (session_id, generation, seq, ts, payload, codec, payload_size)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-        )
+        .prepare(INSERT_EVENT_SQL)
         .map_err(|source| sqlite_error(&source_file.path, source))?;
 
     while byte_offset < committed_len {
@@ -736,19 +878,15 @@ fn import_committed_lines(
             Ok(header) => {
                 capture_metadata(&mut metadata, source_file.source, &header);
                 let ts = event_timestamp(source_file.source, &header);
-                let encoded = encode_event_payload(line)?;
-                let inserted = event_insert
-                    .execute(params![
-                        session_id,
-                        generation,
-                        seq,
-                        ts,
-                        encoded.payload,
-                        encoded.codec,
-                        i64_from_usize(encoded.payload_size, &source_file.path)?,
-                    ])
-                    .map_err(|source| sqlite_error(&source_file.path, source))?;
-                inserted_event_count += inserted as u64;
+                inserted_event_count += insert_event_payload(
+                    &mut event_insert,
+                    source_file,
+                    session_id,
+                    generation,
+                    seq,
+                    ts,
+                    line,
+                )?;
                 next_read_offset = (line_end + 1) as i64;
             }
             Err(error) => {
@@ -779,6 +917,80 @@ fn import_committed_lines(
     })
 }
 
+fn insert_event_payload(
+    event_insert: &mut rusqlite::Statement<'_>,
+    source_file: &SourceFile,
+    session_id: i64,
+    generation: i64,
+    seq: i64,
+    ts: Option<&str>,
+    payload: &[u8],
+) -> Result<u64> {
+    let encoded = encode_event_payload(payload)?;
+    let inserted = event_insert
+        .execute(params![
+            session_id,
+            generation,
+            seq,
+            ts,
+            encoded.payload,
+            encoded.codec,
+            i64_from_usize(encoded.payload_size, &source_file.path)?,
+        ])
+        .map_err(|source| sqlite_error(&source_file.path, source))?;
+    Ok(inserted as u64)
+}
+
+fn import_gemini_chat_json(
+    tx: &Transaction<'_>,
+    source_file: &SourceFile,
+    session_id: i64,
+    generation: i64,
+    buffer: &[u8],
+) -> Result<ImportResult> {
+    let chat = gemini_chat_from_buffer(&source_file.path, buffer)?;
+    let mut metadata = ParsedMetadata::default();
+    if let Some(project_hash) = chat.project_hash {
+        metadata.cwd = Some(project_hash.to_string());
+    }
+    if let Some(start_time) = chat.start_time {
+        capture_metadata_timestamp(&mut metadata, start_time);
+    }
+    if let Some(last_updated) = chat.last_updated {
+        capture_metadata_timestamp(&mut metadata, last_updated);
+    }
+
+    let mut inserted_event_count = 0;
+    let mut event_insert = tx
+        .prepare(INSERT_EVENT_SQL)
+        .map_err(|source| sqlite_error(&source_file.path, source))?;
+
+    for (index, message) in chat.messages.iter().enumerate() {
+        let header = serde_json::from_str::<GeminiMessageHeader<'_>>(message.get())
+            .map_err(|source| invalid_session_meta(&source_file.path, source.to_string()))?;
+        if let Some(ts) = header.timestamp {
+            capture_metadata_timestamp(&mut metadata, ts);
+        }
+
+        let payload = message.get().as_bytes();
+        inserted_event_count += insert_event_payload(
+            &mut event_insert,
+            source_file,
+            session_id,
+            generation,
+            i64_from_usize(index, &source_file.path)?,
+            header.timestamp,
+            payload,
+        )?;
+    }
+
+    Ok(ImportResult {
+        inserted_event_count,
+        next_read_offset: i64_from_usize(buffer.len(), &source_file.path)?,
+        metadata,
+    })
+}
+
 fn record_source_file_ingest_error(
     conn: &mut Connection,
     source_file: &SourceFile,
@@ -787,13 +999,28 @@ fn record_source_file_ingest_error(
     let tx = conn
         .transaction()
         .map_err(|source| sqlite_error(&source_file.path, source))?;
-    insert_session_if_missing(&tx, source_file)?;
-    let stored = load_session(&tx, source_file)?.expect("session row should exist after insert");
+    let stored_by_path = load_session_by_source_file_path(&tx, source_file)?;
+    let (error_source_file, stored) = if let Some(stored) = stored_by_path {
+        (
+            SourceFile {
+                source_session_id: stored.source_session_id.clone(),
+                source_session_id_kind: SourceSessionIdKind::Known,
+                ..source_file.clone()
+            },
+            stored,
+        )
+    } else {
+        let error_source_file = source_file_for_ingest_error(source_file);
+        insert_session_if_missing(&tx, &error_source_file)?;
+        let stored =
+            load_session(&tx, &error_source_file)?.expect("session row should exist after insert");
+        (error_source_file, stored)
+    };
     let message = error.to_string();
     record_ingest_error(
         &tx,
         IngestErrorRecord {
-            source_file,
+            source_file: &error_source_file,
             session_id: Some(stored.id),
             generation: Some(stored.current_generation),
             byte_offset: None,
@@ -803,7 +1030,29 @@ fn record_source_file_ingest_error(
         },
     )?;
     tx.commit()
-        .map_err(|source| sqlite_error(&source_file.path, source))
+        .map_err(|source| sqlite_error(&error_source_file.path, source))
+}
+
+fn source_file_for_ingest_error(source_file: &SourceFile) -> SourceFile {
+    if source_file.source_session_id_kind == SourceSessionIdKind::GeminiChatJson
+        && let Some(source_session_id) = recover_gemini_source_session_id(source_file)
+    {
+        return SourceFile {
+            source_session_id,
+            source_session_id_kind: SourceSessionIdKind::Known,
+            ..source_file.clone()
+        };
+    }
+    source_file.clone()
+}
+
+fn recover_gemini_source_session_id(source_file: &SourceFile) -> Option<String> {
+    let metadata = fs::metadata(&source_file.path).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    let buffer = read_bounded(&source_file.path, metadata.len()).ok()?;
+    gemini_source_session_id_from_buffer(&source_file.path, &buffer).ok()
 }
 
 fn is_source_file_ingest_error(error: &JottraceError) -> bool {
@@ -917,7 +1166,12 @@ fn unchanged_by_mtime(stored: &StoredSession, pass_size: i64, file_mtime: Option
         && stored.content_fingerprint.is_some()
 }
 
-fn import_mode(stored: &StoredSession, pass_size: i64, content_fingerprint: &str) -> ImportMode {
+fn import_mode(
+    source_file: &SourceFile,
+    stored: &StoredSession,
+    pass_size: i64,
+    content_fingerprint: &str,
+) -> ImportMode {
     match stored.file_size {
         None => ImportMode::Append,
         Some(file_size)
@@ -926,7 +1180,11 @@ fn import_mode(stored: &StoredSession, pass_size: i64, content_fingerprint: &str
         {
             ImportMode::Skip
         }
-        Some(file_size) if pass_size > file_size => ImportMode::Append,
+        Some(file_size)
+            if source_file.source_format == SourceFormat::Jsonl && pass_size > file_size =>
+        {
+            ImportMode::Append
+        }
         Some(_) => ImportMode::Rewrite,
     }
 }
@@ -1283,21 +1541,29 @@ fn capture_metadata(metadata: &mut ParsedMetadata, source: &str, header: &EventH
     }
 
     if let Some(ts) = event_timestamp(source, header) {
-        let ts = ts.to_string();
-        if metadata
-            .started_at
-            .as_ref()
-            .is_none_or(|current| ts < *current)
-        {
+        capture_metadata_timestamp(metadata, ts);
+    }
+}
+
+fn capture_metadata_timestamp(metadata: &mut ParsedMetadata, ts: &str) {
+    let replace_started = metadata
+        .started_at
+        .as_deref()
+        .is_none_or(|current| ts < current);
+    let replace_ended = metadata
+        .ended_at
+        .as_deref()
+        .is_none_or(|current| ts > current);
+
+    match (replace_started, replace_ended) {
+        (true, true) => {
+            let ts = ts.to_string();
             metadata.started_at = Some(ts.clone());
-        }
-        if metadata
-            .ended_at
-            .as_ref()
-            .is_none_or(|current| ts > *current)
-        {
             metadata.ended_at = Some(ts);
         }
+        (true, false) => metadata.started_at = Some(ts.to_string()),
+        (false, true) => metadata.ended_at = Some(ts.to_string()),
+        (false, false) => {}
     }
 }
 
@@ -1479,6 +1745,30 @@ fn claude_local_agent_fallback_source_session_id(path: &Path) -> Result<String> 
 
 fn claude_local_agent_metadata_path(path: &Path) -> Option<PathBuf> {
     path.parent().map(|parent| parent.with_extension("json"))
+}
+
+fn gemini_source_session_id_from_buffer(path: &Path, buffer: &[u8]) -> Result<String> {
+    let identity = serde_json::from_slice::<GeminiChatIdentity<'_>>(buffer)
+        .map_err(|source| invalid_session_meta(path, source.to_string()))?;
+    if identity.session_id.trim().is_empty() {
+        return Err(invalid_session_meta(
+            path,
+            "gemini chat sessionId is missing",
+        ));
+    }
+    Ok(identity.session_id.to_string())
+}
+
+fn gemini_chat_from_buffer<'a>(path: &Path, buffer: &'a [u8]) -> Result<GeminiChatFile<'a>> {
+    let chat = serde_json::from_slice::<GeminiChatFile<'a>>(buffer)
+        .map_err(|source| invalid_session_meta(path, source.to_string()))?;
+    if chat.session_id.trim().is_empty() {
+        return Err(invalid_session_meta(
+            path,
+            "gemini chat sessionId is missing",
+        ));
+    }
+    Ok(chat)
 }
 
 fn source_session_ids_from_path(path: &Path) -> Result<(String, Option<String>)> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -28,6 +28,9 @@ const CODEX_ARCHIVED_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-0000000
 const CODEX_LEGACY_FIXTURE_SESSION_ID: &str = "22222222-2222-4222-8222-222222222222";
 const PI_AGENT_FIXTURE_SESSION: &str = "pi-agent/sessions/--Users-fixture-Workspace-jottrace--/2026-05-06T02-00-00-000Z_00000000-0000-4000-8000-000000000064.jsonl";
 const PI_AGENT_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-000000000064";
+const GEMINI_FIXTURE_SESSION: &str =
+    "gemini-cli/tmp/fixture-project/chats/session-2026-05-06T09-00-gemini000.json";
+const GEMINI_FIXTURE_SESSION_ID: &str = "33333333-3333-4333-8333-333333333333";
 const CORRUPT_FIXTURE_SESSION: &str = "edge-cases/corrupt-line.jsonl";
 const CORRUPT_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-000000000000";
 const UNREADABLE_FIXTURE_SESSION_ID: &str = "00000000-0000-4000-8000-000000000001";
@@ -1272,6 +1275,290 @@ fn ingest_preserves_legacy_codex_session_with_top_level_id_header() {
     assert_eq!(event_count, 3);
     assert_eq!(started_at, "2025-09-12T09:54:22.802Z");
     assert_eq!(PathBuf::from(file_path), session_file);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_preserves_gemini_cli_chat_json_session() {
+    let root = temp_root("ingest-gemini-chat");
+    let data_dir = root.join(".jottrace");
+    let session_file = install_gemini_fixture(&root);
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("sessions: 1"));
+    assert!(ingest.contains("events: 4"));
+    assert!(ingest.contains("inserted_events: 4"));
+    assert!(ingest.contains("unresolved_ingest_errors: 0"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let (source_session_id, cwd, started_at, ended_at, event_count, file_path): (
+        String,
+        String,
+        String,
+        String,
+        i64,
+        String,
+    ) = conn
+        .query_row(
+            "SELECT source_session_id, cwd, started_at, ended_at, event_count, file_path
+             FROM sessions
+             WHERE source = 'gemini_cli'",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            },
+        )
+        .expect("gemini session metadata");
+    assert_eq!(source_session_id, GEMINI_FIXTURE_SESSION_ID);
+    assert_eq!(cwd, "fixture-gemini-project-hash");
+    assert_eq!(started_at, "2026-05-06T09:00:00.000Z");
+    assert_eq!(ended_at, "2026-05-06T09:00:06.000Z");
+    assert_eq!(event_count, 4);
+    assert_eq!(PathBuf::from(file_path), session_file);
+
+    let events: Vec<(i64, Option<String>, serde_json::Value)> = conn
+        .prepare(
+            "SELECT seq, ts, payload, codec
+             FROM events
+             JOIN sessions ON sessions.id = events.session_id
+             WHERE sessions.source = 'gemini_cli'
+             ORDER BY seq",
+        )
+        .expect("prepare gemini events")
+        .query_map([], |row| {
+            let payload: Vec<u8> = row.get(2)?;
+            let codec: String = row.get(3)?;
+            let decoded = jottrace::storage::decode_event_payload(&payload, &codec)
+                .expect("decode gemini payload");
+            let json = serde_json::from_slice(&decoded).expect("gemini payload should be json");
+            Ok((row.get(0)?, row.get(1)?, json))
+        })
+        .expect("query gemini events")
+        .map(|row| row.expect("gemini event"))
+        .collect();
+    assert_eq!(events.len(), 4);
+    assert_eq!(
+        events.iter().map(|event| event.0).collect::<Vec<_>>(),
+        vec![0, 1, 2, 3]
+    );
+    assert_eq!(events[0].1.as_deref(), Some("2026-05-06T09:00:01.000Z"));
+    assert_eq!(events[0].2["type"], "user");
+    assert_eq!(events[1].2["type"], "gemini");
+    assert!(events[1].2.get("thoughts").is_some());
+    assert!(events[1].2.get("tokens").is_some());
+    assert!(events[1].2.get("toolCalls").is_some());
+    assert_eq!(events[2].2["type"], "info");
+    assert_eq!(events[3].2["content"], "Final sanitized response.");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_is_idempotent_for_unchanged_gemini_cli_fixture() {
+    let root = temp_root("ingest-gemini-idempotent");
+    let data_dir = root.join(".jottrace");
+    install_gemini_fixture(&root);
+
+    let first = run_ingest(&root, &data_dir);
+    assert!(first.contains("events: 4"));
+    assert!(first.contains("inserted_events: 4"));
+
+    let second = run_ingest(&root, &data_dir);
+    assert!(second.contains("sessions: 1"));
+    assert!(second.contains("events: 4"));
+    assert!(second.contains("inserted_events: 0"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let (current_generation, event_count): (i64, i64) = conn
+        .query_row(
+            "SELECT current_generation, event_count
+             FROM sessions
+             WHERE source = 'gemini_cli'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("gemini idempotent session state");
+    assert_eq!(current_generation, 0);
+    assert_eq!(event_count, 4);
+    assert_eq!(generation_counts(&conn), vec![(0, 4)]);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_preserves_changed_gemini_cli_chat_as_next_generation() {
+    let root = temp_root("ingest-gemini-rewrite");
+    let data_dir = root.join(".jottrace");
+    let session_file = install_gemini_fixture(&root);
+
+    let first = run_ingest(&root, &data_dir);
+    assert!(first.contains("events: 4"));
+    assert!(first.contains("inserted_events: 4"));
+
+    let mut chat: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&session_file).expect("read gemini fixture for rewrite"),
+    )
+    .expect("parse gemini fixture for rewrite");
+    chat["messages"]
+        .as_array_mut()
+        .expect("gemini messages array")
+        .push(serde_json::json!({
+            "id": "gemini-message-005",
+            "timestamp": "2026-05-06T09:00:08.000Z",
+            "type": "user",
+            "content": [
+                {
+                    "text": "Please continue with the next fixture step."
+                }
+            ]
+        }));
+    chat["lastUpdated"] = serde_json::json!("2026-05-06T09:00:08.000Z");
+    write_text_file(
+        &session_file,
+        &serde_json::to_string_pretty(&chat).expect("serialize rewritten gemini fixture"),
+    );
+
+    let second = run_ingest(&root, &data_dir);
+    assert!(second.contains("events: 9"));
+    assert!(second.contains("inserted_events: 5"));
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let (current_generation, event_count, ended_at): (i64, i64, String) = conn
+        .query_row(
+            "SELECT current_generation, event_count, ended_at
+             FROM sessions
+             WHERE source = 'gemini_cli'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("gemini rewritten session state");
+    assert_eq!(current_generation, 1);
+    assert_eq!(event_count, 5);
+    assert_eq!(ended_at, "2026-05-06T09:00:08.000Z");
+    assert_eq!(generation_counts(&conn), vec![(0, 4), (1, 5)]);
+    assert!(event_payload(&conn, 1, 4).contains("Please continue"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_records_invalid_gemini_chat_json_without_blocking_unrelated_files() {
+    let root = temp_root("ingest-gemini-invalid-json");
+    let data_dir = root.join(".jottrace");
+    install_primary_claude_fixture(&root);
+    let bad_file = root
+        .join(".gemini/tmp/bad-project/chats")
+        .join("session-bad-gemini.json");
+    write_text_file(&bad_file, "{\"sessionId\":");
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("sessions: 2"));
+    assert!(ingest.contains("events: 12"));
+    assert!(ingest.contains("inserted_events: 12"));
+    assert!(ingest.contains("unresolved_ingest_errors: 1"));
+
+    let errors = jottrace::storage::unresolved_ingest_errors_for_path(&db_path(&data_dir), 10)
+        .expect("unresolved ingest errors");
+    assert_eq!(errors.len(), 1);
+    let error = &errors[0];
+    assert_eq!(error.source, "gemini_cli");
+    assert_eq!(
+        error.source_session_id.as_deref(),
+        Some("session-bad-gemini")
+    );
+    assert_eq!(error.file_path, bad_file);
+    assert_eq!(error.error_kind, "invalid_session_meta");
+    assert!(!error.message.is_empty());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_records_invalid_gemini_chat_shape_with_readable_session_id() {
+    let root = temp_root("ingest-gemini-invalid-shape");
+    let data_dir = root.join(".jottrace");
+    let bad_file = root
+        .join(".gemini/tmp/bad-project/chats")
+        .join("session-bad-gemini.json");
+    write_text_file(
+        &bad_file,
+        r#"{"sessionId":"33333333-3333-4333-8333-333333333334","messages":{}}"#,
+    );
+
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("sessions: 1"));
+    assert!(ingest.contains("events: 0"));
+    assert!(ingest.contains("inserted_events: 0"));
+    assert!(ingest.contains("unresolved_ingest_errors: 1"));
+
+    let errors = jottrace::storage::unresolved_ingest_errors_for_path(&db_path(&data_dir), 10)
+        .expect("unresolved ingest errors");
+    assert_eq!(errors.len(), 1);
+    let error = &errors[0];
+    assert_eq!(error.source, "gemini_cli");
+    assert_eq!(
+        error.source_session_id.as_deref(),
+        Some("33333333-3333-4333-8333-333333333334")
+    );
+    assert_eq!(error.file_path, bad_file);
+    assert_eq!(error.error_kind, "invalid_session_meta");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn ingest_records_invalid_gemini_rewrite_against_existing_session() {
+    let root = temp_root("ingest-gemini-invalid-rewrite");
+    let data_dir = root.join(".jottrace");
+    let session_file = install_gemini_fixture(&root);
+
+    let first = run_ingest(&root, &data_dir);
+    assert!(first.contains("sessions: 1"));
+    assert!(first.contains("events: 4"));
+    assert!(first.contains("unresolved_ingest_errors: 0"));
+
+    write_text_file(&session_file, "{\"sessionId\":");
+
+    let second = run_ingest(&root, &data_dir);
+    assert!(second.contains("sessions: 1"));
+    assert!(second.contains("events: 4"));
+    assert!(second.contains("inserted_events: 0"));
+    assert!(second.contains("unresolved_ingest_errors: 1"));
+
+    let errors = jottrace::storage::unresolved_ingest_errors_for_path(&db_path(&data_dir), 10)
+        .expect("unresolved ingest errors");
+    assert_eq!(errors.len(), 1);
+    let error = &errors[0];
+    assert_eq!(error.source, "gemini_cli");
+    assert_eq!(
+        error.source_session_id.as_deref(),
+        Some(GEMINI_FIXTURE_SESSION_ID)
+    );
+    assert_eq!(error.file_path, session_file);
+    assert_eq!(error.error_kind, "invalid_session_meta");
+
+    let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
+    let session_ids: Vec<String> = conn
+        .prepare(
+            "SELECT source_session_id
+             FROM sessions
+             WHERE source = 'gemini_cli'
+             ORDER BY source_session_id",
+        )
+        .expect("prepare gemini session ids")
+        .query_map([], |row| row.get(0))
+        .expect("query gemini session ids")
+        .map(|row| row.expect("gemini session id"))
+        .collect();
+    assert_eq!(session_ids, vec![GEMINI_FIXTURE_SESSION_ID]);
 
     let _ = fs::remove_dir_all(root);
 }
@@ -2844,6 +3131,14 @@ fn install_claude_local_agent_fixture(root: &Path) -> PathBuf {
     let audit_file = base.join(local_session).join("audit.jsonl");
     copy_reader_fixture(CLAUDE_LOCAL_AGENT_FIXTURE_AUDIT, &audit_file);
     audit_file
+}
+
+fn install_gemini_fixture(root: &Path) -> PathBuf {
+    let session_file = root
+        .join(".gemini/tmp/fixture-project/chats")
+        .join("session-2026-05-06T09-00-gemini000.json");
+    copy_reader_fixture(GEMINI_FIXTURE_SESSION, &session_file);
+    session_file
 }
 
 fn replace_with_fixture(path: &Path, fixture_relative: &str) {

--- a/tests/fixture_corpus.rs
+++ b/tests/fixture_corpus.rs
@@ -162,6 +162,7 @@ fn reader_fixture_corpus_has_issue_21_required_shapes() {
         "claude-cli/projects/-Users-fixture-Workspace-jottrace/00000000-0000-4000-8000-000000000021/subagents/agent-a000000000000021.jsonl",
         "codex-cli/sessions/2026/05/05/rollout-2026-05-05T09-00-00-00000000-0000-4000-8000-000000000021.jsonl",
         "codex-cli/archived_sessions/rollout-2026-03-28T10-42-29-00000000-0000-4000-8000-000000000021.jsonl",
+        "gemini-cli/tmp/fixture-project/chats/session-2026-05-06T09-00-gemini000.json",
         "edge-cases/partial-tail.jsonl",
         "edge-cases/corrupt-line.jsonl",
         "edge-cases/truncation-before.jsonl",

--- a/tests/fixtures/readers/README.md
+++ b/tests/fixtures/readers/README.md
@@ -1,7 +1,8 @@
 # Reader Fixture Corpus
 
 This corpus started as the issue #21 reader-fixture seed set and now includes
-the Claude local-agent, OpenCode SQLite, and issue #64 Pi agent slices. It is
+the Claude local-agent, OpenCode SQLite, issue #64 Pi agent, and issue #67
+Gemini CLI slices. It is
 source-shaped from inspected local agent artifacts, but all content is
 synthetic and safe to commit.
 
@@ -30,6 +31,9 @@ synthetic and safe to commit.
   assistant, system, result, tool-summary, and rate-limit events. Browser
   session storage, app caches, uploads, outputs, and audit keys are
   intentionally not part of the fixture.
+- `gemini-cli/tmp/fixture-project/chats/` captures the Gemini CLI chat JSON
+  shape with user, gemini, and info messages plus thoughts, token metadata, and
+  tool-call/result payloads.
 - `edge-cases/` contains partial-tail, corrupt-line, truncation, and same-size
   rewrite cases for the shared JSONL ingest core.
 

--- a/tests/fixtures/readers/gemini-cli/tmp/fixture-project/chats/session-2026-05-06T09-00-gemini000.json
+++ b/tests/fixtures/readers/gemini-cli/tmp/fixture-project/chats/session-2026-05-06T09-00-gemini000.json
@@ -1,0 +1,88 @@
+{
+  "sessionId": "33333333-3333-4333-8333-333333333333",
+  "projectHash": "fixture-gemini-project-hash",
+  "startTime": "2026-05-06T09:00:00.000Z",
+  "lastUpdated": "2026-05-06T09:00:06.000Z",
+  "messages": [
+    {
+      "id": "gemini-message-001",
+      "timestamp": "2026-05-06T09:00:01.000Z",
+      "type": "user",
+      "content": [
+        {
+          "text": "Please inspect the fixture project."
+        }
+      ]
+    },
+    {
+      "id": "gemini-message-002",
+      "timestamp": "2026-05-06T09:00:03.000Z",
+      "type": "gemini",
+      "content": "I will inspect the sanitized fixture project.",
+      "thoughts": [
+        {
+          "subject": "Plan",
+          "description": "Use the source-shaped fixture without private content.",
+          "timestamp": "2026-05-06T09:00:02.000Z"
+        }
+      ],
+      "tokens": {
+        "input": 128,
+        "output": 32,
+        "cached": 0,
+        "thoughts": 8,
+        "tool": 12,
+        "total": 180
+      },
+      "model": "gemini-fixture",
+      "toolCalls": [
+        {
+          "id": "tool-call-fixture-001",
+          "name": "list_directory",
+          "args": {
+            "dir_path": "/Users/fixture/Workspace/jottrace"
+          },
+          "result": [
+            {
+              "functionResponse": {
+                "id": "tool-call-fixture-001",
+                "name": "list_directory",
+                "response": {
+                  "output": "README.md\nsrc\ntests\n"
+                }
+              }
+            }
+          ],
+          "status": "success",
+          "timestamp": "2026-05-06T09:00:03.000Z",
+          "resultDisplay": "README.md\nsrc\ntests\n",
+          "displayName": "List directory",
+          "description": "List the fixture project directory.",
+          "renderOutputAsMarkdown": false
+        }
+      ]
+    },
+    {
+      "id": "gemini-message-003",
+      "timestamp": "2026-05-06T09:00:04.000Z",
+      "type": "info",
+      "content": "Fixture command completed."
+    },
+    {
+      "id": "gemini-message-004",
+      "timestamp": "2026-05-06T09:00:06.000Z",
+      "type": "gemini",
+      "content": "Final sanitized response.",
+      "tokens": {
+        "input": 64,
+        "output": 16,
+        "cached": 0,
+        "thoughts": 0,
+        "tool": 0,
+        "total": 80
+      },
+      "model": "gemini-fixture"
+    }
+  ],
+  "kind": "chat"
+}


### PR DESCRIPTION
## Summary

- Add Gemini CLI chat JSON discovery under `~/.gemini/tmp/<project-or-hash>/chats/*.json`.
- Preserve each ordered `messages[]` entry as a raw event payload with deterministic sequence numbers, timestamps, session id, project hash metadata, and whole-file rewrite handling.
- Add sanitized Gemini fixtures, focused ingest/error tests, and README/fixture-corpus documentation.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `TMPDIR=/private/tmp cargo clippy --all-targets -- -D warnings`
- `TMPDIR=/private/tmp cargo test`

Closes #67