### PR TITLE
[codex] Add opt-out background auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,29 @@ rerun the installer fallback:
 curl -fsSL https://raw.githubusercontent.com/season179/jottrace/main/install.sh | bash
 ```
 
+When Jottrace appears to be running from the `install.sh` location
+(`~/.local/bin/jottrace`), normal commands quietly start a throttled background
+update check. The foreground command is not delayed and does not print update
+status. If the background check, download, validation, or replacement fails,
+the existing binary is left in place.
+
+To disable background auto-update checks for one command or shell session:
+
+```sh
+JOTTRACE_AUTO_UPDATE=0 jottrace status
+```
+
+To disable them persistently, create `~/.jottrace/config.json`:
+
+```json
+{
+  "auto_update": false
+}
+```
+
+These opt-outs only affect background auto-updates. You can still run
+`jottrace update` or `jottrace upgrade` manually.
+
 ## Build From Source
 
 ```sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,9 @@ use std::process::ExitCode;
 fn main() -> ExitCode {
     // The first env arg is the executable path; commands start after it.
     let mut args = env::args().skip(1);
+    let command = args.next();
 
-    // Match on &str values so command dispatch stays simple and avoids cloning
-    // the user-provided argument just to inspect it.
-    match args.next().as_deref() {
+    match command.as_deref() {
         None | Some("--help") | Some("-h") => {
             print_help();
             ExitCode::SUCCESS
@@ -24,6 +23,9 @@ fn main() -> ExitCode {
         Some("status") => run_status_command(args),
         Some("update") | Some("upgrade") => run_update_command(args),
         Some("web") => run_web_command(args),
+        Some(command) if jottrace::update::is_auto_update_command(command) => {
+            run_auto_update_background_command(args)
+        }
         Some(command) => {
             eprintln!("unknown command: {command}");
             eprintln!("run `jottrace --help` for usage");
@@ -90,6 +92,7 @@ fn run_events_command(args: impl Iterator<Item = String>) -> ExitCode {
             return ExitCode::from(2);
         }
     };
+    jottrace::update::maybe_spawn_auto_update();
 
     let db_path = match jottrace::storage::db_path_from_env() {
         Ok(db_path) => db_path,
@@ -209,6 +212,7 @@ fn run_web_command(args: impl Iterator<Item = String>) -> ExitCode {
             return ExitCode::from(2);
         }
     };
+    jottrace::update::maybe_spawn_auto_update();
 
     let db_path = match jottrace::storage::db_path_from_env() {
         Ok(db_path) => db_path,
@@ -286,6 +290,7 @@ fn run_ingest_command(args: impl Iterator<Item = String>) -> ExitCode {
             return ExitCode::from(2);
         }
     }
+    jottrace::update::maybe_spawn_auto_update();
 
     match jottrace::run_ingest() {
         Ok(report) => {
@@ -347,6 +352,14 @@ fn run_update_command(args: impl Iterator<Item = String>) -> ExitCode {
     }
 }
 
+fn run_auto_update_background_command(mut args: impl Iterator<Item = String>) -> ExitCode {
+    if args.next().is_some() {
+        return ExitCode::from(2);
+    }
+    jottrace::update::run_auto_update_silent();
+    ExitCode::SUCCESS
+}
+
 fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
     let options = match parse_compact_command(args) {
         Ok(CompactCommand::Run(options)) => options,
@@ -360,6 +373,7 @@ fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
             return ExitCode::from(2);
         }
     };
+    jottrace::update::maybe_spawn_auto_update();
 
     match jottrace::run_compact(options) {
         Ok(report) => {
@@ -498,6 +512,7 @@ fn run_doctor_command(args: impl Iterator<Item = String>) -> ExitCode {
             return ExitCode::from(2);
         }
     }
+    jottrace::update::maybe_spawn_auto_update();
 
     // Keep the CLI responsible for presentation while the library owns the
     // filesystem checks. That makes future commands easier to test directly.
@@ -560,6 +575,7 @@ fn run_status_command(args: impl Iterator<Item = String>) -> ExitCode {
             return ExitCode::from(2);
         }
     }
+    jottrace::update::maybe_spawn_auto_update();
 
     match jottrace::run_status() {
         Ok(report) => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,9 +1,11 @@
+use serde::Deserialize;
 use std::env;
 use std::fmt;
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
+use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(unix)]
@@ -13,6 +15,19 @@ const REPO: &str = "season179/jottrace";
 const VERSION_ENV: &str = "JOTTRACE_VERSION";
 const RELEASE_BASE_URL_ENV: &str = "JOTTRACE_RELEASE_BASE_URL";
 const UPDATE_INSTALL_PATH_ENV: &str = "JOTTRACE_UPDATE_INSTALL_PATH";
+const AUTO_UPDATE_ENV: &str = "JOTTRACE_AUTO_UPDATE";
+const AUTO_UPDATE_LOCK_PATH_ENV: &str = "JOTTRACE_AUTO_UPDATE_LOCK_PATH";
+const AUTO_UPDATE_COMMAND: &str = "__jottrace-auto-update";
+const AUTO_UPDATE_CONFIG_FILE: &str = "config.json";
+const AUTO_UPDATE_STAMP_FILE: &str = "auto-update-check";
+const AUTO_UPDATE_LOCK_FILE: &str = "auto-update-check.lock";
+const AUTO_UPDATE_INTERVAL_SECS: u64 = 24 * 60 * 60;
+const AUTO_UPDATE_LOCK_STALE_SECS: u64 = 60 * 60;
+
+#[derive(Debug, Deserialize)]
+struct JottraceConfig {
+    auto_update: Option<bool>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateReport {
@@ -108,6 +123,22 @@ impl std::error::Error for UpdateError {
 }
 
 pub type Result<T> = std::result::Result<T, UpdateError>;
+
+pub fn is_auto_update_command(command: &str) -> bool {
+    command == AUTO_UPDATE_COMMAND
+}
+
+pub fn maybe_spawn_auto_update() {
+    let _ = spawn_auto_update_if_due();
+}
+
+pub fn run_auto_update_silent() {
+    let lock_path = trusted_auto_update_lock_path();
+    let _ = run_update();
+    if let Some(lock_path) = lock_path {
+        let _ = fs::remove_file(lock_path);
+    }
+}
 
 pub fn run_update() -> Result<UpdateReport> {
     let target = current_release_target()?;
@@ -260,6 +291,228 @@ fn artifact_binary_version(path: &Path) -> Result<String> {
     })
 }
 
+fn spawn_auto_update_if_due() -> io::Result<bool> {
+    if auto_update_disabled_by_env() {
+        return Ok(false);
+    }
+
+    let exe = env::current_exe()?;
+    if !is_installer_managed_binary(&exe) {
+        return Ok(false);
+    }
+
+    let Ok(data_dir) = crate::data_dir_from_env() else {
+        return Ok(false);
+    };
+    if crate::ensure_private_dir(&data_dir).is_err() {
+        return Ok(false);
+    }
+
+    let stamp = data_dir.join(AUTO_UPDATE_STAMP_FILE);
+    if !auto_update_due(&stamp) {
+        return Ok(false);
+    }
+    let Some(lock) = AutoUpdateLock::acquire(&data_dir)? else {
+        return Ok(false);
+    };
+    if !auto_update_due(&stamp) {
+        return Ok(false);
+    }
+    if !config_allows_auto_update(&data_dir) {
+        return Ok(false);
+    }
+    write_auto_update_stamp(&stamp)?;
+
+    let lock_path = lock.into_path();
+    let child = Command::new(&exe)
+        .arg(AUTO_UPDATE_COMMAND)
+        .env(UPDATE_INSTALL_PATH_ENV, &exe)
+        .env(AUTO_UPDATE_LOCK_PATH_ENV, &lock_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+
+    let mut child = match child {
+        Ok(child) => child,
+        Err(source) => {
+            let _ = fs::remove_file(lock_path);
+            return Err(source);
+        }
+    };
+
+    let _ = thread::Builder::new()
+        .name("jottrace-auto-update-wait".to_string())
+        .spawn(move || {
+            let _ = child.wait();
+        });
+
+    Ok(true)
+}
+
+fn auto_update_disabled_by_env() -> bool {
+    env_value(AUTO_UPDATE_ENV).as_deref() == Some("0")
+}
+
+fn config_allows_auto_update(data_dir: &Path) -> bool {
+    let path = data_dir.join(AUTO_UPDATE_CONFIG_FILE);
+    match fs::read_to_string(path) {
+        Ok(contents) if contents.trim().is_empty() => true,
+        Ok(contents) => serde_json::from_str::<JottraceConfig>(&contents)
+            .map(|config| config.auto_update.unwrap_or(true))
+            .unwrap_or(false),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    }
+}
+
+fn is_installer_managed_binary(exe: &Path) -> bool {
+    let Some(home) = env::var_os("HOME") else {
+        return false;
+    };
+    let expected = PathBuf::from(home).join(".local/bin/jottrace");
+    if fs::symlink_metadata(&expected).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return false;
+    }
+    same_parent_and_file_name(exe, &expected)
+}
+
+fn trusted_auto_update_lock_path() -> Option<PathBuf> {
+    let lock_path = env::var_os(AUTO_UPDATE_LOCK_PATH_ENV).map(PathBuf::from)?;
+    let data_dir = crate::data_dir_from_env().ok()?;
+    let expected = data_dir.join(AUTO_UPDATE_LOCK_FILE);
+    same_parent_and_file_name(&lock_path, &expected).then_some(lock_path)
+}
+
+fn same_parent_and_file_name(left: &Path, right: &Path) -> bool {
+    if left.file_name() != right.file_name() {
+        return false;
+    }
+
+    let Some(left_parent) = left.parent() else {
+        return false;
+    };
+    let Some(right_parent) = right.parent() else {
+        return false;
+    };
+
+    match (
+        fs::canonicalize(left_parent),
+        fs::canonicalize(right_parent),
+    ) {
+        (Ok(left_parent), Ok(right_parent)) => left_parent == right_parent,
+        _ => left_parent == right_parent,
+    }
+}
+
+fn auto_update_due(path: &Path) -> bool {
+    match fs::read_to_string(path) {
+        Ok(contents) => contents
+            .trim()
+            .parse::<u64>()
+            .map(|last_checked| {
+                now_unix_seconds().saturating_sub(last_checked) >= AUTO_UPDATE_INTERVAL_SECS
+            })
+            .unwrap_or(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    }
+}
+
+fn write_auto_update_stamp(path: &Path) -> io::Result<()> {
+    crate::ensure_private_file(path).map_err(jottrace_error_to_io)?;
+    fs::write(path, format!("{}\n", now_unix_seconds()))
+}
+
+struct AutoUpdateLock {
+    path: Option<PathBuf>,
+}
+
+impl AutoUpdateLock {
+    fn acquire(data_dir: &Path) -> io::Result<Option<Self>> {
+        let path = data_dir.join(AUTO_UPDATE_LOCK_FILE);
+        let mut file = match Self::create_file(&path)? {
+            Some(file) => file,
+            None if remove_stale_auto_update_lock(&path)? => {
+                let Some(file) = Self::create_file(&path)? else {
+                    return Ok(None);
+                };
+                file
+            }
+            None => return Ok(None),
+        };
+
+        if let Err(source) = writeln!(
+            file,
+            "pid={}\ncreated_at={}",
+            std::process::id(),
+            now_unix_seconds()
+        ) {
+            let _ = fs::remove_file(&path);
+            return Err(source);
+        }
+
+        Ok(Some(Self { path: Some(path) }))
+    }
+
+    fn create_file(path: &Path) -> io::Result<Option<fs::File>> {
+        let file = match crate::create_private_file(path) {
+            Ok(file) => file,
+            Err(crate::JottraceError::Io { source, .. })
+                if source.kind() == io::ErrorKind::AlreadyExists =>
+            {
+                return Ok(None);
+            }
+            Err(error) => return Err(jottrace_error_to_io(error)),
+        };
+        Ok(Some(file))
+    }
+
+    fn into_path(mut self) -> PathBuf {
+        self.path.take().expect("auto-update lock path")
+    }
+}
+
+impl Drop for AutoUpdateLock {
+    fn drop(&mut self) {
+        if let Some(path) = &self.path {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+fn remove_stale_auto_update_lock(path: &Path) -> io::Result<bool> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(true),
+        Err(_) => return Ok(false),
+    };
+
+    let Some(created_at) = lock_created_at(&contents) else {
+        return Ok(false);
+    };
+    if now_unix_seconds().saturating_sub(created_at) < AUTO_UPDATE_LOCK_STALE_SECS {
+        return Ok(false);
+    }
+
+    match fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(true),
+        Err(error) => Err(error),
+    }
+}
+
+fn lock_created_at(contents: &str) -> Option<u64> {
+    contents
+        .lines()
+        .find_map(|line| line.strip_prefix("created_at="))
+        .and_then(|value| value.parse().ok())
+}
+
+fn jottrace_error_to_io(error: crate::JottraceError) -> io::Error {
+    io::Error::other(error.to_string())
+}
+
 fn replace_installed_binary(candidate: &Path, install_path: &Path) -> Result<()> {
     let parent = install_path
         .parent()
@@ -323,6 +576,12 @@ fn unique_suffix() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |duration| duration.as_nanos())
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
 }
 
 #[cfg(test)]

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -1,11 +1,18 @@
 mod common;
 
-use common::{create_release_artifact, current_release_target, temp_root, write_fake_binary};
+use common::{
+    TempRoot, create_release_artifact, current_release_target, temp_root, write_fake_binary,
+};
 use std::fs;
-use std::process::Command;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
 
 #[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+const AUTO_UPDATE_LOCK_FILE: &str = "auto-update-check.lock";
+const HIDDEN_AUTO_UPDATE_COMMAND: &str = "__jottrace-auto-update";
 
 #[test]
 fn update_replaces_installed_binary_from_release_artifact() {
@@ -368,6 +375,254 @@ fn update_rejects_unknown_options_before_running_update() {
     assert!(stderr.contains("jottrace update --help"));
 }
 
+#[test]
+fn normal_command_spawns_quiet_background_update_for_installer_managed_binary() {
+    let Some(fixture) = AutoUpdateFixture::new("auto-update-success") else {
+        eprintln!("skipping auto-update test on unsupported test host");
+        return;
+    };
+
+    let tag = "v26.5.6";
+    fixture.create_release(tag, "26.5.6", "auto-updated binary");
+    let output = fixture.run_status(tag);
+
+    assert_quiet_status_success(&output);
+    wait_for_version(&fixture.installed, "26.5.6");
+    wait_for_missing_path(&fixture.auto_update_lock_path());
+}
+
+#[test]
+fn auto_update_env_opt_out_disables_background_update() {
+    let Some(fixture) = AutoUpdateFixture::new("auto-update-env-opt-out") else {
+        eprintln!("skipping auto-update env opt-out test on unsupported test host");
+        return;
+    };
+
+    let tag = "v26.5.6";
+    fixture.create_release(tag, "26.5.6", "auto-updated binary");
+    let mut command = fixture.status_command(&fixture.installed, tag);
+    let output = command
+        .env("JOTTRACE_AUTO_UPDATE", "0")
+        .output()
+        .expect("run opted-out jottrace status");
+
+    assert_quiet_status_success(&output);
+    assert_version_remains(&fixture.installed, env!("CARGO_PKG_VERSION"));
+    wait_for_missing_path(&fixture.auto_update_lock_path());
+}
+
+#[test]
+fn auto_update_config_opt_out_disables_background_update() {
+    let Some(fixture) = AutoUpdateFixture::new("auto-update-config-opt-out") else {
+        eprintln!("skipping auto-update config opt-out test on unsupported test host");
+        return;
+    };
+
+    let tag = "v26.5.6";
+    fixture.write_config_opt_out();
+    fixture.create_release(tag, "26.5.6", "auto-updated binary");
+    let output = fixture.run_status(tag);
+
+    assert_quiet_status_success(&output);
+    assert_version_remains(&fixture.installed, env!("CARGO_PKG_VERSION"));
+    wait_for_missing_path(&fixture.auto_update_lock_path());
+}
+
+#[test]
+fn auto_update_skips_non_installer_managed_binary() {
+    let Some(fixture) = AutoUpdateFixture::new("auto-update-non-installer") else {
+        eprintln!("skipping non-installer auto-update test on unsupported test host");
+        return;
+    };
+
+    let custom_binary = fixture.home.join("custom/bin/jottrace");
+    copy_current_test_binary_to(&custom_binary);
+    let tag = "v26.5.6";
+    fixture.create_release(tag, "26.5.6", "auto-updated binary");
+    let output = fixture.run_status_from(&custom_binary, tag);
+
+    assert_quiet_status_success(&output);
+    assert_version_remains(&custom_binary, env!("CARGO_PKG_VERSION"));
+}
+
+#[cfg(unix)]
+#[test]
+fn auto_update_skips_non_installer_binary_even_if_local_bin_symlinks_to_it() {
+    let Some(fixture) = AutoUpdateFixture::new("auto-update-symlinked-non-installer") else {
+        eprintln!("skipping symlinked non-installer auto-update test on unsupported test host");
+        return;
+    };
+
+    let custom_binary = fixture.home.join("custom/bin/jottrace");
+    copy_current_test_binary_to(&custom_binary);
+    fs::remove_file(&fixture.installed).expect("remove installer-path test binary");
+    std::os::unix::fs::symlink(&custom_binary, &fixture.installed)
+        .expect("symlink installer path to custom binary");
+
+    let tag = "v26.5.6";
+    fixture.create_release(tag, "26.5.6", "auto-updated binary");
+    let output = fixture.run_status_from(&custom_binary, tag);
+
+    assert_quiet_status_success(&output);
+    assert_version_remains(&custom_binary, env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn auto_update_check_is_throttled_after_normal_startup() {
+    let Some(fixture) = AutoUpdateFixture::new("auto-update-throttled") else {
+        eprintln!("skipping auto-update throttle test on unsupported test host");
+        return;
+    };
+
+    fixture.create_release("vcurrent", env!("CARGO_PKG_VERSION"), "current binary");
+    let first = fixture.run_status("vcurrent");
+    assert_quiet_status_success(&first);
+
+    fixture.create_release("vnext", "26.5.6", "throttled newer binary");
+    let second = fixture.run_status("vnext");
+    assert_quiet_status_success(&second);
+
+    assert_version_remains(&fixture.installed, env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn failed_background_auto_update_leaves_installed_binary_usable() {
+    let Some(fixture) = AutoUpdateFixture::new("auto-update-failed") else {
+        eprintln!("skipping auto-update failure test on unsupported test host");
+        return;
+    };
+
+    fs::create_dir_all(&fixture.releases).expect("create empty releases dir");
+    let output = fixture.run_status("vmissing");
+
+    assert_quiet_status_success(&output);
+    assert_version_remains(&fixture.installed, env!("CARGO_PKG_VERSION"));
+    wait_for_missing_path(&fixture.auto_update_lock_path());
+}
+
+#[test]
+fn auto_update_reclaims_stale_lock_and_runs() {
+    let Some(fixture) = AutoUpdateFixture::new("auto-update-stale-lock") else {
+        eprintln!("skipping stale auto-update lock test on unsupported test host");
+        return;
+    };
+
+    jottrace::ensure_private_dir(&fixture.data_dir).expect("create private data dir");
+    fs::write(fixture.auto_update_lock_path(), "pid=1\ncreated_at=0\n")
+        .expect("write stale auto-update lock");
+
+    let tag = "v26.5.6";
+    fixture.create_release(tag, "26.5.6", "auto-updated binary");
+    let output = fixture.run_status(tag);
+
+    assert_quiet_status_success(&output);
+    wait_for_version(&fixture.installed, "26.5.6");
+    wait_for_missing_path(&fixture.auto_update_lock_path());
+}
+
+#[test]
+fn auto_update_does_not_run_for_command_help() {
+    let Some(fixture) = AutoUpdateFixture::new("auto-update-help") else {
+        eprintln!("skipping auto-update help test on unsupported test host");
+        return;
+    };
+
+    fixture.create_release("v26.5.6", "26.5.6", "auto-updated binary");
+    let mut command = fixture.status_command(&fixture.installed, "v26.5.6");
+    let output = command
+        .arg("--help")
+        .output()
+        .expect("run installer-managed jottrace status --help");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("jottrace status"));
+    assert!(output.stderr.is_empty());
+    assert_version_remains(&fixture.installed, env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn hidden_auto_update_command_does_not_remove_untrusted_lock_path() {
+    let root = temp_root("hidden-auto-update-untrusted-lock");
+    let data_dir = root.join(".jottrace");
+    let untrusted_lock_path = root.join("untrusted.lock");
+    fs::create_dir_all(root.as_ref()).expect("create hidden auto-update test root");
+    fs::write(&untrusted_lock_path, "not an auto-update lock").expect("write untrusted lock path");
+
+    let output = Command::new(binary())
+        .arg(HIDDEN_AUTO_UPDATE_COMMAND)
+        .env("JOTTRACE_HOME", &data_dir)
+        .env("JOTTRACE_AUTO_UPDATE_LOCK_PATH", &untrusted_lock_path)
+        .env(
+            "JOTTRACE_UPDATE_INSTALL_PATH",
+            root.join("missing-jottrace"),
+        )
+        .output()
+        .expect("run hidden auto-update command");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        untrusted_lock_path.exists(),
+        "hidden auto-update command should not remove arbitrary env-provided paths"
+    );
+}
+
+#[test]
+fn manual_update_runs_even_when_auto_update_is_opted_out() {
+    let Some(target) = current_release_target() else {
+        eprintln!("skipping manual update opt-out test on unsupported test host");
+        return;
+    };
+
+    let root = temp_root("manual-update-auto-opt-out");
+    let home = root.join("home");
+    let releases = root.join("releases");
+    let data_dir = home.join(".jottrace");
+    let install_dir = root.join("bin");
+    let installed = install_dir.join("jottrace");
+    let tag = "v26.5.6";
+    fs::create_dir_all(&install_dir).expect("create install dir");
+    jottrace::ensure_private_dir(&data_dir).expect("create private data dir");
+    fs::write(data_dir.join("config.json"), "{\"auto_update\": false}\n")
+        .expect("write auto-update config opt-out");
+    write_fake_binary(&installed, "26.5.4", "old binary");
+    create_release_artifact(&root, &releases, tag, target, "26.5.6", "updated binary");
+
+    let output = Command::new(binary())
+        .arg("update")
+        .env("HOME", &home)
+        .env("JOTTRACE_HOME", &data_dir)
+        .env("JOTTRACE_AUTO_UPDATE", "0")
+        .env("JOTTRACE_UPDATE_INSTALL_PATH", &installed)
+        .env("JOTTRACE_VERSION", tag)
+        .env(
+            "JOTTRACE_RELEASE_BASE_URL",
+            format!("file://{}", releases.display()),
+        )
+        .output()
+        .expect("run manual jottrace update with auto-update opt-outs");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("jottrace update"));
+    assert!(stdout.contains("result: updated"));
+    assert_eq!(installed_version(&installed), "26.5.6");
+}
+
 fn create_invalid_release_artifact(
     root: &std::path::Path,
     releases: &std::path::Path,
@@ -391,6 +646,170 @@ fn create_invalid_release_artifact(
         tar_status.success(),
         "tar should create invalid test artifact"
     );
+}
+
+struct AutoUpdateFixture {
+    root: TempRoot,
+    home: std::path::PathBuf,
+    releases: std::path::PathBuf,
+    data_dir: std::path::PathBuf,
+    installed: std::path::PathBuf,
+    target: &'static str,
+}
+
+impl AutoUpdateFixture {
+    fn new(name: &str) -> Option<Self> {
+        let target = current_release_target()?;
+        let root = temp_root(name);
+        let home = root.join("home");
+        let releases = root.join("releases");
+        let data_dir = home.join(".jottrace");
+        let installed = install_current_test_binary(&home);
+
+        Some(Self {
+            root,
+            home,
+            releases,
+            data_dir,
+            installed,
+            target,
+        })
+    }
+
+    fn create_release(&self, tag: &str, version: &str, marker: &str) {
+        create_release_artifact(
+            self.root.as_ref(),
+            &self.releases,
+            tag,
+            self.target,
+            version,
+            marker,
+        );
+    }
+
+    fn write_config_opt_out(&self) {
+        jottrace::ensure_private_dir(&self.data_dir).expect("create private data dir");
+        fs::write(
+            self.data_dir.join("config.json"),
+            "{\"auto_update\": false}\n",
+        )
+        .expect("write auto-update config opt-out");
+    }
+
+    fn run_status(&self, tag: &str) -> Output {
+        self.run_status_from(&self.installed, tag)
+    }
+
+    fn run_status_from(&self, binary: &Path, tag: &str) -> Output {
+        self.status_command(binary, tag)
+            .output()
+            .expect("run jottrace status")
+    }
+
+    fn status_command(&self, binary: &Path, tag: &str) -> Command {
+        let mut command = Command::new(binary);
+        command
+            .arg("status")
+            .env("HOME", &self.home)
+            .env("JOTTRACE_HOME", &self.data_dir)
+            .env("JOTTRACE_VERSION", tag)
+            .env(
+                "JOTTRACE_RELEASE_BASE_URL",
+                format!("file://{}", self.releases.display()),
+            );
+        command
+    }
+
+    fn auto_update_lock_path(&self) -> std::path::PathBuf {
+        self.data_dir.join(AUTO_UPDATE_LOCK_FILE)
+    }
+}
+
+fn assert_quiet_status_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("jottrace status"));
+    assert!(
+        !stdout.contains("jottrace update"),
+        "foreground stdout should stay script-friendly"
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "foreground stderr should not include background update status"
+    );
+}
+
+fn install_current_test_binary(home: &Path) -> std::path::PathBuf {
+    let install_dir = home.join(".local/bin");
+    let installed = install_dir.join("jottrace");
+    copy_current_test_binary_to(&installed);
+    installed
+}
+
+fn copy_current_test_binary_to(path: &Path) {
+    fs::create_dir_all(path.parent().expect("test binary path has parent"))
+        .expect("create test binary dir");
+    fs::copy(binary(), path).expect("copy current test binary");
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod copied test binary");
+}
+
+fn wait_for_version(path: &Path, expected: &str) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if installed_version(path) == expected {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "expected {} to update to {expected}, got {}",
+                path.display(),
+                installed_version(path)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn assert_version_remains(path: &Path, expected: &str) {
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < deadline {
+        assert_eq!(installed_version(path), expected);
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_for_missing_path(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while path.exists() {
+        if Instant::now() >= deadline {
+            panic!("expected {} to be removed", path.display());
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn installed_version(path: &Path) -> String {
+    let output = Command::new(path)
+        .arg("--version")
+        .output()
+        .unwrap_or_else(|error| panic!("run {} --version: {error}", path.display()));
+    assert!(
+        output.status.success(),
+        "{} --version failed: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .strip_prefix("jottrace ")
+        .unwrap_or_else(|| panic!("unexpected version output from {}", path.display()))
+        .to_string()
 }
 
 fn binary() -> &'static str {


### PR DESCRIPTION
## Summary

- add a throttled background auto-update check for installer-managed `~/.local/bin/jottrace` binaries
- support one-shot and persistent opt-outs via `JOTTRACE_AUTO_UPDATE=0` and `~/.jottrace/config.json`
- keep foreground commands quiet while preserving the existing binary on failed background updates
- add regression coverage for throttling, opt-outs, symlinked binaries, stale locks, and the hidden updater command trust boundary

Closes #58

## Validation

- `rtk cargo clippy --all-targets -- -D warnings`
- `rtk cargo test --test update`
- `rtk cargo test`
- `rtk git diff --check`