### PR TITLE
[codex] Make CLI output agent-compact by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ in the design docs, but are not implemented as user-facing ingest sources yet.
   rewritten or truncated source files as new generations.
 - Record corrupt or unreadable source-file errors without blocking unrelated
   sessions.
+- Inspect and compact eligible raw payload rows with `jottrace compact`.
 - Browse preserved sessions, events, and unresolved ingest errors locally with
   `jottrace web`.
 - Update the installed binary from GitHub Releases with `jottrace update`.
@@ -60,17 +61,24 @@ jottrace --version
 jottrace doctor
 jottrace ingest
 jottrace status
+jottrace compact
 jottrace web
 ```
 
 `jottrace -h` is the fastest CLI discovery path. It prints the top-level
 commands and points to `jottrace <command> --help` for command-specific usage.
+High-frequency agent-facing commands use compact stdout by default:
+`status`, `doctor`, `ingest`, and `compact` print the action-relevant counts
+and next steps without journal paths or long diagnostics. Add `--details` to
+those commands when you need the database path, schema version, recent
+ingest-error fields, or full compaction counters. `jottrace events` keeps its
+explicit `--limit` / `--all` bounded-output contract.
 
 `jottrace doctor` creates or checks the local data directory at `~/.jottrace`
 and reports whether its permissions are private. On Unix systems, the directory
 is expected to use mode `0700`; the SQLite database is expected to use mode
-`0600`. It also reports unresolved ingest errors and shows recent error details
-when any exist.
+`0600`. It also reports unresolved ingest-error counts; use
+`jottrace doctor --details` to show recent error details.
 
 `jottrace ingest` scans these Claude install directories under `HOME`:
 
@@ -106,12 +114,20 @@ uses the first committed `session_start.id` as the stable session id, and links
 matching sibling `.settings.json` files through deterministic source metadata.
 
 The ingest command stores raw source event/message payloads and cheap
-deterministic session metadata, then prints the database path, discovered file
-count, total session/event counts, inserted event count, and unresolved
-ingest-error count.
+deterministic session metadata, then prints discovered file count, total
+session/event counts, inserted event count, and unresolved ingest-error count.
+Use `jottrace ingest --details` to include the database path.
 
 `jottrace status` initializes `~/.jottrace/db.sqlite` if needed and reports
-the schema version plus session, event, and unresolved ingest-error counts.
+session, event, and unresolved ingest-error counts. Use
+`jottrace status --details` to include the database path and schema version.
+
+`jottrace compact` reports eligible raw payload rows and estimated savings
+without mutating the journal. Use `jottrace compact --apply` to rewrite
+eligible rows as zstd and `jottrace compact --vacuum` to reclaim free SQLite
+pages after applying. Use `jottrace compact --details` to include the database
+path, before/after codec counts, skipped-row counters, stored byte totals, and
+SQLite reclaimable-page counters.
 
 `jottrace web` starts a read-only web UI bound to `127.0.0.1`, prints the URL
 and database path, and serves data from the existing SQLite journal. The UI lets
@@ -198,6 +214,7 @@ Run the development binary with:
 cargo run -- doctor
 cargo run -- ingest
 cargo run -- status
+cargo run -- compact
 cargo run -- web
 ```
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -57,7 +57,7 @@ pub struct CompactReport {
     pub unresolved_ingest_errors: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct EventStorageStats {
     raw_events: u64,
     zstd_events: u64,
@@ -92,6 +92,13 @@ type ApplyBatchFn =
     fn(&std::path::Path, &mut Connection, Vec<CompactionUpdate>) -> Result<AppliedBatch>;
 
 pub fn run_compact(options: CompactOptions) -> Result<CompactReport> {
+    run_compact_with_diagnostics(options, true)
+}
+
+pub fn run_compact_with_diagnostics(
+    options: CompactOptions,
+    include_diagnostics: bool,
+) -> Result<CompactReport> {
     validate_compact_options(options)?;
 
     let data_dir = data_dir_from_env()?;
@@ -101,19 +108,24 @@ pub fn run_compact(options: CompactOptions) -> Result<CompactReport> {
     };
     let db_path = data_dir.join(DB_FILE_NAME);
     let mut conn = open_database(&db_path)?;
-    let before = event_storage_stats(&db_path, &conn)?;
-    let sqlite_reclaimable_bytes_before = sqlite_reclaimable_bytes(&db_path, &conn)?;
+    let before = if include_diagnostics {
+        event_storage_stats(&db_path, &conn)?
+    } else {
+        EventStorageStats::default()
+    };
+    let sqlite_reclaimable_bytes_before = if include_diagnostics {
+        sqlite_reclaimable_bytes(&db_path, &conn)?
+    } else {
+        0
+    };
     let (raw_analysis, after) = match options.mode {
         CompactMode::DryRun => {
             let analysis =
                 scan_raw_payload_candidates(&db_path, &mut conn, options.batch_size, None)?;
-            let after = EventStorageStats {
-                raw_events: before.raw_events.saturating_sub(analysis.eligible_events),
-                zstd_events: before.zstd_events + analysis.eligible_events,
-                unsupported_codec_events: before.unsupported_codec_events,
-                stored_bytes: before
-                    .stored_bytes
-                    .saturating_sub(analysis.estimated_bytes_saved),
+            let after = if include_diagnostics {
+                compacted_storage_estimate(&before, analysis.eligible_events, &analysis)
+            } else {
+                EventStorageStats::default()
             };
             (analysis, after)
         }
@@ -124,13 +136,10 @@ pub fn run_compact(options: CompactOptions) -> Result<CompactReport> {
                 options.batch_size,
                 Some(apply_update_batch),
             )?;
-            let after = EventStorageStats {
-                raw_events: before.raw_events.saturating_sub(analysis.converted_events),
-                zstd_events: before.zstd_events + analysis.converted_events,
-                unsupported_codec_events: before.unsupported_codec_events,
-                stored_bytes: before
-                    .stored_bytes
-                    .saturating_sub(analysis.estimated_bytes_saved),
+            let after = if include_diagnostics {
+                compacted_storage_estimate(&before, analysis.converted_events, &analysis)
+            } else {
+                EventStorageStats::default()
             };
             (analysis, after)
         }
@@ -140,7 +149,11 @@ pub fn run_compact(options: CompactOptions) -> Result<CompactReport> {
             (RawPayloadAnalysis::default(), before)
         }
     };
-    let sqlite_reclaimable_bytes = sqlite_reclaimable_bytes(&db_path, &conn)?;
+    let sqlite_reclaimable_bytes = if include_diagnostics || options.mode != CompactMode::DryRun {
+        sqlite_reclaimable_bytes(&db_path, &conn)?
+    } else {
+        0
+    };
     let unresolved_ingest_errors = unresolved_ingest_error_count_from_connection(&db_path, &conn)?;
 
     Ok(CompactReport {
@@ -165,6 +178,21 @@ pub fn run_compact(options: CompactOptions) -> Result<CompactReport> {
         sqlite_reclaimable_bytes,
         unresolved_ingest_errors,
     })
+}
+
+fn compacted_storage_estimate(
+    before: &EventStorageStats,
+    converted_events: u64,
+    analysis: &RawPayloadAnalysis,
+) -> EventStorageStats {
+    EventStorageStats {
+        raw_events: before.raw_events.saturating_sub(converted_events),
+        zstd_events: before.zstd_events + converted_events,
+        unsupported_codec_events: before.unsupported_codec_events,
+        stored_bytes: before
+            .stored_bytes
+            .saturating_sub(analysis.estimated_bytes_saved),
+    }
 }
 
 fn validate_compact_options(options: CompactOptions) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,19 @@ pub struct DoctorReport {
     pub recent_ingest_errors: Vec<IngestErrorSummary>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DoctorOptions {
+    pub include_recent_errors: bool,
+}
+
+impl Default for DoctorOptions {
+    fn default() -> Self {
+        Self {
+            include_recent_errors: true,
+        }
+    }
+}
+
 /// Resolve the data directory from the environment.
 ///
 /// `JOTTRACE_HOME` comes first because tests and future integrations need a
@@ -193,17 +206,25 @@ pub fn data_dir_from_env() -> Result<PathBuf> {
 
 /// Verify the local runtime can safely create and protect its private state.
 pub fn run_doctor() -> Result<DoctorReport> {
+    run_doctor_with_options(DoctorOptions::default())
+}
+
+pub fn run_doctor_with_options(options: DoctorOptions) -> Result<DoctorReport> {
     let data_dir = data_dir_from_env()?;
     ensure_private_dir(&data_dir)?;
     let db_path = data_dir.join(storage::DB_FILE_NAME);
     let conn = storage::open_database(&db_path)?;
     let unresolved_ingest_error_count =
         storage::unresolved_ingest_error_count_from_connection(&db_path, &conn)?;
-    let ingest_errors = storage::unresolved_ingest_errors_from_connection(
-        &db_path,
-        &conn,
-        DOCTOR_INGEST_ERROR_LIMIT,
-    )?;
+    let ingest_errors = if options.include_recent_errors {
+        storage::unresolved_ingest_errors_from_connection(
+            &db_path,
+            &conn,
+            DOCTOR_INGEST_ERROR_LIMIT,
+        )?
+    } else {
+        Vec::new()
+    };
     Ok(DoctorReport {
         data_dir,
         unresolved_ingest_error_count,

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,25 @@ enum WebCommand {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CompactCliOptions {
+    compact_options: jottrace::CompactOptions,
+    details: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CompactCommand {
-    Run(jottrace::CompactOptions),
+    Run(CompactCliOptions),
+    Help,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DetailOptions {
+    details: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DetailCommand {
+    Run(DetailOptions),
     Help,
 }
 
@@ -278,24 +295,26 @@ fn parse_web_command(
 }
 
 fn run_ingest_command(args: impl Iterator<Item = String>) -> ExitCode {
-    match parse_simple_command("ingest", args) {
-        Ok(SimpleCommand::Help) => {
+    let options = match parse_detail_command("ingest", args) {
+        Ok(DetailCommand::Help) => {
             print_ingest_help();
             return ExitCode::SUCCESS;
         }
-        Ok(SimpleCommand::Run) => {}
+        Ok(DetailCommand::Run(options)) => options,
         Err(message) => {
             eprintln!("{message}");
             eprintln!("run `jottrace ingest --help` for usage");
             return ExitCode::from(2);
         }
-    }
+    };
     jottrace::update::maybe_spawn_auto_update();
 
     match jottrace::run_ingest() {
         Ok(report) => {
             println!("jottrace ingest");
-            println!("db: {}", report.db_path.display());
+            if options.details {
+                println!("db: {}", report.db_path.display());
+            }
             println!("files: {}", report.file_count);
             println!("sessions: {}", report.session_count);
             println!("events: {}", report.event_count);
@@ -322,6 +341,23 @@ fn parse_simple_command(
         Some(arg) if arg == "--help" || arg == "-h" => Ok(SimpleCommand::Help),
         Some(arg) => Err(format!("unknown {command} option: {arg}")),
     }
+}
+
+fn parse_detail_command(
+    command: &str,
+    args: impl Iterator<Item = String>,
+) -> std::result::Result<DetailCommand, String> {
+    let mut options = DetailOptions { details: false };
+
+    for arg in args {
+        match arg.as_str() {
+            "--help" | "-h" => return Ok(DetailCommand::Help),
+            "--details" => options.details = true,
+            _ => return Err(format!("unknown {command} option: {arg}")),
+        }
+    }
+
+    Ok(DetailCommand::Run(options))
 }
 
 fn run_update_command(args: impl Iterator<Item = String>) -> ExitCode {
@@ -361,8 +397,8 @@ fn run_auto_update_background_command(mut args: impl Iterator<Item = String>) ->
 }
 
 fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_compact_command(args) {
-        Ok(CompactCommand::Run(options)) => options,
+    let cli_options = match parse_compact_command(args) {
+        Ok(CompactCommand::Run(cli_options)) => cli_options,
         Ok(CompactCommand::Help) => {
             print_compact_help();
             return ExitCode::SUCCESS;
@@ -375,45 +411,56 @@ fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::run_compact(options) {
+    match jottrace::compact::run_compact_with_diagnostics(
+        cli_options.compact_options,
+        cli_options.details,
+    ) {
         Ok(report) => {
             println!("jottrace compact");
-            println!("db: {}", report.db_path.display());
             println!("mode: {}", compact_mode_name(report.mode));
-            if report.mode != jottrace::CompactMode::Vacuum {
+            if cli_options.details {
+                println!("db: {}", report.db_path.display());
+            }
+            if cli_options.details && report.mode != jottrace::CompactMode::Vacuum {
                 println!("batch_size: {}", report.batch_size);
             }
-            println!("raw_events_before: {}", report.raw_events_before);
-            println!("zstd_events_before: {}", report.zstd_events_before);
-            println!("raw_events_after: {}", report.raw_events_after);
-            println!("zstd_events_after: {}", report.zstd_events_after);
-            println!(
-                "unsupported_codec_events: {}",
-                report.unsupported_codec_events
-            );
             println!("eligible_raw_events: {}", report.eligible_raw_events);
-            println!("converted_events: {}", report.converted_events);
-            println!("skipped_raw_events: {}", report.skipped_raw_events);
-            println!("skipped_small_events: {}", report.skipped_small_events);
-            println!(
-                "skipped_not_smaller_events: {}",
-                report.skipped_not_smaller_events
-            );
-            println!(
-                "skipped_round_trip_failed_events: {}",
-                report.skipped_round_trip_failed_events
-            );
-            println!("stored_bytes_before: {}", report.stored_bytes_before);
-            println!("stored_bytes_after: {}", report.stored_bytes_after);
+            if cli_options.details || report.mode == jottrace::CompactMode::Apply {
+                println!("converted_events: {}", report.converted_events);
+            }
             println!("estimated_bytes_saved: {}", report.estimated_bytes_saved);
-            println!(
-                "sqlite_reclaimable_bytes_before: {}",
-                report.sqlite_reclaimable_bytes_before
-            );
-            println!(
-                "sqlite_reclaimable_bytes: {}",
-                report.sqlite_reclaimable_bytes
-            );
+            if cli_options.details {
+                println!("raw_events_before: {}", report.raw_events_before);
+                println!("zstd_events_before: {}", report.zstd_events_before);
+                println!("raw_events_after: {}", report.raw_events_after);
+                println!("zstd_events_after: {}", report.zstd_events_after);
+                println!(
+                    "unsupported_codec_events: {}",
+                    report.unsupported_codec_events
+                );
+                println!("skipped_raw_events: {}", report.skipped_raw_events);
+                println!("skipped_small_events: {}", report.skipped_small_events);
+                println!(
+                    "skipped_not_smaller_events: {}",
+                    report.skipped_not_smaller_events
+                );
+                println!(
+                    "skipped_round_trip_failed_events: {}",
+                    report.skipped_round_trip_failed_events
+                );
+                println!("stored_bytes_before: {}", report.stored_bytes_before);
+                println!("stored_bytes_after: {}", report.stored_bytes_after);
+                println!(
+                    "sqlite_reclaimable_bytes_before: {}",
+                    report.sqlite_reclaimable_bytes_before
+                );
+            }
+            if cli_options.details || report.mode != jottrace::CompactMode::DryRun {
+                println!(
+                    "sqlite_reclaimable_bytes: {}",
+                    report.sqlite_reclaimable_bytes
+                );
+            }
             println!(
                 "unresolved_ingest_errors: {}",
                 report.unresolved_ingest_errors
@@ -423,9 +470,11 @@ fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
                     "next: rerun with `jottrace compact --apply` to rewrite eligible payloads"
                 );
             }
-            println!(
-                "disk_reclaim: after applying, run `jottrace compact --vacuum` to reclaim free SQLite pages"
-            );
+            if cli_options.details || report.mode == jottrace::CompactMode::Apply {
+                println!(
+                    "disk_reclaim: after applying, run `jottrace compact --vacuum` to reclaim free SQLite pages"
+                );
+            }
             ExitCode::SUCCESS
         }
         Err(error) => {
@@ -439,12 +488,14 @@ fn parse_compact_command(
     mut args: impl Iterator<Item = String>,
 ) -> std::result::Result<CompactCommand, String> {
     let mut options = jottrace::CompactOptions::default();
+    let mut details = false;
     let mut explicit_mode = false;
     let mut batch_size_provided = false;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--help" | "-h" => return Ok(CompactCommand::Help),
+            "--details" => details = true,
             "--apply" => {
                 if explicit_mode {
                     return Err("compact accepts only one of --apply or --vacuum".to_string());
@@ -488,7 +539,10 @@ fn parse_compact_command(
         }
     }
 
-    Ok(CompactCommand::Run(options))
+    Ok(CompactCommand::Run(CompactCliOptions {
+        compact_options: options,
+        details,
+    }))
 }
 
 fn compact_mode_name(mode: jottrace::CompactMode) -> &'static str {
@@ -500,58 +554,67 @@ fn compact_mode_name(mode: jottrace::CompactMode) -> &'static str {
 }
 
 fn run_doctor_command(args: impl Iterator<Item = String>) -> ExitCode {
-    match parse_simple_command("doctor", args) {
-        Ok(SimpleCommand::Help) => {
+    let options = match parse_detail_command("doctor", args) {
+        Ok(DetailCommand::Help) => {
             print_doctor_help();
             return ExitCode::SUCCESS;
         }
-        Ok(SimpleCommand::Run) => {}
+        Ok(DetailCommand::Run(options)) => options,
         Err(message) => {
             eprintln!("{message}");
             eprintln!("run `jottrace doctor --help` for usage");
             return ExitCode::from(2);
         }
-    }
+    };
     jottrace::update::maybe_spawn_auto_update();
 
     // Keep the CLI responsible for presentation while the library owns the
     // filesystem checks. That makes future commands easier to test directly.
-    match jottrace::run_doctor() {
+    match jottrace::run_doctor_with_options(jottrace::DoctorOptions {
+        include_recent_errors: options.details,
+    }) {
         Ok(report) => {
             println!("jottrace doctor");
-            println!("data_dir: {} (ok)", report.data_dir.display());
+            if options.details {
+                println!("data_dir: {} (ok)", report.data_dir.display());
+            }
             println!("permissions: private (ok)");
             println!(
                 "unresolved_ingest_errors: {}",
                 report.unresolved_ingest_error_count
             );
-            if !report.recent_ingest_errors.is_empty() {
+            if !options.details && report.unresolved_ingest_error_count > 0 {
+                println!("next: run `jottrace doctor --details` to inspect recent ingest errors");
+            }
+            if options.details && !report.recent_ingest_errors.is_empty() {
                 println!(
                     "recent_ingest_errors: {}",
                     report.recent_ingest_errors.len()
                 );
             }
-            for ingest_error in &report.recent_ingest_errors {
-                println!("recent_ingest_error:");
-                println!("  source: {}", ingest_error.source);
-                if let Some(source_session_id) = &ingest_error.source_session_id {
-                    println!("  source_session_id: {source_session_id}");
+            if options.details {
+                for ingest_error in &report.recent_ingest_errors {
+                    println!("recent_ingest_error:");
+                    println!("  source: {}", ingest_error.source);
+                    if let Some(source_session_id) = &ingest_error.source_session_id {
+                        println!("  source_session_id: {source_session_id}");
+                    }
+                    println!("  file: {}", ingest_error.file_path.display());
+                    if let Some(line_number) = ingest_error.line_number {
+                        println!("  line: {line_number}");
+                    }
+                    if let Some(byte_offset) = ingest_error.byte_offset {
+                        println!("  byte_offset: {byte_offset}");
+                    }
+                    if let Some(generation) = ingest_error.generation {
+                        println!("  generation: {generation}");
+                    }
+                    println!("  kind: {}", ingest_error.error_kind);
+                    println!("  first_seen_at: {}", ingest_error.first_seen_at);
+                    println!("  last_seen_at: {}", ingest_error.last_seen_at);
+                    println!("  occurrences: {}", ingest_error.occurrence_count);
+                    println!("  message: {}", ingest_error.message);
                 }
-                println!("  file: {}", ingest_error.file_path.display());
-                if let Some(line_number) = ingest_error.line_number {
-                    println!("  line: {line_number}");
-                }
-                if let Some(byte_offset) = ingest_error.byte_offset {
-                    println!("  byte_offset: {byte_offset}");
-                }
-                if let Some(generation) = ingest_error.generation {
-                    println!("  generation: {generation}");
-                }
-                println!("  kind: {}", ingest_error.error_kind);
-                println!("  first_seen_at: {}", ingest_error.first_seen_at);
-                println!("  last_seen_at: {}", ingest_error.last_seen_at);
-                println!("  occurrences: {}", ingest_error.occurrence_count);
-                println!("  message: {}", ingest_error.message);
             }
             ExitCode::SUCCESS
         }
@@ -563,25 +626,27 @@ fn run_doctor_command(args: impl Iterator<Item = String>) -> ExitCode {
 }
 
 fn run_status_command(args: impl Iterator<Item = String>) -> ExitCode {
-    match parse_simple_command("status", args) {
-        Ok(SimpleCommand::Help) => {
+    let options = match parse_detail_command("status", args) {
+        Ok(DetailCommand::Help) => {
             print_status_help();
             return ExitCode::SUCCESS;
         }
-        Ok(SimpleCommand::Run) => {}
+        Ok(DetailCommand::Run(options)) => options,
         Err(message) => {
             eprintln!("{message}");
             eprintln!("run `jottrace status --help` for usage");
             return ExitCode::from(2);
         }
-    }
+    };
     jottrace::update::maybe_spawn_auto_update();
 
     match jottrace::run_status() {
         Ok(report) => {
             println!("jottrace status");
-            println!("db: {}", report.db_path.display());
-            println!("schema_version: {}", report.schema_version);
+            if options.details {
+                println!("db: {}", report.db_path.display());
+                println!("schema_version: {}", report.schema_version);
+            }
             println!("sessions: {}", report.session_count);
             println!("events: {}", report.event_count);
             println!(
@@ -604,13 +669,13 @@ fn print_help() {
     println!("Preserve AI coding-session transcripts into a local journal.");
     println!();
     println!("Usage:");
-    println!("  jottrace compact [--apply|--vacuum] [--batch-size <n>]");
-    println!("  jottrace doctor");
+    println!("  jottrace compact [--apply|--vacuum] [--batch-size <n>] [--details]");
+    println!("  jottrace doctor [--details]");
     println!(
         "  jottrace events --source <source> --session <source_session_id> (--limit <n>|--all)"
     );
-    println!("  jottrace ingest");
-    println!("  jottrace status");
+    println!("  jottrace ingest [--details]");
+    println!("  jottrace status [--details]");
     println!("  jottrace update");
     println!("  jottrace upgrade");
     println!("  jottrace web [--port <port>] [--once]");
@@ -623,12 +688,13 @@ fn print_compact_help() {
     println!("Report or rewrite eligible raw event payloads as zstd.");
     println!();
     println!("Usage:");
-    println!("  jottrace compact [--apply|--vacuum] [--batch-size <n>]");
+    println!("  jottrace compact [--apply|--vacuum] [--batch-size <n>] [--details]");
     println!();
     println!("Options:");
     println!("  --apply           Rewrite eligible raw payload rows in bounded batches");
     println!("  --vacuum          Reclaim free SQLite pages after compaction");
     println!("  --batch-size <n>  Raw rows to inspect per batch (default: 1000, max: 10000)");
+    println!("  --details         Include database path and full compaction counters");
 }
 
 fn print_events_help() {
@@ -652,7 +718,10 @@ fn print_doctor_help() {
     println!("Check the journal directory, database, permissions, and ingest errors.");
     println!();
     println!("Usage:");
-    println!("  jottrace doctor");
+    println!("  jottrace doctor [--details]");
+    println!();
+    println!("Options:");
+    println!("  --details  Include data directory and recent ingest-error fields");
 }
 
 fn print_ingest_help() {
@@ -660,7 +729,10 @@ fn print_ingest_help() {
     println!("Preserve Claude and Codex JSONL sessions into the local journal.");
     println!();
     println!("Usage:");
-    println!("  jottrace ingest");
+    println!("  jottrace ingest [--details]");
+    println!();
+    println!("Options:");
+    println!("  --details  Include the database path");
 }
 
 fn print_status_help() {
@@ -668,7 +740,10 @@ fn print_status_help() {
     println!("Print journal schema, session, event, and ingest-error counts.");
     println!();
     println!("Usage:");
-    println!("  jottrace status");
+    println!("  jottrace status [--details]");
+    println!();
+    println!("Options:");
+    println!("  --details  Include the database path and schema version");
 }
 
 fn print_update_help() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -229,6 +229,28 @@ fn doctor_creates_private_data_dir() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("jottrace doctor"));
     assert!(stdout.contains("permissions: private (ok)"));
+    assert!(stdout.contains("unresolved_ingest_errors: 0"));
+    assert!(!stdout.contains("data_dir: "));
+    assert!(!stdout.contains("next: "));
+
+    let detailed = Command::new(binary())
+        .args(["doctor", "--details"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace doctor --details");
+
+    assert!(
+        detailed.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&detailed.stdout),
+        String::from_utf8_lossy(&detailed.stderr)
+    );
+
+    let detailed_stdout = String::from_utf8_lossy(&detailed.stdout);
+    assert!(detailed_stdout.contains("jottrace doctor"));
+    assert!(detailed_stdout.contains(&format!("data_dir: {} (ok)", data_dir.display())));
+    assert!(detailed_stdout.contains("permissions: private (ok)"));
+    assert!(detailed_stdout.contains("unresolved_ingest_errors: 0"));
 
     #[cfg(unix)]
     assert_eq!(mode(&data_dir), 0o700);
@@ -259,6 +281,24 @@ fn status_reports_empty_fresh_database() {
     assert!(stdout.contains("sessions: 0"));
     assert!(stdout.contains("events: 0"));
     assert!(stdout.contains("unresolved_ingest_errors: 0"));
+    assert!(!stdout.contains("db: "));
+    assert!(!stdout.contains("schema_version: "));
+
+    let detailed = Command::new(binary())
+        .args(["status", "--details"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace status --details");
+
+    assert!(
+        detailed.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&detailed.stdout),
+        String::from_utf8_lossy(&detailed.stderr)
+    );
+    let detailed_stdout = String::from_utf8_lossy(&detailed.stdout);
+    assert!(detailed_stdout.contains(&format!("db: {}", db_path(&data_dir).display())));
+    assert!(detailed_stdout.contains("schema_version: "));
 
     let db_path = db_path(&data_dir);
     assert!(
@@ -296,10 +336,31 @@ fn doctor_reports_unresolved_ingest_errors() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("unresolved_ingest_errors: 1"));
-    assert!(stdout.contains(CORRUPT_FIXTURE_SESSION_ID));
-    assert!(stdout.contains("line: 2"));
-    assert!(stdout.contains("kind: invalid_json"));
-    assert!(stdout.contains("message: "));
+    assert!(stdout.contains("next: run `jottrace doctor --details`"));
+    assert!(!stdout.contains("data_dir: "));
+    assert!(!stdout.contains(CORRUPT_FIXTURE_SESSION_ID));
+    assert!(!stdout.contains("kind: invalid_json"));
+    assert!(!stdout.contains("message: "));
+
+    let detailed = Command::new(binary())
+        .args(["doctor", "--details"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace doctor --details");
+
+    assert!(
+        detailed.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&detailed.stdout),
+        String::from_utf8_lossy(&detailed.stderr)
+    );
+
+    let detailed_stdout = String::from_utf8_lossy(&detailed.stdout);
+    assert!(detailed_stdout.contains("data_dir: "));
+    assert!(detailed_stdout.contains(CORRUPT_FIXTURE_SESSION_ID));
+    assert!(detailed_stdout.contains("line: 2"));
+    assert!(detailed_stdout.contains("kind: invalid_json"));
+    assert!(detailed_stdout.contains("message: "));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -702,7 +763,27 @@ fn ingest_preserves_claude_cli_fixture_and_status_reports_counts() {
     let data_dir = root.join(".jottrace");
     let session_file = install_primary_claude_fixture(&root);
 
-    run_ingest(&root, &data_dir);
+    let ingest = run_ingest(&root, &data_dir);
+    assert!(ingest.contains("sessions: 1"));
+    assert!(ingest.contains("events: 12"));
+    assert!(ingest.contains("inserted_events: 12"));
+    assert!(ingest.contains("unresolved_ingest_errors: 0"));
+    assert!(!ingest.contains("db: "));
+
+    let detailed_ingest = Command::new(binary())
+        .args(["ingest", "--details"])
+        .env("HOME", &root)
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace ingest --details");
+    assert!(
+        detailed_ingest.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&detailed_ingest.stdout),
+        String::from_utf8_lossy(&detailed_ingest.stderr)
+    );
+    let detailed_stdout = String::from_utf8_lossy(&detailed_ingest.stdout);
+    assert!(detailed_stdout.contains(&format!("db: {}", db_path(&data_dir).display())));
 
     let status = Command::new(binary())
         .arg("status")
@@ -2365,19 +2446,43 @@ fn compact_dry_run_reports_savings_without_mutating_payloads() {
     let stdout = String::from_utf8(output.stdout).expect("compact stdout should be utf-8");
     assert!(stdout.contains("jottrace compact"));
     assert!(stdout.contains("mode: dry-run"));
-    assert!(stdout.contains("raw_events_before: 1"));
-    assert!(stdout.contains("zstd_events_before: 0"));
     assert!(stdout.contains("eligible_raw_events: 1"));
-    assert!(stdout.contains("converted_events: 0"));
     assert!(stdout.contains("unresolved_ingest_errors: 0"));
+    assert!(stdout.contains("next: rerun with `jottrace compact --apply`"));
+    assert!(!stdout.contains("db: "));
+    assert!(!stdout.contains("raw_events_before: "));
+    assert!(!stdout.contains("zstd_events_before: "));
+    assert!(!stdout.contains("converted_events: "));
+    assert!(!stdout.contains("stored_bytes_before: "));
+    assert!(!stdout.contains("sqlite_reclaimable_bytes: "));
     assert!(
         compact_metric(&stdout, "estimated_bytes_saved") > 0,
         "{stdout}"
     );
+
+    let detailed = Command::new(binary())
+        .args(["compact", "--details"])
+        .env("JOTTRACE_HOME", &data_dir)
+        .output()
+        .expect("run jottrace compact --details");
+
     assert!(
-        compact_metric(&stdout, "stored_bytes_after")
-            < compact_metric(&stdout, "stored_bytes_before"),
-        "{stdout}"
+        detailed.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&detailed.stdout),
+        String::from_utf8_lossy(&detailed.stderr)
+    );
+    let detailed_stdout =
+        String::from_utf8(detailed.stdout).expect("compact stdout should be utf-8");
+    assert!(detailed_stdout.contains(&format!("db: {}", db_path(&data_dir).display())));
+    assert!(detailed_stdout.contains("raw_events_before: 1"));
+    assert!(detailed_stdout.contains("zstd_events_before: 0"));
+    assert!(detailed_stdout.contains("eligible_raw_events: 1"));
+    assert!(detailed_stdout.contains("converted_events: 0"));
+    assert!(
+        compact_metric(&detailed_stdout, "stored_bytes_after")
+            < compact_metric(&detailed_stdout, "stored_bytes_before"),
+        "{detailed_stdout}"
     );
 
     let conn = Connection::open(db_path(&data_dir)).expect("open preserved db");
@@ -2404,7 +2509,7 @@ fn compact_apply_rewrites_only_eligible_raw_rows_and_is_idempotent() {
     drop(conn);
 
     let output = Command::new(binary())
-        .args(["compact", "--apply", "--batch-size", "2"])
+        .args(["compact", "--apply", "--batch-size", "2", "--details"])
         .env("JOTTRACE_HOME", &data_dir)
         .output()
         .expect("run jottrace compact --apply");
@@ -2450,7 +2555,7 @@ fn compact_apply_rewrites_only_eligible_raw_rows_and_is_idempotent() {
     drop(conn);
 
     let second = Command::new(binary())
-        .args(["compact", "--apply"])
+        .args(["compact", "--apply", "--details"])
         .env("JOTTRACE_HOME", &data_dir)
         .output()
         .expect("rerun jottrace compact --apply");
@@ -2475,7 +2580,7 @@ fn compact_vacuum_reclaims_free_sqlite_pages_after_apply() {
     insert_single_raw_compaction_session(&data_dir, &payload);
 
     let apply = Command::new(binary())
-        .args(["compact", "--apply"])
+        .args(["compact", "--apply", "--details"])
         .env("JOTTRACE_HOME", &data_dir)
         .output()
         .expect("run jottrace compact --apply");
@@ -2492,7 +2597,7 @@ fn compact_vacuum_reclaims_free_sqlite_pages_after_apply() {
     );
 
     let vacuum = Command::new(binary())
-        .args(["compact", "--vacuum"])
+        .args(["compact", "--vacuum", "--details"])
         .env("JOTTRACE_HOME", &data_dir)
         .output()
         .expect("run jottrace compact --vacuum");


### PR DESCRIPTION
## Summary

- Make `jottrace status`, `doctor`, `ingest`, and `compact` print compact agent-facing output by default.
- Add `--details` for database paths, schema versions, recent ingest-error fields, and full compaction counters.
- Keep `events` on its explicit bounded-output contract and update README/help text for the new defaults.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `TMPDIR=/private/tmp cargo test`

Closes #55