### PR TITLE
Reduce complexity: consolidate duplicated scaffolding into shared helpers

### DIFF
--- a/src/compact.rs
+++ b/src/compact.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use crate::storage::{
     DB_FILE_NAME, RAW_CODEC, ZSTD_CODEC, ZSTD_MIN_PAYLOAD_BYTES, decode_event_payload,
-    encode_event_payload, open_database, sqlite_error,
+    encode_event_payload, open_database, query_one, sqlite_error,
     unresolved_ingest_error_count_from_connection,
 };
 use crate::{JottraceError, Result, data_dir_from_env};
@@ -434,22 +434,24 @@ fn raw_event_batch(
 }
 
 fn count_small_raw_events(path: &std::path::Path, conn: &Connection) -> Result<u64> {
-    let count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*)
+    let count: i64 = query_one(
+        path,
+        conn,
+        "SELECT COUNT(*)
              FROM events
              WHERE codec = ?1
                AND payload_size < ?2",
-            params![RAW_CODEC, ZSTD_MIN_PAYLOAD_BYTES as i64],
-            |row| row.get(0),
-        )
-        .map_err(|source| sqlite_error(path, source))?;
+        params![RAW_CODEC, ZSTD_MIN_PAYLOAD_BYTES as i64],
+        |row| row.get(0),
+    )?;
     Ok(count as u64)
 }
 
 fn event_storage_stats(path: &std::path::Path, conn: &Connection) -> Result<EventStorageStats> {
     let (raw_events, zstd_events, unsupported_codec_events, stored_bytes): (i64, i64, i64, i64) =
-        conn.query_row(
+        query_one(
+            path,
+            conn,
             "SELECT
                 COALESCE(SUM(CASE WHEN codec = ?1 THEN 1 ELSE 0 END), 0),
                 COALESCE(SUM(CASE WHEN codec = ?2 THEN 1 ELSE 0 END), 0),
@@ -458,8 +460,7 @@ fn event_storage_stats(path: &std::path::Path, conn: &Connection) -> Result<Even
              FROM events",
             params![RAW_CODEC, ZSTD_CODEC],
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-        )
-        .map_err(|source| sqlite_error(path, source))?;
+        )?;
 
     Ok(EventStorageStats {
         raw_events: raw_events as u64,
@@ -470,11 +471,7 @@ fn event_storage_stats(path: &std::path::Path, conn: &Connection) -> Result<Even
 }
 
 fn sqlite_reclaimable_bytes(path: &std::path::Path, conn: &Connection) -> Result<u64> {
-    let page_size: i64 = conn
-        .query_row("PRAGMA page_size", [], |row| row.get(0))
-        .map_err(|source| sqlite_error(path, source))?;
-    let freelist_count: i64 = conn
-        .query_row("PRAGMA freelist_count", [], |row| row.get(0))
-        .map_err(|source| sqlite_error(path, source))?;
+    let page_size: i64 = query_one(path, conn, "PRAGMA page_size", [], |row| row.get(0))?;
+    let freelist_count: i64 = query_one(path, conn, "PRAGMA freelist_count", [], |row| row.get(0))?;
     Ok((page_size as u64).saturating_mul(freelist_count as u64))
 }

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use crate::storage::{
     DB_FILE_NAME, RAW_CODEC, ZSTD_CODEC, ZSTD_MIN_PAYLOAD_BYTES, count, decode_event_payload,
-    encode_event_payload, open_database, query_one, row_value, sqlite_error,
+    encode_event_payload, map_sqlite_error, open_database, query_one, row_value,
     unresolved_ingest_error_count_from_connection,
 };
 use crate::{JottraceError, Result, data_dir_from_env};
@@ -145,7 +145,7 @@ pub fn run_compact_with_diagnostics(
         }
         CompactMode::Vacuum => {
             conn.execute_batch("VACUUM;")
-                .map_err(|source| sqlite_error(&db_path, source))?;
+                .map_err(map_sqlite_error(&db_path))?;
             (RawPayloadAnalysis::default(), before)
         }
     };
@@ -281,9 +281,7 @@ fn apply_update_batch(
         return Ok(AppliedBatch::default());
     }
 
-    let tx = conn
-        .transaction()
-        .map_err(|source| sqlite_error(path, source))?;
+    let tx = conn.transaction().map_err(map_sqlite_error(path))?;
     let mut converted_events = 0;
     let mut saved_bytes = 0;
     {
@@ -298,7 +296,7 @@ fn apply_update_batch(
                    AND seq = ?6
                    AND codec = ?7",
             )
-            .map_err(|source| sqlite_error(path, source))?;
+            .map_err(map_sqlite_error(path))?;
         for update in updates {
             let updated = statement
                 .execute(params![
@@ -310,14 +308,14 @@ fn apply_update_batch(
                     update.key.seq,
                     RAW_CODEC,
                 ])
-                .map_err(|source| sqlite_error(path, source))?;
+                .map_err(map_sqlite_error(path))?;
             if updated > 0 {
                 converted_events += updated as u64;
                 saved_bytes += update.saved_bytes;
             }
         }
     }
-    tx.commit().map_err(|source| sqlite_error(path, source))?;
+    tx.commit().map_err(map_sqlite_error(path))?;
     Ok(AppliedBatch {
         converted_events,
         saved_bytes,
@@ -397,9 +395,7 @@ fn raw_event_batch(
              LIMIT ?3"
         }
     };
-    let mut statement = conn
-        .prepare(sql)
-        .map_err(|source| sqlite_error(path, source))?;
+    let mut statement = conn.prepare(sql).map_err(map_sqlite_error(path))?;
     let mut rows = match cursor {
         Some(cursor) => statement
             .query(params![
@@ -410,17 +406,17 @@ fn raw_event_batch(
                 cursor.seq,
                 batch_size
             ])
-            .map_err(|source| sqlite_error(path, source))?,
+            .map_err(map_sqlite_error(path))?,
         None => statement
             .query(params![
                 RAW_CODEC,
                 ZSTD_MIN_PAYLOAD_BYTES as i64,
                 batch_size
             ])
-            .map_err(|source| sqlite_error(path, source))?,
+            .map_err(map_sqlite_error(path))?,
     };
     let mut events = Vec::new();
-    while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
+    while let Some(row) = rows.next().map_err(map_sqlite_error(path))? {
         events.push(RawEvent {
             key: EventKey {
                 session_id: row_value(path, row, 0)?,

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use crate::storage::{
     DB_FILE_NAME, RAW_CODEC, ZSTD_CODEC, ZSTD_MIN_PAYLOAD_BYTES, decode_event_payload,
-    encode_event_payload, open_database, query_one, sqlite_error,
+    encode_event_payload, open_database, query_one, row_value, sqlite_error,
     unresolved_ingest_error_count_from_connection,
 };
 use crate::{JottraceError, Result, data_dir_from_env};
@@ -423,11 +423,11 @@ fn raw_event_batch(
     while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
         events.push(RawEvent {
             key: EventKey {
-                session_id: row.get(0).map_err(|source| sqlite_error(path, source))?,
-                generation: row.get(1).map_err(|source| sqlite_error(path, source))?,
-                seq: row.get(2).map_err(|source| sqlite_error(path, source))?,
+                session_id: row_value(path, row, 0)?,
+                generation: row_value(path, row, 1)?,
+                seq: row_value(path, row, 2)?,
             },
-            payload: row.get(3).map_err(|source| sqlite_error(path, source))?,
+            payload: row_value(path, row, 3)?,
         });
     }
     Ok(events)

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -2,7 +2,7 @@ use rusqlite::{Connection, params};
 use std::path::PathBuf;
 
 use crate::storage::{
-    DB_FILE_NAME, RAW_CODEC, ZSTD_CODEC, ZSTD_MIN_PAYLOAD_BYTES, decode_event_payload,
+    DB_FILE_NAME, RAW_CODEC, ZSTD_CODEC, ZSTD_MIN_PAYLOAD_BYTES, count, decode_event_payload,
     encode_event_payload, open_database, query_one, row_value, sqlite_error,
     unresolved_ingest_error_count_from_connection,
 };
@@ -434,7 +434,7 @@ fn raw_event_batch(
 }
 
 fn count_small_raw_events(path: &std::path::Path, conn: &Connection) -> Result<u64> {
-    let count: i64 = query_one(
+    count(
         path,
         conn,
         "SELECT COUNT(*)
@@ -442,9 +442,7 @@ fn count_small_raw_events(path: &std::path::Path, conn: &Connection) -> Result<u
              WHERE codec = ?1
                AND payload_size < ?2",
         params![RAW_CODEC, ZSTD_MIN_PAYLOAD_BYTES as i64],
-        |row| row.get(0),
-    )?;
-    Ok(count as u64)
+    )
 }
 
 fn event_storage_stats(path: &std::path::Path, conn: &Connection) -> Result<EventStorageStats> {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -2744,8 +2744,7 @@ fn claude_local_agent_metadata(metadata_path: Option<&Path>) -> Result<ParsedMet
             return Err(io_error(path, source));
         }
     };
-    let metadata = serde_json::from_slice::<ClaudeLocalAgentMetadata<'_>>(&bytes)
-        .map_err(|source| invalid_session_meta(path, source.to_string()))?;
+    let metadata = parse_session_json::<ClaudeLocalAgentMetadata<'_>>(path, &bytes)?;
     let started_at = claude_local_agent_metadata_timestamp(path, "createdAt", metadata.started_at)?;
     let ended_at =
         claude_local_agent_metadata_timestamp(path, "lastActivityAt", metadata.ended_at)?;
@@ -2875,8 +2874,7 @@ fn claude_local_agent_source_session_id_from_file(path: &Path) -> Result<String>
     else {
         return claude_local_agent_fallback_source_session_id(path);
     };
-    let header = serde_json::from_slice::<ClaudeLocalAgentAuditHeader<'_>>(&first_line)
-        .map_err(|source| invalid_session_meta(path, source.to_string()))?;
+    let header = parse_session_json::<ClaudeLocalAgentAuditHeader<'_>>(path, &first_line)?;
 
     header
         .session_id
@@ -2898,8 +2896,7 @@ fn codex_source_session_id_from_file(path: &Path) -> Result<String> {
         )
     })?;
 
-    let header = serde_json::from_slice::<EventHeader<'_>>(&first_line)
-        .map_err(|source| invalid_session_meta(path, source.to_string()))?;
+    let header = parse_session_json::<EventHeader<'_>>(path, &first_line)?;
     if header.event_type != Some("session_meta") {
         if header.event_type.is_none()
             && let Ok(legacy_header) = serde_json::from_slice::<LegacyCodexHeader<'_>>(&first_line)
@@ -2928,8 +2925,7 @@ fn factory_source_session_id_from_file(path: &Path) -> Result<String> {
         FACTORY_SESSION_START_MISSING_MESSAGE,
     )?
     .ok_or_else(|| invalid_session_meta(path, FACTORY_SESSION_START_MISSING_MESSAGE))?;
-    let header = serde_json::from_slice::<EventHeader<'_>>(&first_line)
-        .map_err(|source| invalid_session_meta(path, source.to_string()))?;
+    let header = parse_session_json::<EventHeader<'_>>(path, &first_line)?;
     if header.event_type != Some("session_start") {
         return Err(invalid_session_meta(
             path,
@@ -2999,8 +2995,7 @@ fn claude_local_agent_metadata_path(path: &Path) -> Option<PathBuf> {
 }
 
 fn gemini_source_session_id_from_buffer(path: &Path, buffer: &[u8]) -> Result<String> {
-    let identity = serde_json::from_slice::<GeminiChatIdentity<'_>>(buffer)
-        .map_err(|source| invalid_session_meta(path, source.to_string()))?;
+    let identity = parse_session_json::<GeminiChatIdentity<'_>>(path, buffer)?;
     if identity.session_id.trim().is_empty() {
         return Err(invalid_session_meta(
             path,
@@ -3011,8 +3006,7 @@ fn gemini_source_session_id_from_buffer(path: &Path, buffer: &[u8]) -> Result<St
 }
 
 fn gemini_chat_from_buffer<'a>(path: &Path, buffer: &'a [u8]) -> Result<GeminiChatFile<'a>> {
-    let chat = serde_json::from_slice::<GeminiChatFile<'a>>(buffer)
-        .map_err(|source| invalid_session_meta(path, source.to_string()))?;
+    let chat = parse_session_json::<GeminiChatFile<'a>>(path, buffer)?;
     if chat.session_id.trim().is_empty() {
         return Err(invalid_session_meta(
             path,
@@ -3101,8 +3095,7 @@ fn pi_agent_source_session_id_from_file(path: &Path) -> Result<String> {
         PI_AGENT_SESSION_HEADER_MISSING_MESSAGE,
     )?
     .ok_or_else(|| invalid_session_meta(path, PI_AGENT_SESSION_HEADER_MISSING_MESSAGE))?;
-    let header = serde_json::from_slice::<EventHeader<'_>>(&first_line)
-        .map_err(|source| invalid_session_meta(path, source.to_string()))?;
+    let header = parse_session_json::<EventHeader<'_>>(path, &first_line)?;
     if header.event_type != Some("session") {
         return Err(invalid_session_meta(
             path,
@@ -3210,6 +3203,14 @@ fn invalid_session_meta(path: &Path, message: impl Into<String>) -> JottraceErro
         path: path.to_path_buf(),
         message: message.into(),
     }
+}
+
+fn parse_session_json<'a, T>(path: &Path, bytes: &'a [u8]) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    serde_json::from_slice::<T>(bytes)
+        .map_err(|source| invalid_session_meta(path, source.to_string()))
 }
 
 #[cfg(test)]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -472,6 +472,19 @@ fn jsonl_source_files_from_paths(
         .collect()
 }
 
+/// Build [`SourceFile`]s for a JSONL source whose entries may carry a parent
+/// session (Claude, Pi Agent), ordering the result so files with parents sort
+/// last. `build` derives each path's per-source identity; the shared collect and
+/// parents-last sort live here.
+fn jsonl_source_files_with_parents(
+    paths: Vec<PathBuf>,
+    build: impl FnMut(PathBuf) -> Result<SourceFile>,
+) -> Result<Vec<SourceFile>> {
+    let mut source_files = paths.into_iter().map(build).collect::<Result<Vec<_>>>()?;
+    sort_source_files_with_parents_last(&mut source_files);
+    Ok(source_files)
+}
+
 fn discover_claude_session_files() -> Result<Vec<SourceFile>> {
     let home = home_dir()?;
     let mut paths = Vec::new();
@@ -484,24 +497,18 @@ fn discover_claude_session_files() -> Result<Vec<SourceFile>> {
 
     sort_dedup_paths(&mut paths);
 
-    let mut source_files = paths
-        .into_iter()
-        .map(|path| {
-            let (source_session_id, parent_source_session_id) =
-                source_session_ids_from_path(&path)?;
-            Ok(SourceFile {
-                source: CLAUDE_SOURCE,
-                source_session_id,
-                source_session_id_kind: SourceSessionIdKind::Known,
-                parent_source_session_id,
-                metadata_path: None,
-                source_format: SourceFormat::Jsonl,
-                path,
-            })
+    jsonl_source_files_with_parents(paths, |path| {
+        let (source_session_id, parent_source_session_id) = source_session_ids_from_path(&path)?;
+        Ok(SourceFile {
+            source: CLAUDE_SOURCE,
+            source_session_id,
+            source_session_id_kind: SourceSessionIdKind::Known,
+            parent_source_session_id,
+            metadata_path: None,
+            source_format: SourceFormat::Jsonl,
+            path,
         })
-        .collect::<Result<Vec<_>>>()?;
-    sort_source_files_with_parents_last(&mut source_files);
-    Ok(source_files)
+    })
 }
 
 fn discover_claude_local_agent_session_files() -> Result<Vec<SourceFile>> {
@@ -575,36 +582,31 @@ fn discover_pi_agent_session_files() -> Result<Vec<SourceFile>> {
 
     sort_dedup_paths(&mut paths);
 
-    let mut source_files = paths
-        .into_iter()
-        .map(|path| {
-            let (source_session_id, source_session_id_kind, parent_source_session_id) =
-                if let Some(nested) = pi_agent_nested_run_info(&path) {
-                    (
-                        nested.placeholder_source_session_id,
-                        SourceSessionIdKind::PiAgentSessionHeader,
-                        Some(nested.parent_source_session_id),
-                    )
-                } else {
-                    (
-                        pi_source_session_id_from_path(&path)?,
-                        SourceSessionIdKind::Known,
-                        None,
-                    )
-                };
-            Ok(SourceFile {
-                source: PI_AGENT_SOURCE,
-                source_session_id,
-                source_session_id_kind,
-                parent_source_session_id,
-                metadata_path: None,
-                source_format: SourceFormat::Jsonl,
-                path,
-            })
+    jsonl_source_files_with_parents(paths, |path| {
+        let (source_session_id, source_session_id_kind, parent_source_session_id) =
+            if let Some(nested) = pi_agent_nested_run_info(&path) {
+                (
+                    nested.placeholder_source_session_id,
+                    SourceSessionIdKind::PiAgentSessionHeader,
+                    Some(nested.parent_source_session_id),
+                )
+            } else {
+                (
+                    pi_source_session_id_from_path(&path)?,
+                    SourceSessionIdKind::Known,
+                    None,
+                )
+            };
+        Ok(SourceFile {
+            source: PI_AGENT_SOURCE,
+            source_session_id,
+            source_session_id_kind,
+            parent_source_session_id,
+            metadata_path: None,
+            source_format: SourceFormat::Jsonl,
+            path,
         })
-        .collect::<Result<Vec<_>>>()?;
-    sort_source_files_with_parents_last(&mut source_files);
-    Ok(source_files)
+    })
 }
 
 fn discover_factory_session_files() -> Result<Vec<SourceFile>> {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -12,7 +12,7 @@ use crate::storage::{
     DB_FILE_NAME, encode_event_payload, execute_sql, map_sqlite_error, open_database,
     open_readonly_database, query_one, query_optional, status_from_connection,
 };
-use crate::{JottraceError, Result, io_error};
+use crate::{JottraceError, Result, io_error, map_io_error};
 
 const CLAUDE_SOURCE: &str = "claude_cli";
 const CLAUDE_LOCAL_AGENT_SOURCE: &str = "claude_local_agent";
@@ -793,11 +793,9 @@ fn for_each_dir_entry(
     };
 
     for entry in entries {
-        let entry = entry.map_err(|source| io_error(root, source))?;
+        let entry = entry.map_err(map_io_error(root))?;
         let path = entry.path();
-        let file_type = entry
-            .file_type()
-            .map_err(|source| io_error(&path, source))?;
+        let file_type = entry.file_type().map_err(map_io_error(&path))?;
         handle(path, file_type)?;
     }
 
@@ -881,8 +879,7 @@ fn ingest_source_file(
     ingest_state: &mut IngestState,
     source_file: &SourceFile,
 ) -> Result<u64> {
-    let metadata =
-        fs::metadata(&source_file.path).map_err(|source| io_error(&source_file.path, source))?;
+    let metadata = fs::metadata(&source_file.path).map_err(map_io_error(&source_file.path))?;
     if !metadata.is_file() {
         return Err(JottraceError::NotFile(source_file.path.clone()));
     }
@@ -2624,12 +2621,12 @@ fn generation_event_count(
 }
 
 fn read_bounded(path: &Path, pass_size: u64) -> Result<Vec<u8>> {
-    let file = File::open(path).map_err(|source| io_error(path, source))?;
+    let file = File::open(path).map_err(map_io_error(path))?;
     let mut reader = file.take(pass_size);
     let mut buffer = Vec::with_capacity(pass_size.min(1024 * 1024) as usize);
     reader
         .read_to_end(&mut buffer)
-        .map_err(|source| io_error(path, source))?;
+        .map_err(map_io_error(path))?;
     Ok(buffer)
 }
 
@@ -2940,12 +2937,12 @@ fn first_committed_line(
     byte_limit: u64,
     missing_line_message: &str,
 ) -> Result<Option<Vec<u8>>> {
-    let file = File::open(path).map_err(|source| io_error(path, source))?;
+    let file = File::open(path).map_err(map_io_error(path))?;
     let mut reader = BufReader::new(file).take(byte_limit);
     let mut first_line = Vec::new();
     let read = reader
         .read_until(b'\n', &mut first_line)
-        .map_err(|source| io_error(path, source))?;
+        .map_err(map_io_error(path))?;
     if read == 0 || !first_line.ends_with(b"\n") {
         if read as u64 == byte_limit {
             return Ok(None);

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, OpenFlags, OptionalExtension, Transaction, named_params, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, named_params, params};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 use std::collections::HashSet;
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use crate::storage::{
-    DB_FILE_NAME, encode_event_payload, execute_sql, open_database, query_one, query_optional,
-    sqlite_error, status_from_connection,
+    DB_FILE_NAME, encode_event_payload, execute_sql, open_database, open_readonly_database,
+    query_one, query_optional, sqlite_error, status_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
 
@@ -1449,13 +1449,11 @@ fn opencode_session_snapshot(source_file: &SourceFile) -> Result<SqliteSessionSn
 }
 
 fn opencode_source_connection(path: &Path) -> Result<Connection> {
-    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .map_err(|source| opencode_sqlite_error(path, source))
+    open_readonly_database(path, opencode_sqlite_error)
 }
 
 fn hermes_source_connection(path: &Path) -> Result<Connection> {
-    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .map_err(|source| hermes_sqlite_error(path, source))
+    open_readonly_database(path, hermes_sqlite_error)
 }
 
 fn opencode_session_event(

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -665,19 +665,16 @@ fn discover_sqlite_session_files(
     let Some(metadata) = metadata_optional(&path)? else {
         return Ok(Vec::new());
     };
-    if !metadata.is_file() {
-        return Ok(sqlite_discovery_errors(
-            source,
-            error_session_id,
-            source_format,
-            path,
-        ));
-    }
 
-    // Any failure reading the store — open, prepare, query, a bad row, or an
-    // empty session id — collapses to a single discovery error so the rest of
-    // ingest can proceed.
-    let Some(sessions) = read_sqlite_session_rows(&path, session_query, open_connection) else {
+    // A non-file path, or any failure reading the store — open, prepare, query,
+    // a bad row, or an empty session id — collapses to a single discovery error
+    // so the rest of ingest can proceed.
+    let sessions = if metadata.is_file() {
+        read_sqlite_session_rows(&path, session_query, open_connection)
+    } else {
+        None
+    };
+    let Some(sessions) = sessions else {
         return Ok(sqlite_discovery_errors(
             source,
             error_session_id,

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -667,62 +667,21 @@ fn discover_sqlite_session_files(
         Err(source) => return Err(JottraceError::Io { path, source }),
     }
 
-    let conn = match open_connection(&path) {
-        Ok(conn) => conn,
-        Err(_) => {
-            return Ok(sqlite_discovery_errors(
-                source,
-                error_session_id,
-                source_format,
-                path,
-            ));
-        }
-    };
-    let mut statement = match conn.prepare(session_query) {
-        Ok(statement) => statement,
-        Err(_) => {
-            return Ok(sqlite_discovery_errors(
-                source,
-                error_session_id,
-                source_format,
-                path,
-            ));
-        }
-    };
-    let rows = match statement.query_map([], |row| Ok((row.get(0)?, row.get(1)?))) {
-        Ok(rows) => rows,
-        Err(_) => {
-            return Ok(sqlite_discovery_errors(
-                source,
-                error_session_id,
-                source_format,
-                path,
-            ));
-        }
+    // Any failure reading the store — open, prepare, query, a bad row, or an
+    // empty session id — collapses to a single discovery error so the rest of
+    // ingest can proceed.
+    let Some(sessions) = read_sqlite_session_rows(&path, session_query, open_connection) else {
+        return Ok(sqlite_discovery_errors(
+            source,
+            error_session_id,
+            source_format,
+            path,
+        ));
     };
 
-    let mut source_files = Vec::new();
-    for row in rows {
-        let (source_session_id, parent_source_session_id): (String, Option<String>) = match row {
-            Ok(row) => row,
-            Err(_) => {
-                return Ok(sqlite_discovery_errors(
-                    source,
-                    error_session_id,
-                    source_format,
-                    path,
-                ));
-            }
-        };
-        if source_session_id.trim().is_empty() {
-            return Ok(sqlite_discovery_errors(
-                source,
-                error_session_id,
-                source_format,
-                path,
-            ));
-        }
-        source_files.push(SourceFile {
+    Ok(sessions
+        .into_iter()
+        .map(|(source_session_id, parent_source_session_id)| SourceFile {
             source,
             source_session_id,
             source_session_id_kind: SourceSessionIdKind::Known,
@@ -730,9 +689,34 @@ fn discover_sqlite_session_files(
             metadata_path: None,
             source_format,
             path: path.clone(),
-        });
+        })
+        .collect())
+}
+
+/// Read `(source_session_id, parent_source_session_id)` rows from a source
+/// SQLite store, returning `None` if the store cannot be opened or queried, or
+/// yields a row with an empty session id. Callers translate `None` into a
+/// discovery error placeholder.
+fn read_sqlite_session_rows(
+    path: &Path,
+    session_query: &str,
+    open_connection: fn(&Path) -> Result<Connection>,
+) -> Option<Vec<(String, Option<String>)>> {
+    let conn = open_connection(path).ok()?;
+    let mut statement = conn.prepare(session_query).ok()?;
+    let rows = statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .ok()?;
+
+    let mut sessions = Vec::new();
+    for row in rows {
+        let (source_session_id, parent_source_session_id): (String, Option<String>) = row.ok()?;
+        if source_session_id.trim().is_empty() {
+            return None;
+        }
+        sessions.push((source_session_id, parent_source_session_id));
     }
-    Ok(source_files)
+    Some(sessions)
 }
 
 fn sqlite_discovery_errors(

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use crate::storage::{
-    DB_FILE_NAME, encode_event_payload, open_database, query_optional, sqlite_error,
+    DB_FILE_NAME, encode_event_payload, execute_sql, open_database, query_optional, sqlite_error,
     status_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
@@ -1913,7 +1913,9 @@ fn source_file_error_kind(error: &JottraceError) -> &'static str {
 }
 
 fn insert_session_if_missing(tx: &Transaction<'_>, source_file: &SourceFile) -> Result<()> {
-    tx.execute(
+    execute_sql(
+        &source_file.path,
+        tx,
         "INSERT OR IGNORE INTO sessions (source, source_session_id, file_path)
          VALUES (?1, ?2, ?3)",
         params![
@@ -1921,8 +1923,7 @@ fn insert_session_if_missing(tx: &Transaction<'_>, source_file: &SourceFile) -> 
             source_file.source_session_id.as_str(),
             source_file.path.to_string_lossy(),
         ],
-    )
-    .map_err(|source| sqlite_error(&source_file.path, source))?;
+    )?;
     Ok(())
 }
 
@@ -2189,7 +2190,9 @@ fn update_skipped_session(tx: &Transaction<'_>, update: &SkippedSessionUpdate<'_
     let file_path = update.source_file.path.to_string_lossy();
     let has_parent_source = update.source_file.parent_source_session_id.is_some();
 
-    tx.execute(
+    execute_sql(
+        &update.source_file.path,
+        tx,
         "UPDATE sessions
          SET file_path = :file_path,
              parent_session_id = CASE
@@ -2217,8 +2220,7 @@ fn update_skipped_session(tx: &Transaction<'_>, update: &SkippedSessionUpdate<'_
             ":content_fingerprint": content_fingerprint,
             ":session_id": update.session_id,
         },
-    )
-    .map_err(|source| sqlite_error(&update.source_file.path, source))?;
+    )?;
     Ok(())
 }
 
@@ -2226,7 +2228,9 @@ fn update_session_after_import(tx: &Transaction<'_>, update: SessionUpdate<'_>) 
     let file_path = update.source_file.path.to_string_lossy();
     let has_parent_source = update.source_file.parent_source_session_id.is_some();
 
-    tx.execute(
+    execute_sql(
+        &update.source_file.path,
+        tx,
         "UPDATE sessions
          SET file_path = :file_path,
              parent_session_id = CASE
@@ -2274,8 +2278,7 @@ fn update_session_after_import(tx: &Transaction<'_>, update: SessionUpdate<'_>) 
             ":event_count": update.event_count,
             ":session_id": update.session_id,
         },
-    )
-    .map_err(|source| sqlite_error(&update.source_file.path, source))?;
+    )?;
     Ok(())
 }
 
@@ -2305,14 +2308,15 @@ fn reuse_source_file_session_identity(
         return Ok(());
     }
 
-    conn.execute(
+    execute_sql(
+        &source_file.path,
+        conn,
         "UPDATE sessions
          SET source_session_id = ?1,
              updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
          WHERE id = ?2",
         params![source_session_id, stored.id],
-    )
-    .map_err(|source| sqlite_error(&source_file.path, source))?;
+    )?;
     Ok(())
 }
 
@@ -2516,7 +2520,9 @@ fn resolve_source_file_error(
         return Ok(());
     }
 
-    conn.execute(
+    execute_sql(
+        &source_file.path,
+        conn,
         "UPDATE ingest_errors
          SET resolved_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
              resolution_note = ?1
@@ -2530,8 +2536,7 @@ fn resolve_source_file_error(
             source_file.path.to_string_lossy(),
             error_kind,
         ],
-    )
-    .map_err(|source| sqlite_error(&source_file.path, source))?;
+    )?;
     Ok(())
 }
 
@@ -2554,15 +2559,20 @@ fn remove_empty_source_file_placeholder(
         return Ok(());
     }
 
-    conn.execute("DELETE FROM sessions WHERE id = ?1", [stored.id])
-        .map_err(|source| sqlite_error(&source_file.path, source))?;
+    execute_sql(
+        &source_file.path,
+        conn,
+        "DELETE FROM sessions WHERE id = ?1",
+        [stored.id],
+    )?;
     Ok(())
 }
 
 fn record_ingest_error(tx: &Transaction<'_>, record: IngestErrorRecord<'_>) -> Result<()> {
-    let updated = tx
-        .execute(
-            "UPDATE ingest_errors
+    let updated = execute_sql(
+        &record.source_file.path,
+        tx,
+        "UPDATE ingest_errors
              SET session_id = ?1,
                  message = ?2,
                  last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
@@ -2575,25 +2585,26 @@ fn record_ingest_error(tx: &Transaction<'_>, record: IngestErrorRecord<'_>) -> R
                AND line_number IS ?8
                AND error_kind = ?9
                AND resolved_at IS NULL",
-            params![
-                record.session_id,
-                record.message,
-                record.source_file.source,
-                record.source_file.source_session_id.as_str(),
-                record.source_file.path.to_string_lossy(),
-                record.generation,
-                record.byte_offset,
-                record.line_number,
-                record.error_kind,
-            ],
-        )
-        .map_err(|source| sqlite_error(&record.source_file.path, source))?;
+        params![
+            record.session_id,
+            record.message,
+            record.source_file.source,
+            record.source_file.source_session_id.as_str(),
+            record.source_file.path.to_string_lossy(),
+            record.generation,
+            record.byte_offset,
+            record.line_number,
+            record.error_kind,
+        ],
+    )?;
 
     if updated > 0 {
         return Ok(());
     }
 
-    tx.execute(
+    execute_sql(
+        &record.source_file.path,
+        tx,
         "INSERT INTO ingest_errors
             (source, source_session_id, session_id, file_path, generation, byte_offset,
              line_number, error_kind, message)
@@ -2609,8 +2620,7 @@ fn record_ingest_error(tx: &Transaction<'_>, record: IngestErrorRecord<'_>) -> R
             record.error_kind,
             record.message,
         ],
-    )
-    .map_err(|source| sqlite_error(&record.source_file.path, source))?;
+    )?;
     Ok(())
 }
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -660,18 +660,16 @@ fn discover_sqlite_session_files(
     open_connection: fn(&Path) -> Result<Connection>,
 ) -> Result<Vec<SourceFile>> {
     let path = home_dir()?.join(db_relative_path);
-    match fs::metadata(&path) {
-        Ok(metadata) if metadata.is_file() => {}
-        Ok(_) => {
-            return Ok(sqlite_discovery_errors(
-                source,
-                error_session_id,
-                source_format,
-                path,
-            ));
-        }
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(source) => return Err(io_error(&path, source)),
+    let Some(metadata) = metadata_optional(&path)? else {
+        return Ok(Vec::new());
+    };
+    if !metadata.is_file() {
+        return Ok(sqlite_discovery_errors(
+            source,
+            error_session_id,
+            source_format,
+            path,
+        ));
     }
 
     // Any failure reading the store — open, prepare, query, a bad row, or an
@@ -830,13 +828,10 @@ fn is_claude_local_agent_session_dir(path: &Path) -> bool {
 
 fn push_claude_local_agent_audit_file(session_dir: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
     let audit_path = session_dir.join(CLAUDE_LOCAL_AGENT_AUDIT_FILE_NAME);
-    match fs::metadata(&audit_path) {
-        Ok(metadata) if metadata.is_file() => paths.push(audit_path),
-        Ok(_) => {}
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(source) => {
-            return Err(io_error(&audit_path, source));
-        }
+    if let Some(metadata) = metadata_optional(&audit_path)?
+        && metadata.is_file()
+    {
+        paths.push(audit_path);
     }
     Ok(())
 }
@@ -2341,12 +2336,8 @@ fn source_metadata_for_source_file(
     }
 
     let settings_path = source_file.path.with_extension("settings.json");
-    let metadata = match fs::metadata(&settings_path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(source) => {
-            return Err(io_error(&settings_path, source));
-        }
+    let Some(metadata) = metadata_optional(&settings_path)? else {
+        return Ok(None);
     };
     if !metadata.is_file() {
         return Err(JottraceError::NotFile(settings_path));
@@ -3199,6 +3190,17 @@ fn i64_from_usize(value: usize, path: &Path) -> Result<i64> {
 
 fn invalid_path(path: &Path, message: &str) -> JottraceError {
     io_error(path, io::Error::new(io::ErrorKind::InvalidData, message))
+}
+
+/// Read filesystem metadata for `path`, mapping a missing path to `Ok(None)`
+/// and any other read failure to a [`JottraceError::Io`]. Callers inspect the
+/// returned [`Metadata`] (e.g. `is_file`) to handle the present-path case.
+fn metadata_optional(path: &Path) -> Result<Option<Metadata>> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(io_error(path, source)),
+    }
 }
 
 fn invalid_session_meta(path: &Path, message: impl Into<String>) -> JottraceError {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use crate::storage::{
-    DB_FILE_NAME, encode_event_payload, execute_sql, open_database, query_optional, sqlite_error,
-    status_from_connection,
+    DB_FILE_NAME, encode_event_payload, execute_sql, open_database, query_one, query_optional,
+    sqlite_error, status_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
 
@@ -2630,12 +2630,13 @@ fn generation_event_count(
     session_id: i64,
     generation: i64,
 ) -> Result<i64> {
-    tx.query_row(
+    query_one(
+        &source_file.path,
+        tx,
         "SELECT COUNT(*) FROM events WHERE session_id = ?1 AND generation = ?2",
         [session_id, generation],
         |row| row.get(0),
     )
-    .map_err(|source| sqlite_error(&source_file.path, source))
 }
 
 fn read_bounded(path: &Path, pass_size: u64) -> Result<Vec<u8>> {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -9,7 +9,8 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use crate::storage::{
-    DB_FILE_NAME, encode_event_payload, open_database, sqlite_error, status_from_connection,
+    DB_FILE_NAME, encode_event_payload, open_database, query_optional, sqlite_error,
+    status_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
 
@@ -1940,7 +1941,9 @@ fn load_session_by_source_session_id(
     source: &str,
     source_session_id: &str,
 ) -> Result<Option<StoredSession>> {
-    conn.query_row(
+    query_optional(
+        error_path,
+        conn,
         "SELECT id, source_session_id, file_path, parent_session_id, current_generation, file_size, file_mtime,
                 content_fingerprint, source_metadata, next_read_offset, event_count, prefix_fingerprint
          FROM sessions
@@ -1963,15 +1966,15 @@ fn load_session_by_source_session_id(
             })
         },
     )
-    .optional()
-    .map_err(|source| sqlite_error(error_path, source))
 }
 
 fn load_session_by_source_file_path(
     conn: &Connection,
     source_file: &SourceFile,
 ) -> Result<Option<StoredSession>> {
-    conn.query_row(
+    query_optional(
+        &source_file.path,
+        conn,
         "SELECT id, source_session_id, file_path, parent_session_id, current_generation, file_size, file_mtime,
                 content_fingerprint, source_metadata, next_read_offset, event_count, prefix_fingerprint
          FROM sessions
@@ -1997,8 +2000,6 @@ fn load_session_by_source_file_path(
             })
         },
     )
-    .optional()
-    .map_err(|source| sqlite_error(&source_file.path, source))
 }
 
 fn stored_session_path_matches(stored: &StoredSession, source_file: &SourceFile) -> bool {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1559,7 +1559,7 @@ fn opencode_session_event(
                         rank: 0,
                         id: event_id,
                         ts: event_ts,
-                        payload: serde_json::to_vec(&payload).expect("serialize OpenCode payload"),
+                        payload: serialize_payload(&payload),
                     },
                     metadata,
                     source_metadata,
@@ -1623,7 +1623,7 @@ fn opencode_row_events(
                 rank: table.rank(),
                 id: event_id,
                 ts: event_ts,
-                payload: serde_json::to_vec(&payload).expect("serialize OpenCode payload"),
+                payload: serialize_payload(&payload),
             })
         })
         .map_err(|source| opencode_sqlite_error(&source_file.path, source))?;
@@ -1736,7 +1736,7 @@ fn hermes_session_event(
                         rank: 0,
                         id: source_file.source_session_id.clone(),
                         ts: metadata.started_at.clone(),
-                        payload: serde_json::to_vec(&payload).expect("serialize Hermes payload"),
+                        payload: serialize_payload(&payload),
                     },
                     metadata,
                     source_metadata,
@@ -1805,7 +1805,7 @@ fn hermes_message_events(conn: &Connection, source_file: &SourceFile) -> Result<
                 rank: 1,
                 id: format!("{id:020}"),
                 ts: event_ts,
-                payload: serde_json::to_vec(&payload).expect("serialize Hermes payload"),
+                payload: serialize_payload(&payload),
             })
         })
         .map_err(|source| hermes_sqlite_error(&source_file.path, source))?;
@@ -1818,6 +1818,10 @@ fn json_text_column(value: Option<String>) -> serde_json::Value {
     value.map_or(serde_json::Value::Null, |value| {
         serde_json::from_str(&value).unwrap_or(serde_json::Value::String(value))
     })
+}
+
+fn serialize_payload(payload: &serde_json::Value) -> Vec<u8> {
+    serde_json::to_vec(payload).expect("serialize source payload")
 }
 
 fn source_events_fingerprint(events: &[SourceEvent]) -> String {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -11,7 +11,7 @@ use std::time::UNIX_EPOCH;
 use crate::storage::{
     DB_FILE_NAME, encode_event_payload, open_database, sqlite_error, status_from_connection,
 };
-use crate::{JottraceError, Result};
+use crate::{JottraceError, Result, io_error};
 
 const CLAUDE_SOURCE: &str = "claude_cli";
 const CLAUDE_LOCAL_AGENT_SOURCE: &str = "claude_local_agent";
@@ -528,21 +528,17 @@ fn discover_gemini_session_files() -> Result<Vec<SourceFile>> {
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(source) => {
-            return Err(JottraceError::Io { path: root, source });
+            return Err(io_error(&root, source));
         }
     };
 
     let mut paths = Vec::new();
     for entry in entries {
-        let entry = entry.map_err(|source| JottraceError::Io {
-            path: root.clone(),
-            source,
-        })?;
+        let entry = entry.map_err(|source| io_error(&root, source))?;
         let path = entry.path();
-        let file_type = entry.file_type().map_err(|source| JottraceError::Io {
-            path: path.clone(),
-            source,
-        })?;
+        let file_type = entry
+            .file_type()
+            .map_err(|source| io_error(&path, source))?;
         if file_type.is_dir() {
             collect_json_files(&path.join("chats"), false, &mut paths)?;
         }
@@ -662,7 +658,7 @@ fn discover_sqlite_session_files(
             ));
         }
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(source) => return Err(JottraceError::Io { path, source }),
+        Err(source) => return Err(io_error(&path, source)),
     }
 
     // Any failure reading the store — open, prepare, query, a bad row, or an
@@ -773,23 +769,16 @@ fn collect_claude_local_agent_audit_files(root: &Path, paths: &mut Vec<PathBuf>)
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: root.to_path_buf(),
-                source,
-            });
+            return Err(io_error(root, source));
         }
     };
 
     for entry in entries {
-        let entry = entry.map_err(|source| JottraceError::Io {
-            path: root.to_path_buf(),
-            source,
-        })?;
+        let entry = entry.map_err(|source| io_error(root, source))?;
         let path = entry.path();
-        let file_type = entry.file_type().map_err(|source| JottraceError::Io {
-            path: path.clone(),
-            source,
-        })?;
+        let file_type = entry
+            .file_type()
+            .map_err(|source| io_error(&path, source))?;
         if !file_type.is_dir() {
             continue;
         }
@@ -817,10 +806,7 @@ fn push_claude_local_agent_audit_file(session_dir: &Path, paths: &mut Vec<PathBu
         Ok(_) => {}
         Err(error) if error.kind() == io::ErrorKind::NotFound => {}
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: audit_path,
-                source,
-            });
+            return Err(io_error(&audit_path, source));
         }
     }
     Ok(())
@@ -844,23 +830,16 @@ fn collect_files_with_extension(
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: root.to_path_buf(),
-                source,
-            });
+            return Err(io_error(root, source));
         }
     };
 
     for entry in entries {
-        let entry = entry.map_err(|source| JottraceError::Io {
-            path: root.to_path_buf(),
-            source,
-        })?;
+        let entry = entry.map_err(|source| io_error(root, source))?;
         let path = entry.path();
-        let file_type = entry.file_type().map_err(|source| JottraceError::Io {
-            path: path.clone(),
-            source,
-        })?;
+        let file_type = entry
+            .file_type()
+            .map_err(|source| io_error(&path, source))?;
         if file_type.is_dir() {
             if recursive {
                 collect_files_with_extension(&path, extension, true, paths)?;
@@ -893,10 +872,8 @@ fn ingest_source_file(
     ingest_state: &mut IngestState,
     source_file: &SourceFile,
 ) -> Result<u64> {
-    let metadata = fs::metadata(&source_file.path).map_err(|source| JottraceError::Io {
-        path: source_file.path.clone(),
-        source,
-    })?;
+    let metadata =
+        fs::metadata(&source_file.path).map_err(|source| io_error(&source_file.path, source))?;
     if !metadata.is_file() {
         return Err(JottraceError::NotFile(source_file.path.clone()));
     }
@@ -2381,10 +2358,7 @@ fn source_metadata_for_source_file(
         Ok(metadata) => metadata,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: settings_path,
-                source,
-            });
+            return Err(io_error(&settings_path, source));
         }
     };
     if !metadata.is_file() {
@@ -2663,18 +2637,12 @@ fn generation_event_count(
 }
 
 fn read_bounded(path: &Path, pass_size: u64) -> Result<Vec<u8>> {
-    let file = File::open(path).map_err(|source| JottraceError::Io {
-        path: path.to_path_buf(),
-        source,
-    })?;
+    let file = File::open(path).map_err(|source| io_error(path, source))?;
     let mut reader = file.take(pass_size);
     let mut buffer = Vec::with_capacity(pass_size.min(1024 * 1024) as usize);
     reader
         .read_to_end(&mut buffer)
-        .map_err(|source| JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        .map_err(|source| io_error(path, source))?;
     Ok(buffer)
 }
 
@@ -2782,10 +2750,7 @@ fn claude_local_agent_metadata(metadata_path: Option<&Path>) -> Result<ParsedMet
             return Ok(ParsedMetadata::default());
         }
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: path.to_path_buf(),
-                source,
-            });
+            return Err(io_error(path, source));
         }
     };
     let metadata = serde_json::from_slice::<ClaudeLocalAgentMetadata<'_>>(&bytes)
@@ -2992,18 +2957,12 @@ fn first_committed_line(
     byte_limit: u64,
     missing_line_message: &str,
 ) -> Result<Option<Vec<u8>>> {
-    let file = File::open(path).map_err(|source| JottraceError::Io {
-        path: path.to_path_buf(),
-        source,
-    })?;
+    let file = File::open(path).map_err(|source| io_error(path, source))?;
     let mut reader = BufReader::new(file).take(byte_limit);
     let mut first_line = Vec::new();
     let read = reader
         .read_until(b'\n', &mut first_line)
-        .map_err(|source| JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        .map_err(|source| io_error(path, source))?;
     if read == 0 || !first_line.ends_with(b"\n") {
         if read as u64 == byte_limit {
             return Ok(None);
@@ -3252,10 +3211,7 @@ fn i64_from_usize(value: usize, path: &Path) -> Result<i64> {
 }
 
 fn invalid_path(path: &Path, message: &str) -> JottraceError {
-    JottraceError::Io {
-        path: path.to_path_buf(),
-        source: io::Error::new(io::ErrorKind::InvalidData, message),
-    }
+    io_error(path, io::Error::new(io::ErrorKind::InvalidData, message))
 }
 
 fn invalid_session_meta(path: &Path, message: impl Into<String>) -> JottraceError {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -122,6 +122,29 @@ struct StoredSession {
     prefix_fingerprint: Option<String>,
 }
 
+impl StoredSession {
+    /// Build a session from a `sessions` row whose columns are, in order: id,
+    /// source_session_id, file_path, parent_session_id, current_generation,
+    /// file_size, file_mtime, content_fingerprint, source_metadata,
+    /// next_read_offset, event_count, prefix_fingerprint.
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(StoredSession {
+            id: row.get(0)?,
+            source_session_id: row.get(1)?,
+            file_path: row.get(2)?,
+            parent_session_id: row.get(3)?,
+            current_generation: row.get(4)?,
+            file_size: row.get(5)?,
+            file_mtime: row.get(6)?,
+            content_fingerprint: row.get(7)?,
+            source_metadata: row.get(8)?,
+            next_read_offset: row.get(9)?,
+            event_count: row.get(10)?,
+            prefix_fingerprint: row.get(11)?,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ImportMode {
     Append,
@@ -1950,22 +1973,7 @@ fn load_session_by_source_session_id(
          FROM sessions
          WHERE source = ?1 AND source_session_id = ?2",
         params![source, source_session_id],
-        |row| {
-            Ok(StoredSession {
-                id: row.get(0)?,
-                source_session_id: row.get(1)?,
-                file_path: row.get(2)?,
-                parent_session_id: row.get(3)?,
-                current_generation: row.get(4)?,
-                file_size: row.get(5)?,
-                file_mtime: row.get(6)?,
-                content_fingerprint: row.get(7)?,
-                source_metadata: row.get(8)?,
-                next_read_offset: row.get(9)?,
-                event_count: row.get(10)?,
-                prefix_fingerprint: row.get(11)?,
-            })
-        },
+        StoredSession::from_row,
     )
 }
 
@@ -1984,22 +1992,7 @@ fn load_session_by_source_file_path(
             source_file.source,
             source_file.path.to_string_lossy().as_ref(),
         ],
-        |row| {
-            Ok(StoredSession {
-                id: row.get(0)?,
-                source_session_id: row.get(1)?,
-                file_path: row.get(2)?,
-                parent_session_id: row.get(3)?,
-                current_generation: row.get(4)?,
-                file_size: row.get(5)?,
-                file_mtime: row.get(6)?,
-                content_fingerprint: row.get(7)?,
-                source_metadata: row.get(8)?,
-                next_read_offset: row.get(9)?,
-                event_count: row.get(10)?,
-                prefix_fingerprint: row.get(11)?,
-            })
-        },
+        StoredSession::from_row,
     )
 }
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -524,25 +524,14 @@ fn discover_codex_session_files() -> Result<Vec<SourceFile>> {
 
 fn discover_gemini_session_files() -> Result<Vec<SourceFile>> {
     let root = home_dir()?.join(GEMINI_TMP_DIR);
-    let entries = match fs::read_dir(&root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(source) => {
-            return Err(io_error(&root, source));
-        }
-    };
 
     let mut paths = Vec::new();
-    for entry in entries {
-        let entry = entry.map_err(|source| io_error(&root, source))?;
-        let path = entry.path();
-        let file_type = entry
-            .file_type()
-            .map_err(|source| io_error(&path, source))?;
+    for_each_dir_entry(&root, |path, file_type| {
         if file_type.is_dir() {
             collect_json_files(&path.join("chats"), false, &mut paths)?;
         }
-    }
+        Ok(())
+    })?;
 
     sort_dedup_paths(&mut paths);
 
@@ -764,7 +753,16 @@ fn home_dir() -> Result<PathBuf> {
         .ok_or(JottraceError::MissingHome)
 }
 
-fn collect_claude_local_agent_audit_files(root: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
+/// Iterate the entries of `root`, invoking `handle` with each entry's path and
+/// file type. A missing directory is treated as empty (returns `Ok(())`),
+/// matching the discovery callers that tolerate absent source roots; any other
+/// `read_dir`/`file_type` failure becomes an [`io_error`]. Entries are read and
+/// handled lazily so the first failure short-circuits exactly as an inline loop
+/// would.
+fn for_each_dir_entry(
+    root: &Path,
+    mut handle: impl FnMut(PathBuf, fs::FileType) -> Result<()>,
+) -> Result<()> {
     let entries = match fs::read_dir(root) {
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
@@ -779,8 +777,16 @@ fn collect_claude_local_agent_audit_files(root: &Path, paths: &mut Vec<PathBuf>)
         let file_type = entry
             .file_type()
             .map_err(|source| io_error(&path, source))?;
+        handle(path, file_type)?;
+    }
+
+    Ok(())
+}
+
+fn collect_claude_local_agent_audit_files(root: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
+    for_each_dir_entry(root, |path, file_type| {
         if !file_type.is_dir() {
-            continue;
+            return Ok(());
         }
 
         if is_claude_local_agent_session_dir(&path) {
@@ -788,9 +794,8 @@ fn collect_claude_local_agent_audit_files(root: &Path, paths: &mut Vec<PathBuf>)
         } else {
             collect_claude_local_agent_audit_files(&path, paths)?;
         }
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 fn is_claude_local_agent_session_dir(path: &Path) -> bool {
@@ -826,20 +831,7 @@ fn collect_files_with_extension(
     recursive: bool,
     paths: &mut Vec<PathBuf>,
 ) -> Result<()> {
-    let entries = match fs::read_dir(root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(source) => {
-            return Err(io_error(root, source));
-        }
-    };
-
-    for entry in entries {
-        let entry = entry.map_err(|source| io_error(root, source))?;
-        let path = entry.path();
-        let file_type = entry
-            .file_type()
-            .map_err(|source| io_error(&path, source))?;
+    for_each_dir_entry(root, |path, file_type| {
         if file_type.is_dir() {
             if recursive {
                 collect_files_with_extension(&path, extension, true, paths)?;
@@ -851,9 +843,8 @@ fn collect_files_with_extension(
         {
             paths.push(path);
         }
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 fn collect_flat_session_files(root: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -423,6 +423,31 @@ fn discover_session_files() -> Result<Vec<SourceFile>> {
     Ok(source_files)
 }
 
+/// Build [`SourceFile`]s for a JSONL source whose session id derives purely from
+/// the file path and which never carries a parent session (Codex, Gemini, Factory).
+fn jsonl_source_files_from_paths(
+    paths: Vec<PathBuf>,
+    source: &'static str,
+    source_session_id_kind: SourceSessionIdKind,
+    source_format: SourceFormat,
+) -> Result<Vec<SourceFile>> {
+    paths
+        .into_iter()
+        .map(|path| {
+            let (source_session_id, _) = source_session_ids_from_path(&path)?;
+            Ok(SourceFile {
+                source,
+                source_session_id,
+                source_session_id_kind,
+                parent_source_session_id: None,
+                metadata_path: None,
+                source_format,
+                path,
+            })
+        })
+        .collect()
+}
+
 fn discover_claude_session_files() -> Result<Vec<SourceFile>> {
     let home = home_dir()?;
     let mut paths = Vec::new();
@@ -489,21 +514,12 @@ fn discover_codex_session_files() -> Result<Vec<SourceFile>> {
 
     sort_dedup_paths(&mut paths);
 
-    paths
-        .into_iter()
-        .map(|path| {
-            let (source_session_id, _) = source_session_ids_from_path(&path)?;
-            Ok(SourceFile {
-                source: CODEX_SOURCE,
-                source_session_id,
-                source_session_id_kind: SourceSessionIdKind::CodexSessionMeta,
-                parent_source_session_id: None,
-                metadata_path: None,
-                source_format: SourceFormat::Jsonl,
-                path,
-            })
-        })
-        .collect()
+    jsonl_source_files_from_paths(
+        paths,
+        CODEX_SOURCE,
+        SourceSessionIdKind::CodexSessionMeta,
+        SourceFormat::Jsonl,
+    )
 }
 
 fn discover_gemini_session_files() -> Result<Vec<SourceFile>> {
@@ -534,21 +550,12 @@ fn discover_gemini_session_files() -> Result<Vec<SourceFile>> {
 
     sort_dedup_paths(&mut paths);
 
-    paths
-        .into_iter()
-        .map(|path| {
-            let (source_session_id, _) = source_session_ids_from_path(&path)?;
-            Ok(SourceFile {
-                source: GEMINI_SOURCE,
-                source_session_id,
-                source_session_id_kind: SourceSessionIdKind::GeminiChatJson,
-                parent_source_session_id: None,
-                metadata_path: None,
-                source_format: SourceFormat::GeminiChatJson,
-                path,
-            })
-        })
-        .collect()
+    jsonl_source_files_from_paths(
+        paths,
+        GEMINI_SOURCE,
+        SourceSessionIdKind::GeminiChatJson,
+        SourceFormat::GeminiChatJson,
+    )
 }
 
 fn discover_pi_agent_session_files() -> Result<Vec<SourceFile>> {
@@ -601,21 +608,12 @@ fn discover_factory_session_files() -> Result<Vec<SourceFile>> {
 
     sort_dedup_paths(&mut paths);
 
-    paths
-        .into_iter()
-        .map(|path| {
-            let (source_session_id, _) = source_session_ids_from_path(&path)?;
-            Ok(SourceFile {
-                source: FACTORY_SOURCE,
-                source_session_id,
-                source_session_id_kind: SourceSessionIdKind::FactorySessionStart,
-                parent_source_session_id: None,
-                metadata_path: None,
-                source_format: SourceFormat::Jsonl,
-                path,
-            })
-        })
-        .collect()
+    jsonl_source_files_from_paths(
+        paths,
+        FACTORY_SOURCE,
+        SourceSessionIdKind::FactorySessionStart,
+        SourceFormat::Jsonl,
+    )
 }
 
 fn discover_opencode_session_files() -> Result<Vec<SourceFile>> {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use crate::storage::{
-    DB_FILE_NAME, encode_event_payload, execute_sql, open_database, open_readonly_database,
-    query_one, query_optional, sqlite_error, status_from_connection,
+    DB_FILE_NAME, encode_event_payload, execute_sql, map_sqlite_error, open_database,
+    open_readonly_database, query_one, query_optional, status_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
 
@@ -1153,7 +1153,7 @@ fn ingest_sqlite_session_snapshot(
     {
         let mut event_insert = tx
             .prepare(INSERT_EVENT_SQL)
-            .map_err(|source| sqlite_error(&source_file.path, source))?;
+            .map_err(map_sqlite_error(&source_file.path))?;
         for (seq, event) in snapshot.events.iter().enumerate() {
             inserted_event_count += insert_event_payload(
                 &mut event_insert,
@@ -1295,7 +1295,7 @@ fn import_committed_lines(
     let mut seq = line_number_at(buffer, start_offset);
     let mut event_insert = tx
         .prepare(INSERT_EVENT_SQL)
-        .map_err(|source| sqlite_error(&source_file.path, source))?;
+        .map_err(map_sqlite_error(&source_file.path))?;
 
     while byte_offset < committed_len {
         let line_end = next_line_end(buffer, byte_offset, committed_len);
@@ -1364,7 +1364,7 @@ fn insert_event_payload(
             encoded.codec,
             i64_from_usize(encoded.payload_size, &source_file.path)?,
         ])
-        .map_err(|source| sqlite_error(&source_file.path, source))?;
+        .map_err(map_sqlite_error(&source_file.path))?;
     Ok(inserted as u64)
 }
 
@@ -1390,7 +1390,7 @@ fn import_gemini_chat_json(
     let mut inserted_event_count = 0;
     let mut event_insert = tx
         .prepare(INSERT_EVENT_SQL)
-        .map_err(|source| sqlite_error(&source_file.path, source))?;
+        .map_err(map_sqlite_error(&source_file.path))?;
 
     for (index, message) in chat.messages.iter().enumerate() {
         let header = serde_json::from_str::<GeminiMessageHeader<'_>>(message.get())
@@ -2104,12 +2104,11 @@ fn invalid_json_resolution_boundary(
 }
 
 fn begin_transaction<'a>(conn: &'a mut Connection, path: &Path) -> Result<Transaction<'a>> {
-    conn.transaction()
-        .map_err(|source| sqlite_error(path, source))
+    conn.transaction().map_err(map_sqlite_error(path))
 }
 
 fn commit_ingest_transaction(tx: Transaction<'_>, path: &Path) -> Result<()> {
-    tx.commit().map_err(|source| sqlite_error(path, source))
+    tx.commit().map_err(map_sqlite_error(path))
 }
 
 /// Bounds for resolving a stale `invalid_json` ingest error after a JSONL pass:
@@ -2416,13 +2415,13 @@ fn unresolved_source_file_error_paths(
              WHERE error_kind = ?1
                AND resolved_at IS NULL",
         )
-        .map_err(|source| sqlite_error(db_path, source))?;
+        .map_err(map_sqlite_error(db_path))?;
     let rows = statement
         .query_map([error_kind], |row| Ok((row.get(0)?, row.get(1)?)))
-        .map_err(|source| sqlite_error(db_path, source))?;
+        .map_err(map_sqlite_error(db_path))?;
     let mut paths = HashSet::new();
     for row in rows {
-        paths.insert(row.map_err(|source| sqlite_error(db_path, source))?);
+        paths.insert(row.map_err(map_sqlite_error(db_path))?);
     }
     Ok(paths)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,10 +471,7 @@ fn acquire_data_lock_file(path: &Path, token: &str) -> Result<File> {
         .write(true)
         .create(true)
         .open(path)
-        .map_err(|source| JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        .map_err(|source| io_error(path, source))?;
 
     acquire_os_file_lock(&file, path)?;
     write_data_lock_metadata(&mut file, path, token)?;
@@ -511,10 +508,7 @@ fn write_data_lock_metadata(file: &mut File, path: &Path, token: &str) -> Result
 
     result.map_err(|source| {
         let _ = fs::remove_file(path);
-        JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        }
+        io_error(path, source)
     })
 }
 
@@ -529,10 +523,7 @@ fn acquire_os_file_lock(file: &File, path: &Path) -> Result<()> {
     if source.kind() == io::ErrorKind::WouldBlock {
         return Err(JottraceError::LockHeld(path.to_path_buf()));
     }
-    Err(JottraceError::Io {
-        path: path.to_path_buf(),
-        source,
-    })
+    Err(io_error(path, source))
 }
 
 fn remove_data_lock_file_if_owned(path: &Path, token: &str) {
@@ -567,10 +558,7 @@ pub fn ensure_private_dir(path: &Path) -> Result<()> {
             create_private_dir(path)?;
             ensure_dir_mode(path)
         }
-        Err(source) => Err(JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        }),
+        Err(source) => Err(io_error(path, source)),
     }
 }
 
@@ -586,10 +574,7 @@ pub fn create_private_file(path: &Path) -> Result<File> {
         .write(true)
         .create_new(true)
         .open(path)
-        .map_err(|source| JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        .map_err(|source| io_error(path, source))?;
 
     #[cfg(unix)]
     // The open mode is the first line of defense, but chmod after creation
@@ -619,10 +604,7 @@ pub fn ensure_private_file(path: &Path) -> Result<()> {
             drop(create_private_file(path)?);
             Ok(())
         }
-        Err(source) => Err(JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        }),
+        Err(source) => Err(io_error(path, source)),
     }
 }
 
@@ -631,10 +613,9 @@ fn create_private_dir(path: &Path) -> Result<()> {
     let mut builder = fs::DirBuilder::new();
     builder.recursive(true);
     builder.mode(PRIVATE_DIR_MODE);
-    builder.create(path).map_err(|source| JottraceError::Io {
-        path: path.to_path_buf(),
-        source,
-    })?;
+    builder
+        .create(path)
+        .map_err(|source| io_error(path, source))?;
     // DirBuilder's mode is affected by the process umask, so enforce the final
     // permission after the directory exists.
     set_mode(path, PRIVATE_DIR_MODE)
@@ -642,10 +623,7 @@ fn create_private_dir(path: &Path) -> Result<()> {
 
 #[cfg(not(unix))]
 fn create_private_dir(path: &Path) -> Result<()> {
-    fs::create_dir_all(path).map_err(|source| JottraceError::Io {
-        path: path.to_path_buf(),
-        source,
-    })
+    fs::create_dir_all(path).map_err(|source| io_error(path, source))
 }
 
 #[cfg(unix)]
@@ -689,26 +667,17 @@ fn ensure_file_mode(_path: &Path) -> Result<()> {
 #[cfg(unix)]
 fn set_mode(path: &Path, expected: u32) -> Result<()> {
     let mut permissions = fs::metadata(path)
-        .map_err(|source| JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?
+        .map_err(|source| io_error(path, source))?
         .permissions();
     permissions.set_mode(expected);
-    fs::set_permissions(path, permissions).map_err(|source| JottraceError::Io {
-        path: path.to_path_buf(),
-        source,
-    })
+    fs::set_permissions(path, permissions).map_err(|source| io_error(path, source))
 }
 
 #[cfg(unix)]
 fn mode(path: &Path) -> Result<u32> {
     // Mask out file-type bits so callers compare only the familiar chmod mode.
     Ok(fs::metadata(path)
-        .map_err(|source| JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?
+        .map_err(|source| io_error(path, source))?
         .permissions()
         .mode()
         & 0o777)
@@ -721,6 +690,17 @@ pub(crate) fn private_open_options() -> OpenOptions {
     // afterwards would leave a small window with process-default permissions.
     options.mode(PRIVATE_FILE_MODE);
     options
+}
+
+/// Build a `JottraceError::Io` for a filesystem operation that failed at `path`.
+/// Mirrors `storage::sqlite_error` so the pervasive
+/// `.map_err(|source| io_error(path, source))` idiom stays uniform across the
+/// crate instead of repeating the struct literal at every call site.
+pub(crate) fn io_error(path: &Path, source: io::Error) -> JottraceError {
+    JottraceError::Io {
+        path: path.to_path_buf(),
+        source,
+    }
 }
 
 fn lock_token() -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -740,6 +740,17 @@ pub(crate) fn unsupported_schema_version(
     }
 }
 
+/// Build a `JottraceError::SessionNotFound` for the session identified by
+/// `source` and `source_session_id`. Mirrors `io_error` so the not-found guard
+/// stays uniform across the storage reader, `taste show`, and `taste extract`
+/// instead of repeating the struct literal at every call site.
+pub(crate) fn session_not_found(source: &str, source_session_id: &str) -> JottraceError {
+    JottraceError::SessionNotFound {
+        source: source.to_string(),
+        source_session_id: source_session_id.to_string(),
+    }
+}
+
 fn lock_token() -> String {
     let started_at = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,6 +435,21 @@ pub(crate) fn acquire_data_lock(data_dir: &Path) -> Result<DataLock> {
     })
 }
 
+/// Acquire the data lock and open the journal database under `data_dir`.
+///
+/// Returns the database path, the held [`DataLock`] (bind it to a live name so
+/// the lock is released only when the caller's scope ends), and an open
+/// connection, bundling the `join(DB_FILE_NAME)` + [`acquire_data_lock`] +
+/// [`storage::open_database`] prologue shared by the locked journal commands.
+pub(crate) fn open_locked_database(
+    data_dir: &Path,
+) -> Result<(PathBuf, DataLock, rusqlite::Connection)> {
+    let db_path = data_dir.join(storage::DB_FILE_NAME);
+    let lock = acquire_data_lock(data_dir)?;
+    let conn = storage::open_database(&db_path)?;
+    Ok((db_path, lock, conn))
+}
+
 fn acquire_process_data_lock(path: &Path) -> Result<ProcessDataLock> {
     // `flock` behavior for duplicate locks inside one process varies by
     // platform and kernel. Track the path in-process too, preserving the old

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -718,6 +718,23 @@ pub(crate) fn io_error(path: &Path, source: io::Error) -> JottraceError {
     }
 }
 
+/// Build a `JottraceError::UnsupportedSchemaVersion` for a database at `path`
+/// whose `actual` schema version exceeds the `supported` version. Mirrors
+/// `io_error` so the schema-too-new guard stays uniform across the migration
+/// runner, the web reader, and the archive validator instead of repeating the
+/// struct literal at every call site.
+pub(crate) fn unsupported_schema_version(
+    path: &Path,
+    actual: i64,
+    supported: i64,
+) -> JottraceError {
+    JottraceError::UnsupportedSchemaVersion {
+        path: path.to_path_buf(),
+        actual,
+        supported,
+    }
+}
+
 fn lock_token() -> String {
     let started_at = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,7 +486,7 @@ fn acquire_data_lock_file(path: &Path, token: &str) -> Result<File> {
         .write(true)
         .create(true)
         .open(path)
-        .map_err(|source| io_error(path, source))?;
+        .map_err(map_io_error(path))?;
 
     acquire_os_file_lock(&file, path)?;
     write_data_lock_metadata(&mut file, path, token)?;
@@ -589,7 +589,7 @@ pub fn create_private_file(path: &Path) -> Result<File> {
         .write(true)
         .create_new(true)
         .open(path)
-        .map_err(|source| io_error(path, source))?;
+        .map_err(map_io_error(path))?;
 
     #[cfg(unix)]
     // The open mode is the first line of defense, but chmod after creation
@@ -628,9 +628,7 @@ fn create_private_dir(path: &Path) -> Result<()> {
     let mut builder = fs::DirBuilder::new();
     builder.recursive(true);
     builder.mode(PRIVATE_DIR_MODE);
-    builder
-        .create(path)
-        .map_err(|source| io_error(path, source))?;
+    builder.create(path).map_err(map_io_error(path))?;
     // DirBuilder's mode is affected by the process umask, so enforce the final
     // permission after the directory exists.
     set_mode(path, PRIVATE_DIR_MODE)
@@ -638,7 +636,7 @@ fn create_private_dir(path: &Path) -> Result<()> {
 
 #[cfg(not(unix))]
 fn create_private_dir(path: &Path) -> Result<()> {
-    fs::create_dir_all(path).map_err(|source| io_error(path, source))
+    fs::create_dir_all(path).map_err(map_io_error(path))
 }
 
 #[cfg(unix)]
@@ -682,17 +680,17 @@ fn ensure_file_mode(_path: &Path) -> Result<()> {
 #[cfg(unix)]
 fn set_mode(path: &Path, expected: u32) -> Result<()> {
     let mut permissions = fs::metadata(path)
-        .map_err(|source| io_error(path, source))?
+        .map_err(map_io_error(path))?
         .permissions();
     permissions.set_mode(expected);
-    fs::set_permissions(path, permissions).map_err(|source| io_error(path, source))
+    fs::set_permissions(path, permissions).map_err(map_io_error(path))
 }
 
 #[cfg(unix)]
 fn mode(path: &Path) -> Result<u32> {
     // Mask out file-type bits so callers compare only the familiar chmod mode.
     Ok(fs::metadata(path)
-        .map_err(|source| io_error(path, source))?
+        .map_err(map_io_error(path))?
         .permissions()
         .mode()
         & 0o777)
@@ -716,6 +714,13 @@ pub(crate) fn io_error(path: &Path, source: io::Error) -> JottraceError {
         path: path.to_path_buf(),
         source,
     }
+}
+
+/// Build a `map_err` adapter that routes an `io::Error` through [`io_error`] for
+/// `path`, so the per-operation `|source| io_error(path, source)` closure is
+/// written once. Mirrors `storage::map_sqlite_error` for filesystem operations.
+pub(crate) fn map_io_error(path: &Path) -> impl Fn(io::Error) -> JottraceError {
+    move |source| io_error(path, source)
 }
 
 /// Build a `JottraceError::UnsupportedSchemaVersion` for a database at `path`

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,16 +308,9 @@ fn run_ingest_command(args: impl Iterator<Item = String>) -> ExitCode {
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::run_ingest() {
-        Ok(report) => {
-            print_ingest_report(&report, options.details);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("ingest", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command("ingest", jottrace::run_ingest(), |report| {
+        print_ingest_report(report, options.details);
+    })
 }
 
 fn parse_simple_command(
@@ -354,16 +347,9 @@ fn run_update_command(args: impl Iterator<Item = String>) -> ExitCode {
             print_update_help();
             ExitCode::SUCCESS
         }
-        Ok(SimpleCommand::Run) => match jottrace::run_update() {
-            Ok(report) => {
-                print_update_report(&report);
-                ExitCode::SUCCESS
-            }
-            Err(error) => {
-                eprint_command_failure("update", error);
-                ExitCode::FAILURE
-            }
-        },
+        Ok(SimpleCommand::Run) => {
+            finish_command("update", jottrace::run_update(), print_update_report)
+        }
         Err(message) => {
             eprint_command_usage("update", &message);
             ExitCode::from(2)
@@ -430,16 +416,11 @@ fn run_taste_show_example_command(args: impl Iterator<Item = String>) -> ExitCod
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::run_taste_show_example(options) {
-        Ok(report) => {
-            print_taste_example_report(&report);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("taste show example", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command(
+        "taste show example",
+        jottrace::run_taste_show_example(options),
+        print_taste_example_report,
+    )
 }
 
 fn run_taste_show_timeline_command(args: impl Iterator<Item = String>) -> ExitCode {
@@ -456,16 +437,11 @@ fn run_taste_show_timeline_command(args: impl Iterator<Item = String>) -> ExitCo
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::run_taste_show_timeline(options) {
-        Ok(report) => {
-            print_taste_timeline_report(&report);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("taste show timeline", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command(
+        "taste show timeline",
+        jottrace::run_taste_show_timeline(options),
+        print_taste_timeline_report,
+    )
 }
 
 enum TasteShowExampleCommand {
@@ -644,16 +620,9 @@ fn run_taste_status_command(args: impl Iterator<Item = String>) -> ExitCode {
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::run_taste_status() {
-        Ok(report) => {
-            print_taste_status_report(&report, options.details);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("taste status", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command("taste status", jottrace::run_taste_status(), |report| {
+        print_taste_status_report(report, options.details);
+    })
 }
 
 fn print_taste_status_report(report: &jottrace::TasteStatusReport, details: bool) {
@@ -709,16 +678,11 @@ fn run_taste_export_command(args: impl Iterator<Item = String>) -> ExitCode {
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::run_taste_export(options) {
-        Ok(report) => {
-            print_taste_export_report(&report);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("taste export", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command(
+        "taste export",
+        jottrace::run_taste_export(options),
+        print_taste_export_report,
+    )
 }
 
 fn parse_taste_export_command(
@@ -790,16 +754,11 @@ fn run_taste_extract_command(args: impl Iterator<Item = String>) -> ExitCode {
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::run_taste_extract(options.extract_options) {
-        Ok(report) => {
-            print_taste_extract_report(&report);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("taste extract", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command(
+        "taste extract",
+        jottrace::run_taste_extract(options.extract_options),
+        print_taste_extract_report,
+    )
 }
 
 fn parse_taste_extract_command(
@@ -860,19 +819,14 @@ fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::compact::run_compact_with_diagnostics(
-        cli_options.compact_options,
-        cli_options.details,
-    ) {
-        Ok(report) => {
-            print_compact_report(&report, cli_options.details);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("compact", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command(
+        "compact",
+        jottrace::compact::run_compact_with_diagnostics(
+            cli_options.compact_options,
+            cli_options.details,
+        ),
+        |report| print_compact_report(report, cli_options.details),
+    )
 }
 
 fn eprint_command_usage(command: &str, message: &str) {
@@ -882,6 +836,26 @@ fn eprint_command_usage(command: &str, message: &str) {
 
 fn eprint_command_failure(command: &str, error: impl Display) {
     eprintln!("jottrace {command} failed: {error}");
+}
+
+/// Print a command's report on success, or report the failure, mapping each to
+/// the matching exit code. Centralizes the Ok->print->SUCCESS /
+/// Err->report-failure->FAILURE shape shared by every report-producing command.
+fn finish_command<R, E: Display>(
+    command: &str,
+    result: std::result::Result<R, E>,
+    print: impl FnOnce(&R),
+) -> ExitCode {
+    match result {
+        Ok(report) => {
+            print(&report);
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprint_command_failure(command, error);
+            ExitCode::FAILURE
+        }
+    }
 }
 
 fn print_web_startup(local_url: impl AsRef<str>, db_path: &Path) {
@@ -1141,18 +1115,13 @@ fn run_doctor_command(args: impl Iterator<Item = String>) -> ExitCode {
 
     // Keep the CLI responsible for presentation while the library owns the
     // filesystem checks. That makes future commands easier to test directly.
-    match jottrace::run_doctor_with_options(jottrace::DoctorOptions {
-        include_recent_errors: options.details,
-    }) {
-        Ok(report) => {
-            print_doctor_report(&report, options.details);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("doctor", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command(
+        "doctor",
+        jottrace::run_doctor_with_options(jottrace::DoctorOptions {
+            include_recent_errors: options.details,
+        }),
+        |report| print_doctor_report(report, options.details),
+    )
 }
 
 fn run_status_command(args: impl Iterator<Item = String>) -> ExitCode {
@@ -1169,16 +1138,9 @@ fn run_status_command(args: impl Iterator<Item = String>) -> ExitCode {
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::run_status() {
-        Ok(report) => {
-            print_status_report(&report, options.details);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("status", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command("status", jottrace::run_status(), |report| {
+        print_status_report(report, options.details);
+    })
 }
 
 enum PackCommand {
@@ -1257,18 +1219,13 @@ fn run_pack_command(args: impl Iterator<Item = String>) -> ExitCode {
     };
     jottrace::update::maybe_spawn_auto_update();
 
-    match jottrace::run_pack(jottrace::PackOptions {
-        output: options.output,
-    }) {
-        Ok(report) => {
-            print_pack_report(&report);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("pack", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command(
+        "pack",
+        jottrace::run_pack(jottrace::PackOptions {
+            output: options.output,
+        }),
+        print_pack_report,
+    )
 }
 
 fn run_settle_command(args: impl Iterator<Item = String>) -> ExitCode {
@@ -1284,19 +1241,14 @@ fn run_settle_command(args: impl Iterator<Item = String>) -> ExitCode {
         }
     };
 
-    match jottrace::run_settle(jottrace::SettleOptions {
-        archive: options.archive,
-        force: options.force,
-    }) {
-        Ok(report) => {
-            print_settle_report(&report);
-            ExitCode::SUCCESS
-        }
-        Err(error) => {
-            eprint_command_failure("settle", error);
-            ExitCode::FAILURE
-        }
-    }
+    finish_command(
+        "settle",
+        jottrace::run_settle(jottrace::SettleOptions {
+            archive: options.archive,
+            force: options.force,
+        }),
+        print_settle_report,
+    )
 }
 
 fn print_help() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,56 +87,57 @@ enum SimpleCommand {
 }
 
 fn run_events_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command("events", parse_events_command(args), print_events_help) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
+    run_resolved_command(
+        "events",
+        parse_events_command(args),
+        print_events_help,
+        |options| {
+            let db_path = match jottrace::storage::db_path_from_env() {
+                Ok(db_path) => db_path,
+                Err(error) => {
+                    eprint_command_failure("events", error);
+                    return ExitCode::FAILURE;
+                }
+            };
+            let limit = match options.selection {
+                EventsSelection::All => None,
+                EventsSelection::Limit(limit) => Some(limit),
+            };
+            let stdout = io::stdout();
+            let mut stdout = io::BufWriter::new(stdout.lock());
+            let result = jottrace::storage::for_each_decoded_event_payload_for_session(
+                &db_path,
+                &options.source,
+                &options.source_session_id,
+                limit,
+                |payload| {
+                    stdout
+                        .write_all(payload)
+                        .and_then(|()| stdout.write_all(b"\n"))
+                        .map_err(|source| jottrace::JottraceError::Output { source })
+                },
+            );
 
-    let db_path = match jottrace::storage::db_path_from_env() {
-        Ok(db_path) => db_path,
-        Err(error) => {
-            eprint_command_failure("events", error);
-            return ExitCode::FAILURE;
-        }
-    };
-    let limit = match options.selection {
-        EventsSelection::All => None,
-        EventsSelection::Limit(limit) => Some(limit),
-    };
-    let stdout = io::stdout();
-    let mut stdout = io::BufWriter::new(stdout.lock());
-    let result = jottrace::storage::for_each_decoded_event_payload_for_session(
-        &db_path,
-        &options.source,
-        &options.source_session_id,
-        limit,
-        |payload| {
-            stdout
-                .write_all(payload)
-                .and_then(|()| stdout.write_all(b"\n"))
-                .map_err(|source| jottrace::JottraceError::Output { source })
+            let result = result.and_then(|()| {
+                stdout
+                    .flush()
+                    .map_err(|source| jottrace::JottraceError::Output { source })
+            });
+            if let Err(error) = result {
+                if matches!(
+                    &error,
+                    jottrace::JottraceError::Output { source }
+                        if source.kind() == io::ErrorKind::BrokenPipe
+                ) {
+                    return ExitCode::SUCCESS;
+                }
+                eprint_command_failure("events", error);
+                return ExitCode::FAILURE;
+            }
+
+            ExitCode::SUCCESS
         },
-    );
-
-    let result = result.and_then(|()| {
-        stdout
-            .flush()
-            .map_err(|source| jottrace::JottraceError::Output { source })
-    });
-    if let Err(error) = result {
-        if matches!(
-            &error,
-            jottrace::JottraceError::Output { source }
-                if source.kind() == io::ErrorKind::BrokenPipe
-        ) {
-            return ExitCode::SUCCESS;
-        }
-        eprint_command_failure("events", error);
-        return ExitCode::FAILURE;
-    }
-
-    ExitCode::SUCCESS
+    )
 }
 
 fn parse_events_command(
@@ -199,43 +200,39 @@ fn parse_events_command(
 }
 
 fn run_web_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command("web", parse_web_command(args), print_web_help) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
+    run_resolved_command("web", parse_web_command(args), print_web_help, |options| {
+        let db_path = match jottrace::storage::db_path_from_env() {
+            Ok(db_path) => db_path,
+            Err(error) => {
+                eprint_command_failure("web", error);
+                return ExitCode::FAILURE;
+            }
+        };
 
-    let db_path = match jottrace::storage::db_path_from_env() {
-        Ok(db_path) => db_path,
-        Err(error) => {
-            eprint_command_failure("web", error);
-            return ExitCode::FAILURE;
+        let server = match jottrace::web::WebServer::bind(db_path.clone(), options.port) {
+            Ok(server) => server,
+            Err(error) => {
+                eprint_command_failure("web", error);
+                return ExitCode::FAILURE;
+            }
+        };
+
+        print_web_startup(server.local_url(), &db_path);
+
+        let result = if options.once {
+            server.serve_once()
+        } else {
+            server.serve_forever()
+        };
+
+        match result {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) => {
+                eprint_command_failure("web", error);
+                ExitCode::FAILURE
+            }
         }
-    };
-
-    let server = match jottrace::web::WebServer::bind(db_path.clone(), options.port) {
-        Ok(server) => server,
-        Err(error) => {
-            eprint_command_failure("web", error);
-            return ExitCode::FAILURE;
-        }
-    };
-
-    print_web_startup(server.local_url(), &db_path);
-
-    let result = if options.once {
-        server.serve_once()
-    } else {
-        server.serve_forever()
-    };
-
-    match result {
-        Ok(()) => ExitCode::SUCCESS,
-        Err(error) => {
-            eprint_command_failure("web", error);
-            ExitCode::FAILURE
-        }
-    }
+    })
 }
 
 fn parse_web_command(
@@ -266,19 +263,16 @@ fn parse_web_command(
 }
 
 fn run_ingest_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command(
+    run_resolved_command(
         "ingest",
         parse_detail_command("ingest", args),
         print_ingest_help,
-    ) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
-
-    finish_command("ingest", jottrace::run_ingest(), |report| {
-        print_ingest_report(report, options.details);
-    })
+        |options| {
+            finish_command("ingest", jottrace::run_ingest(), |report| {
+                print_ingest_report(report, options.details);
+            })
+        },
+    )
 }
 
 fn parse_simple_command(
@@ -365,38 +359,32 @@ fn run_taste_show_command(mut args: impl Iterator<Item = String>) -> ExitCode {
 }
 
 fn run_taste_show_example_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command(
+    run_resolved_command(
         "taste show example",
         parse_taste_show_example_command(args),
         print_taste_show_example_help,
-    ) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
-
-    finish_command(
-        "taste show example",
-        jottrace::run_taste_show_example(options),
-        print_taste_example_report,
+        |options| {
+            finish_command(
+                "taste show example",
+                jottrace::run_taste_show_example(options),
+                print_taste_example_report,
+            )
+        },
     )
 }
 
 fn run_taste_show_timeline_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command(
+    run_resolved_command(
         "taste show timeline",
         parse_taste_show_timeline_command(args),
         print_taste_show_timeline_help,
-    ) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
-
-    finish_command(
-        "taste show timeline",
-        jottrace::run_taste_show_timeline(options),
-        print_taste_timeline_report,
+        |options| {
+            finish_command(
+                "taste show timeline",
+                jottrace::run_taste_show_timeline(options),
+                print_taste_timeline_report,
+            )
+        },
     )
 }
 
@@ -549,19 +537,16 @@ fn print_taste_timeline_report(report: &jottrace::TasteTimelineShowReport) {
 }
 
 fn run_taste_status_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command(
+    run_resolved_command(
         "taste status",
         parse_detail_command("taste status", args),
         print_taste_status_help,
-    ) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
-
-    finish_command("taste status", jottrace::run_taste_status(), |report| {
-        print_taste_status_report(report, options.details);
-    })
+        |options| {
+            finish_command("taste status", jottrace::run_taste_status(), |report| {
+                print_taste_status_report(report, options.details);
+            })
+        },
+    )
 }
 
 fn print_taste_status_report(report: &jottrace::TasteStatusReport, details: bool) {
@@ -599,20 +584,17 @@ fn print_taste_status_report(report: &jottrace::TasteStatusReport, details: bool
 }
 
 fn run_taste_export_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command(
+    run_resolved_command(
         "taste export",
         parse_taste_export_command(args),
         print_taste_export_help,
-    ) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
-
-    finish_command(
-        "taste export",
-        jottrace::run_taste_export(options),
-        print_taste_export_report,
+        |options| {
+            finish_command(
+                "taste export",
+                jottrace::run_taste_export(options),
+                print_taste_export_report,
+            )
+        },
     )
 }
 
@@ -672,20 +654,17 @@ fn print_taste_export_report(report: &jottrace::TasteExportReport) {
 }
 
 fn run_taste_extract_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command(
+    run_resolved_command(
         "taste extract",
         parse_taste_extract_command(args),
         print_taste_extract_help,
-    ) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
-
-    finish_command(
-        "taste extract",
-        jottrace::run_taste_extract(options.extract_options),
-        print_taste_extract_report,
+        |options| {
+            finish_command(
+                "taste extract",
+                jottrace::run_taste_extract(options.extract_options),
+                print_taste_extract_report,
+            )
+        },
     )
 }
 
@@ -734,20 +713,20 @@ fn run_auto_update_background_command(mut args: impl Iterator<Item = String>) ->
 }
 
 fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let cli_options =
-        match resolve_command("compact", parse_compact_command(args), print_compact_help) {
-            Ok(cli_options) => cli_options,
-            Err(code) => return code,
-        };
-    jottrace::update::maybe_spawn_auto_update();
-
-    finish_command(
+    run_resolved_command(
         "compact",
-        jottrace::compact::run_compact_with_diagnostics(
-            cli_options.compact_options,
-            cli_options.details,
-        ),
-        |report| print_compact_report(report, cli_options.details),
+        parse_compact_command(args),
+        print_compact_help,
+        |cli_options| {
+            finish_command(
+                "compact",
+                jottrace::compact::run_compact_with_diagnostics(
+                    cli_options.compact_options,
+                    cli_options.details,
+                ),
+                |report| print_compact_report(report, cli_options.details),
+            )
+        },
     )
 }
 
@@ -778,6 +757,26 @@ fn resolve_command<T>(
             eprint_command_usage(command, &message);
             Err(ExitCode::from(2))
         }
+    }
+}
+
+/// Resolve a parsed command, spawn the background auto-update check, then run
+/// `body` with the resolved options. Centralizes the resolve-then-spawn prologue
+/// shared by every option-carrying command runner: `Help` and parse errors
+/// short-circuit to their exit code (via [`resolve_command`]) without spawning
+/// the updater or invoking `body`.
+fn run_resolved_command<T>(
+    command: &str,
+    parsed: std::result::Result<ParsedCommand<T>, String>,
+    print_help: fn(),
+    body: impl FnOnce(T) -> ExitCode,
+) -> ExitCode {
+    match resolve_command(command, parsed, print_help) {
+        Ok(options) => {
+            jottrace::update::maybe_spawn_auto_update();
+            body(options)
+        }
+        Err(code) => code,
     }
 }
 
@@ -1043,41 +1042,36 @@ fn compact_mode_name(mode: jottrace::CompactMode) -> &'static str {
 }
 
 fn run_doctor_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command(
+    run_resolved_command(
         "doctor",
         parse_detail_command("doctor", args),
         print_doctor_help,
-    ) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
-
-    // Keep the CLI responsible for presentation while the library owns the
-    // filesystem checks. That makes future commands easier to test directly.
-    finish_command(
-        "doctor",
-        jottrace::run_doctor_with_options(jottrace::DoctorOptions {
-            include_recent_errors: options.details,
-        }),
-        |report| print_doctor_report(report, options.details),
+        |options| {
+            // Keep the CLI responsible for presentation while the library owns
+            // the filesystem checks. That makes future commands easier to test
+            // directly.
+            finish_command(
+                "doctor",
+                jottrace::run_doctor_with_options(jottrace::DoctorOptions {
+                    include_recent_errors: options.details,
+                }),
+                |report| print_doctor_report(report, options.details),
+            )
+        },
     )
 }
 
 fn run_status_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command(
+    run_resolved_command(
         "status",
         parse_detail_command("status", args),
         print_status_help,
-    ) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
-
-    finish_command("status", jottrace::run_status(), |report| {
-        print_status_report(report, options.details);
-    })
+        |options| {
+            finish_command("status", jottrace::run_status(), |report| {
+                print_status_report(report, options.details);
+            })
+        },
+    )
 }
 
 struct PackCliOptions {
@@ -1133,18 +1127,19 @@ fn parse_settle_command(
 }
 
 fn run_pack_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match resolve_command("pack", parse_pack_command(args), print_pack_help) {
-        Ok(options) => options,
-        Err(code) => return code,
-    };
-    jottrace::update::maybe_spawn_auto_update();
-
-    finish_command(
+    run_resolved_command(
         "pack",
-        jottrace::run_pack(jottrace::PackOptions {
-            output: options.output,
-        }),
-        print_pack_report,
+        parse_pack_command(args),
+        print_pack_help,
+        |options| {
+            finish_command(
+                "pack",
+                jottrace::run_pack(jottrace::PackOptions {
+                    output: options.output,
+                }),
+                print_pack_report,
+            )
+        },
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1087,9 +1087,7 @@ fn parse_pack_command(
         match arg.as_str() {
             "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--output" | "-o" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| String::from("missing value for --output"))?;
+                let value = next_flag_value(&mut args, "--output")?;
                 options.output = Some(PathBuf::from(value));
             }
             _ => return Err(format!("unknown pack option: {arg}")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,12 @@ enum EventsSelection {
     Limit(i64),
 }
 
+/// Outcome of parsing a command's arguments: run with `T` options, or print
+/// help. Parse errors are returned separately as `Err(String)` by the parse
+/// functions and surfaced by [`resolve_command`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum EventsCommand {
-    Run(EventsOptions),
+enum ParsedCommand<T> {
+    Run(T),
     Help,
 }
 
@@ -67,32 +70,14 @@ struct WebOptions {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WebCommand {
-    Run(WebOptions),
-    Help,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CompactCliOptions {
     compact_options: jottrace::CompactOptions,
     details: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CompactCommand {
-    Run(CompactCliOptions),
-    Help,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DetailOptions {
     details: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DetailCommand {
-    Run(DetailOptions),
-    Help,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -102,16 +87,9 @@ enum SimpleCommand {
 }
 
 fn run_events_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_events_command(args) {
-        Ok(EventsCommand::Run(options)) => options,
-        Ok(EventsCommand::Help) => {
-            print_events_help();
-            return ExitCode::SUCCESS;
-        }
-        Err(message) => {
-            eprint_command_usage("events", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command("events", parse_events_command(args), print_events_help) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -163,7 +141,7 @@ fn run_events_command(args: impl Iterator<Item = String>) -> ExitCode {
 
 fn parse_events_command(
     mut args: impl Iterator<Item = String>,
-) -> std::result::Result<EventsCommand, String> {
+) -> std::result::Result<ParsedCommand<EventsOptions>, String> {
     let mut source_session_id = None;
     let mut source = None;
     let mut limit = None;
@@ -171,7 +149,7 @@ fn parse_events_command(
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(EventsCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--all" => all = true,
             "--source" => {
                 source = Some(
@@ -213,7 +191,7 @@ fn parse_events_command(
         (false, None) => return Err("events requires --limit <n> or --all".to_string()),
     };
 
-    Ok(EventsCommand::Run(EventsOptions {
+    Ok(ParsedCommand::Run(EventsOptions {
         source,
         source_session_id,
         selection,
@@ -221,16 +199,9 @@ fn parse_events_command(
 }
 
 fn run_web_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_web_command(args) {
-        Ok(WebCommand::Run(options)) => options,
-        Ok(WebCommand::Help) => {
-            print_web_help();
-            return ExitCode::SUCCESS;
-        }
-        Err(message) => {
-            eprint_command_usage("web", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command("web", parse_web_command(args), print_web_help) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -269,7 +240,7 @@ fn run_web_command(args: impl Iterator<Item = String>) -> ExitCode {
 
 fn parse_web_command(
     mut args: impl Iterator<Item = String>,
-) -> std::result::Result<WebCommand, String> {
+) -> std::result::Result<ParsedCommand<WebOptions>, String> {
     let mut options = WebOptions {
         port: 0,
         once: false,
@@ -277,7 +248,7 @@ fn parse_web_command(
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(WebCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--once" => options.once = true,
             "--port" => {
                 let value = args
@@ -291,20 +262,17 @@ fn parse_web_command(
         }
     }
 
-    Ok(WebCommand::Run(options))
+    Ok(ParsedCommand::Run(options))
 }
 
 fn run_ingest_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_detail_command("ingest", args) {
-        Ok(DetailCommand::Help) => {
-            print_ingest_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(DetailCommand::Run(options)) => options,
-        Err(message) => {
-            eprint_command_usage("ingest", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command(
+        "ingest",
+        parse_detail_command("ingest", args),
+        print_ingest_help,
+    ) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -327,18 +295,18 @@ fn parse_simple_command(
 fn parse_detail_command(
     command: &str,
     args: impl Iterator<Item = String>,
-) -> std::result::Result<DetailCommand, String> {
+) -> std::result::Result<ParsedCommand<DetailOptions>, String> {
     let mut options = DetailOptions { details: false };
 
     for arg in args {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(DetailCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--details" => options.details = true,
             _ => return Err(format!("unknown {command} option: {arg}")),
         }
     }
 
-    Ok(DetailCommand::Run(options))
+    Ok(ParsedCommand::Run(options))
 }
 
 fn run_update_command(args: impl Iterator<Item = String>) -> ExitCode {
@@ -360,12 +328,6 @@ fn run_update_command(args: impl Iterator<Item = String>) -> ExitCode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TasteExtractCliOptions {
     extract_options: jottrace::TasteExtractOptions,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum TasteCommand {
-    Extract(TasteExtractCliOptions),
-    Help,
 }
 
 fn run_taste_command(mut args: impl Iterator<Item = String>) -> ExitCode {
@@ -403,16 +365,13 @@ fn run_taste_show_command(mut args: impl Iterator<Item = String>) -> ExitCode {
 }
 
 fn run_taste_show_example_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_taste_show_example_command(args) {
-        Ok(TasteShowExampleCommand::Help) => {
-            print_taste_show_example_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(TasteShowExampleCommand::Run(options)) => options,
-        Err(message) => {
-            eprint_command_usage("taste show example", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command(
+        "taste show example",
+        parse_taste_show_example_command(args),
+        print_taste_show_example_help,
+    ) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -424,16 +383,13 @@ fn run_taste_show_example_command(args: impl Iterator<Item = String>) -> ExitCod
 }
 
 fn run_taste_show_timeline_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_taste_show_timeline_command(args) {
-        Ok(TasteShowTimelineCommand::Help) => {
-            print_taste_show_timeline_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(TasteShowTimelineCommand::Run(options)) => options,
-        Err(message) => {
-            eprint_command_usage("taste show timeline", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command(
+        "taste show timeline",
+        parse_taste_show_timeline_command(args),
+        print_taste_show_timeline_help,
+    ) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -442,16 +398,6 @@ fn run_taste_show_timeline_command(args: impl Iterator<Item = String>) -> ExitCo
         jottrace::run_taste_show_timeline(options),
         print_taste_timeline_report,
     )
-}
-
-enum TasteShowExampleCommand {
-    Run(jottrace::TasteShowExampleOptions),
-    Help,
-}
-
-enum TasteShowTimelineCommand {
-    Run(jottrace::TasteShowTimelineOptions),
-    Help,
 }
 
 /// Consume the value following a single-value flag, rejecting a repeated flag.
@@ -475,13 +421,13 @@ fn take_single_flag_value(
 
 fn parse_taste_show_example_command(
     mut args: impl Iterator<Item = String>,
-) -> std::result::Result<TasteShowExampleCommand, String> {
+) -> std::result::Result<ParsedCommand<jottrace::TasteShowExampleOptions>, String> {
     let mut source_session_id = None;
     let mut tool_use_id = None;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(TasteShowExampleCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--session" => {
                 source_session_id = Some(take_single_flag_value(
                     &mut args,
@@ -507,23 +453,21 @@ fn parse_taste_show_example_command(
     let tool_use_id =
         tool_use_id.ok_or_else(|| "taste show example requires <tool_use_id>".to_string())?;
 
-    Ok(TasteShowExampleCommand::Run(
-        jottrace::TasteShowExampleOptions {
-            tool_use_id,
-            source_session_id,
-        },
-    ))
+    Ok(ParsedCommand::Run(jottrace::TasteShowExampleOptions {
+        tool_use_id,
+        source_session_id,
+    }))
 }
 
 fn parse_taste_show_timeline_command(
     mut args: impl Iterator<Item = String>,
-) -> std::result::Result<TasteShowTimelineCommand, String> {
+) -> std::result::Result<ParsedCommand<jottrace::TasteShowTimelineOptions>, String> {
     let mut source_session_id = None;
     let mut file_path = None;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(TasteShowTimelineCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--session" => {
                 source_session_id = Some(take_single_flag_value(
                     &mut args,
@@ -549,12 +493,10 @@ fn parse_taste_show_timeline_command(
     let file_path =
         file_path.ok_or_else(|| "taste show timeline requires --file <path>".to_string())?;
 
-    Ok(TasteShowTimelineCommand::Run(
-        jottrace::TasteShowTimelineOptions {
-            source_session_id,
-            file_path,
-        },
-    ))
+    Ok(ParsedCommand::Run(jottrace::TasteShowTimelineOptions {
+        source_session_id,
+        file_path,
+    }))
 }
 
 fn print_taste_example_report(report: &jottrace::TasteExampleShowReport) {
@@ -607,16 +549,13 @@ fn print_taste_timeline_report(report: &jottrace::TasteTimelineShowReport) {
 }
 
 fn run_taste_status_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_detail_command("taste status", args) {
-        Ok(DetailCommand::Help) => {
-            print_taste_status_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(DetailCommand::Run(options)) => options,
-        Err(message) => {
-            eprint_command_usage("taste status", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command(
+        "taste status",
+        parse_detail_command("taste status", args),
+        print_taste_status_help,
+    ) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -659,22 +598,14 @@ fn print_taste_status_report(report: &jottrace::TasteStatusReport, details: bool
     }
 }
 
-enum TasteExportCommand {
-    Run(jottrace::TasteExportOptions),
-    Help,
-}
-
 fn run_taste_export_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_taste_export_command(args) {
-        Ok(TasteExportCommand::Help) => {
-            print_taste_export_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(TasteExportCommand::Run(options)) => options,
-        Err(message) => {
-            eprint_command_usage("taste export", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command(
+        "taste export",
+        parse_taste_export_command(args),
+        print_taste_export_help,
+    ) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -687,13 +618,13 @@ fn run_taste_export_command(args: impl Iterator<Item = String>) -> ExitCode {
 
 fn parse_taste_export_command(
     mut args: impl Iterator<Item = String>,
-) -> std::result::Result<TasteExportCommand, String> {
+) -> std::result::Result<ParsedCommand<jottrace::TasteExportOptions>, String> {
     let mut format = None;
     let mut output_path = None;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(TasteExportCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--format" => {
                 let value = take_single_flag_value(
                     &mut args,
@@ -724,7 +655,7 @@ fn parse_taste_export_command(
 
     let format = format.ok_or_else(|| "taste export requires --format <format>".to_string())?;
 
-    Ok(TasteExportCommand::Run(jottrace::TasteExportOptions {
+    Ok(ParsedCommand::Run(jottrace::TasteExportOptions {
         format,
         output_path,
     }))
@@ -741,16 +672,13 @@ fn print_taste_export_report(report: &jottrace::TasteExportReport) {
 }
 
 fn run_taste_extract_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_taste_extract_command(args) {
-        Ok(TasteCommand::Help) => {
-            print_taste_extract_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(TasteCommand::Extract(cli_options)) => cli_options,
-        Err(message) => {
-            eprint_command_usage("taste extract", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command(
+        "taste extract",
+        parse_taste_extract_command(args),
+        print_taste_extract_help,
+    ) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -763,12 +691,12 @@ fn run_taste_extract_command(args: impl Iterator<Item = String>) -> ExitCode {
 
 fn parse_taste_extract_command(
     mut args: impl Iterator<Item = String>,
-) -> std::result::Result<TasteCommand, String> {
+) -> std::result::Result<ParsedCommand<TasteExtractCliOptions>, String> {
     let mut options = jottrace::TasteExtractOptions::default();
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(TasteCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--force" => options.force = true,
             "--session" => {
                 options.source_session_id = Some(take_single_flag_value(
@@ -782,7 +710,7 @@ fn parse_taste_extract_command(
         }
     }
 
-    Ok(TasteCommand::Extract(TasteExtractCliOptions {
+    Ok(ParsedCommand::Run(TasteExtractCliOptions {
         extract_options: options,
     }))
 }
@@ -806,17 +734,11 @@ fn run_auto_update_background_command(mut args: impl Iterator<Item = String>) ->
 }
 
 fn run_compact_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let cli_options = match parse_compact_command(args) {
-        Ok(CompactCommand::Run(cli_options)) => cli_options,
-        Ok(CompactCommand::Help) => {
-            print_compact_help();
-            return ExitCode::SUCCESS;
-        }
-        Err(message) => {
-            eprint_command_usage("compact", &message);
-            return ExitCode::from(2);
-        }
-    };
+    let cli_options =
+        match resolve_command("compact", parse_compact_command(args), print_compact_help) {
+            Ok(cli_options) => cli_options,
+            Err(code) => return code,
+        };
     jottrace::update::maybe_spawn_auto_update();
 
     finish_command(
@@ -836,6 +758,27 @@ fn eprint_command_usage(command: &str, message: &str) {
 
 fn eprint_command_failure(command: &str, error: impl Display) {
     eprintln!("jottrace {command} failed: {error}");
+}
+
+/// Resolve a parsed command into its run options, or an [`ExitCode`] the caller
+/// should return immediately: `Help` prints usage and exits 0, a parse error
+/// prints the usage hint and exits 2.
+fn resolve_command<T>(
+    command: &str,
+    parsed: std::result::Result<ParsedCommand<T>, String>,
+    print_help: fn(),
+) -> std::result::Result<T, ExitCode> {
+    match parsed {
+        Ok(ParsedCommand::Run(options)) => Ok(options),
+        Ok(ParsedCommand::Help) => {
+            print_help();
+            Err(ExitCode::SUCCESS)
+        }
+        Err(message) => {
+            eprint_command_usage(command, &message);
+            Err(ExitCode::from(2))
+        }
+    }
 }
 
 /// Print a command's report on success, or report the failure, mapping each to
@@ -1032,7 +975,7 @@ fn print_compact_report(report: &jottrace::CompactReport, details: bool) {
 
 fn parse_compact_command(
     mut args: impl Iterator<Item = String>,
-) -> std::result::Result<CompactCommand, String> {
+) -> std::result::Result<ParsedCommand<CompactCliOptions>, String> {
     let mut options = jottrace::CompactOptions::default();
     let mut details = false;
     let mut explicit_mode = false;
@@ -1040,7 +983,7 @@ fn parse_compact_command(
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(CompactCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--details" => details = true,
             "--apply" => {
                 if explicit_mode {
@@ -1085,7 +1028,7 @@ fn parse_compact_command(
         }
     }
 
-    Ok(CompactCommand::Run(CompactCliOptions {
+    Ok(ParsedCommand::Run(CompactCliOptions {
         compact_options: options,
         details,
     }))
@@ -1100,16 +1043,13 @@ fn compact_mode_name(mode: jottrace::CompactMode) -> &'static str {
 }
 
 fn run_doctor_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_detail_command("doctor", args) {
-        Ok(DetailCommand::Help) => {
-            print_doctor_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(DetailCommand::Run(options)) => options,
-        Err(message) => {
-            eprint_command_usage("doctor", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command(
+        "doctor",
+        parse_detail_command("doctor", args),
+        print_doctor_help,
+    ) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -1125,16 +1065,13 @@ fn run_doctor_command(args: impl Iterator<Item = String>) -> ExitCode {
 }
 
 fn run_status_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_detail_command("status", args) {
-        Ok(DetailCommand::Help) => {
-            print_status_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(DetailCommand::Run(options)) => options,
-        Err(message) => {
-            eprint_command_usage("status", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command(
+        "status",
+        parse_detail_command("status", args),
+        print_status_help,
+    ) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -1143,18 +1080,8 @@ fn run_status_command(args: impl Iterator<Item = String>) -> ExitCode {
     })
 }
 
-enum PackCommand {
-    Run(PackCliOptions),
-    Help,
-}
-
 struct PackCliOptions {
     output: Option<PathBuf>,
-}
-
-enum SettleCommand {
-    Run(SettleCliOptions),
-    Help,
 }
 
 struct SettleCliOptions {
@@ -1164,11 +1091,11 @@ struct SettleCliOptions {
 
 fn parse_pack_command(
     mut args: impl Iterator<Item = String>,
-) -> std::result::Result<PackCommand, String> {
+) -> std::result::Result<ParsedCommand<PackCliOptions>, String> {
     let mut options = PackCliOptions { output: None };
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(PackCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--output" | "-o" => {
                 let value = args
                     .next()
@@ -1178,17 +1105,17 @@ fn parse_pack_command(
             _ => return Err(format!("unknown pack option: {arg}")),
         }
     }
-    Ok(PackCommand::Run(options))
+    Ok(ParsedCommand::Run(options))
 }
 
 fn parse_settle_command(
     args: impl Iterator<Item = String>,
-) -> std::result::Result<SettleCommand, String> {
+) -> std::result::Result<ParsedCommand<SettleCliOptions>, String> {
     let mut archive: Option<PathBuf> = None;
     let mut force = false;
     for arg in args {
         match arg.as_str() {
-            "--help" | "-h" => return Ok(SettleCommand::Help),
+            "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--force" => force = true,
             arg if arg.starts_with("--") => {
                 return Err(format!("unknown settle option: {arg}"));
@@ -1202,20 +1129,13 @@ fn parse_settle_command(
         }
     }
     let archive = archive.ok_or_else(|| String::from("missing archive path"))?;
-    Ok(SettleCommand::Run(SettleCliOptions { archive, force }))
+    Ok(ParsedCommand::Run(SettleCliOptions { archive, force }))
 }
 
 fn run_pack_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_pack_command(args) {
-        Ok(PackCommand::Help) => {
-            print_pack_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(PackCommand::Run(options)) => options,
-        Err(message) => {
-            eprint_command_usage("pack", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command("pack", parse_pack_command(args), print_pack_help) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
     jottrace::update::maybe_spawn_auto_update();
 
@@ -1229,16 +1149,9 @@ fn run_pack_command(args: impl Iterator<Item = String>) -> ExitCode {
 }
 
 fn run_settle_command(args: impl Iterator<Item = String>) -> ExitCode {
-    let options = match parse_settle_command(args) {
-        Ok(SettleCommand::Help) => {
-            print_settle_help();
-            return ExitCode::SUCCESS;
-        }
-        Ok(SettleCommand::Run(options)) => options,
-        Err(message) => {
-            eprint_command_usage("settle", &message);
-            return ExitCode::from(2);
-        }
+    let options = match resolve_command("settle", parse_settle_command(args), print_settle_help) {
+        Ok(options) => options,
+        Err(code) => return code,
     };
 
     finish_command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -478,6 +478,25 @@ enum TasteShowTimelineCommand {
     Help,
 }
 
+/// Consume the value following a single-value flag, rejecting a repeated flag.
+///
+/// The value is always consumed first, so a missing value is reported before a
+/// duplicate — matching the inline order these call sites previously used.
+fn take_single_flag_value(
+    args: &mut impl Iterator<Item = String>,
+    flag: &str,
+    command: &str,
+    already_set: bool,
+) -> std::result::Result<String, String> {
+    let value = args
+        .next()
+        .ok_or_else(|| format!("{flag} requires a value"))?;
+    if already_set {
+        return Err(format!("{command} accepts only one {flag} value"));
+    }
+    Ok(value)
+}
+
 fn parse_taste_show_example_command(
     mut args: impl Iterator<Item = String>,
 ) -> std::result::Result<TasteShowExampleCommand, String> {
@@ -488,13 +507,12 @@ fn parse_taste_show_example_command(
         match arg.as_str() {
             "--help" | "-h" => return Ok(TasteShowExampleCommand::Help),
             "--session" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--session requires a value".to_string())?;
-                if source_session_id.is_some() {
-                    return Err("taste show example accepts only one --session value".to_string());
-                }
-                source_session_id = Some(value);
+                source_session_id = Some(take_single_flag_value(
+                    &mut args,
+                    "--session",
+                    "taste show example",
+                    source_session_id.is_some(),
+                )?);
             }
             value if value.starts_with('-') => {
                 return Err(format!("unknown taste show example option: {value}"));
@@ -531,22 +549,20 @@ fn parse_taste_show_timeline_command(
         match arg.as_str() {
             "--help" | "-h" => return Ok(TasteShowTimelineCommand::Help),
             "--session" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--session requires a value".to_string())?;
-                if source_session_id.is_some() {
-                    return Err("taste show timeline accepts only one --session value".to_string());
-                }
-                source_session_id = Some(value);
+                source_session_id = Some(take_single_flag_value(
+                    &mut args,
+                    "--session",
+                    "taste show timeline",
+                    source_session_id.is_some(),
+                )?);
             }
             "--file" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--file requires a value".to_string())?;
-                if file_path.is_some() {
-                    return Err("taste show timeline accepts only one --file value".to_string());
-                }
-                file_path = Some(value);
+                file_path = Some(take_single_flag_value(
+                    &mut args,
+                    "--file",
+                    "taste show timeline",
+                    file_path.is_some(),
+                )?);
             }
             _ => return Err(format!("unknown taste show timeline option: {arg}")),
         }
@@ -715,24 +731,24 @@ fn parse_taste_export_command(
         match arg.as_str() {
             "--help" | "-h" => return Ok(TasteExportCommand::Help),
             "--format" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--format requires a value".to_string())?;
-                if format.is_some() {
-                    return Err("taste export accepts only one --format value".to_string());
-                }
+                let value = take_single_flag_value(
+                    &mut args,
+                    "--format",
+                    "taste export",
+                    format.is_some(),
+                )?;
                 format = Some(
                     jottrace::TasteExportFormat::from_cli(&value)
                         .ok_or_else(|| format!("unsupported export format: {value}"))?,
                 );
             }
             "--out" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--out requires a value".to_string())?;
-                if output_path.is_some() {
-                    return Err("taste export accepts only one --out value".to_string());
-                }
+                let value = take_single_flag_value(
+                    &mut args,
+                    "--out",
+                    "taste export",
+                    output_path.is_some(),
+                )?;
                 output_path = Some(PathBuf::from(value));
             }
             value if value.starts_with('-') => {
@@ -796,13 +812,12 @@ fn parse_taste_extract_command(
             "--help" | "-h" => return Ok(TasteCommand::Help),
             "--force" => options.force = true,
             "--session" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--session requires a value".to_string())?;
-                if options.source_session_id.is_some() {
-                    return Err("taste extract accepts only one --session value".to_string());
-                }
-                options.source_session_id = Some(value);
+                options.source_session_id = Some(take_single_flag_value(
+                    &mut args,
+                    "--session",
+                    "taste extract",
+                    options.source_session_id.is_some(),
+                )?);
             }
             _ => return Err(format!("unknown taste extract option: {arg}")),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,21 +153,13 @@ fn parse_events_command(
             "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--all" => all = true,
             "--source" => {
-                source = Some(
-                    args.next()
-                        .ok_or_else(|| "--source requires a value".to_string())?,
-                );
+                source = Some(next_flag_value(&mut args, "--source")?);
             }
             "--session" => {
-                source_session_id = Some(
-                    args.next()
-                        .ok_or_else(|| "--session requires a value".to_string())?,
-                );
+                source_session_id = Some(next_flag_value(&mut args, "--session")?);
             }
             "--limit" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--limit requires a value".to_string())?;
+                let value = next_flag_value(&mut args, "--limit")?;
                 let parsed = value
                     .parse::<i64>()
                     .map_err(|_| format!("invalid limit: {value}"))?;
@@ -248,9 +240,7 @@ fn parse_web_command(
             "--help" | "-h" => return Ok(ParsedCommand::Help),
             "--once" => options.once = true,
             "--port" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--port requires a value".to_string())?;
+                let value = next_flag_value(&mut args, "--port")?;
                 options.port = value
                     .parse()
                     .map_err(|_| format!("invalid port: {value}"))?;
@@ -388,6 +378,16 @@ fn run_taste_show_timeline_command(args: impl Iterator<Item = String>) -> ExitCo
     )
 }
 
+/// Consume the value following a flag, erroring `"{flag} requires a value"`
+/// when the flag is the final argument.
+fn next_flag_value(
+    args: &mut impl Iterator<Item = String>,
+    flag: &str,
+) -> std::result::Result<String, String> {
+    args.next()
+        .ok_or_else(|| format!("{flag} requires a value"))
+}
+
 /// Consume the value following a single-value flag, rejecting a repeated flag.
 ///
 /// The value is always consumed first, so a missing value is reported before a
@@ -398,9 +398,7 @@ fn take_single_flag_value(
     command: &str,
     already_set: bool,
 ) -> std::result::Result<String, String> {
-    let value = args
-        .next()
-        .ok_or_else(|| format!("{flag} requires a value"))?;
+    let value = next_flag_value(args, flag)?;
     if already_set {
         return Err(format!("{command} accepts only one {flag} value"));
     }
@@ -1005,9 +1003,7 @@ fn parse_compact_command(
                 if options.mode == jottrace::CompactMode::Vacuum {
                     return Err("compact --vacuum does not accept --batch-size".to_string());
                 }
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--batch-size requires a value".to_string())?;
+                let value = next_flag_value(&mut args, "--batch-size")?;
                 let parsed = value
                     .parse::<usize>()
                     .map_err(|_| format!("invalid batch size: {value}"))?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -488,7 +488,7 @@ pub(crate) fn count(
     params: impl rusqlite::Params,
 ) -> Result<u64> {
     let value: i64 = query_one(path, conn, sql, params, |row| row.get(0))?;
-    Ok(value as u64)
+    Ok(u64::try_from(value).expect("count fits in u64"))
 }
 
 fn user_version(path: &Path, conn: &Connection) -> Result<i64> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -191,7 +191,7 @@ fn raw_event_payload(payload: &[u8]) -> EncodedEventPayload {
 pub fn open_database(path: &Path) -> Result<Connection> {
     ensure_private_file(path)?;
 
-    let mut conn = Connection::open(path).map_err(|source| sqlite_error(path, source))?;
+    let mut conn = Connection::open(path).map_err(map_sqlite_error(path))?;
     configure_connection(path, &conn)?;
     run_migrations(path, &mut conn)?;
     Ok(conn)
@@ -215,12 +215,12 @@ pub(crate) fn open_readonly_database(
 
 fn configure_connection(path: &Path, conn: &Connection) -> Result<()> {
     conn.busy_timeout(Duration::from_secs(5))
-        .map_err(|source| sqlite_error(path, source))?;
+        .map_err(map_sqlite_error(path))?;
     conn.execute_batch(
         "PRAGMA foreign_keys = ON;
          PRAGMA journal_mode = WAL;",
     )
-    .map_err(|source| sqlite_error(path, source))
+    .map_err(map_sqlite_error(path))
 }
 
 fn run_migrations(path: &Path, conn: &mut Connection) -> Result<()> {
@@ -238,21 +238,19 @@ fn run_migrations(path: &Path, conn: &mut Connection) -> Result<()> {
         return Ok(());
     }
 
-    let tx = conn
-        .transaction()
-        .map_err(|source| sqlite_error(path, source))?;
+    let tx = conn.transaction().map_err(map_sqlite_error(path))?;
 
     for migration in MIGRATIONS
         .iter()
         .filter(|migration| migration.version > current)
     {
         tx.execute_batch(migration.sql)
-            .map_err(|source| sqlite_error(path, source))?;
+            .map_err(map_sqlite_error(path))?;
         tx.pragma_update(None, "user_version", migration.version)
-            .map_err(|source| sqlite_error(path, source))?;
+            .map_err(map_sqlite_error(path))?;
     }
 
-    tx.commit().map_err(|source| sqlite_error(path, source))
+    tx.commit().map_err(map_sqlite_error(path))
 }
 
 pub(crate) fn status_from_connection(path: &Path, conn: &Connection) -> Result<StatusReport> {
@@ -360,19 +358,17 @@ fn for_each_decoded_event_payload_from_connection(
              ORDER BY events.generation, events.seq"
         }
     };
-    let mut statement = conn
-        .prepare(sql)
-        .map_err(|source| sqlite_error(path, source))?;
+    let mut statement = conn.prepare(sql).map_err(map_sqlite_error(path))?;
     let mut rows = match limit {
         Some(limit) => statement
             .query(params![session_id, limit])
-            .map_err(|source| sqlite_error(path, source))?,
+            .map_err(map_sqlite_error(path))?,
         None => statement
             .query(params![session_id])
-            .map_err(|source| sqlite_error(path, source))?,
+            .map_err(map_sqlite_error(path))?,
     };
 
-    while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
+    while let Some(row) = rows.next().map_err(map_sqlite_error(path))? {
         let payload: Vec<u8> = row_value(path, row, 0)?;
         let codec: String = row_value(path, row, 1)?;
         if codec == RAW_CODEC {
@@ -510,6 +506,14 @@ pub(crate) fn sqlite_error(path: &Path, source: rusqlite::Error) -> JottraceErro
     }
 }
 
+/// Build a `map_err` adapter that routes a `rusqlite::Error` through [`sqlite_error`]
+/// for `path`, so the per-operation `|source| sqlite_error(path, source)` closure is
+/// written once. Used by the open/transaction/prepare/commit calls and manual
+/// row-streaming loops that fall outside the row-mapping query helpers.
+pub(crate) fn map_sqlite_error(path: &Path) -> impl Fn(rusqlite::Error) -> JottraceError {
+    move |source| sqlite_error(path, source)
+}
+
 /// Prepare `sql`, run it with `params`, and collect every mapped row into a `Vec`,
 /// routing each fallible step's failure through [`sqlite_error`] for `path`.
 pub(crate) fn query_collect<T, P, F>(
@@ -523,14 +527,12 @@ where
     P: rusqlite::Params,
     F: FnMut(&Row<'_>) -> rusqlite::Result<T>,
 {
-    let mut statement = conn
-        .prepare(sql)
-        .map_err(|source| sqlite_error(path, source))?;
+    let mut statement = conn.prepare(sql).map_err(map_sqlite_error(path))?;
     statement
         .query_map(params, mapper)
-        .map_err(|source| sqlite_error(path, source))?
+        .map_err(map_sqlite_error(path))?
         .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|source| sqlite_error(path, source))
+        .map_err(map_sqlite_error(path))
 }
 
 /// Run `sql` with `params`, returning the single mapped row if present (`Ok(None)` when
@@ -548,7 +550,7 @@ where
 {
     conn.query_row(sql, params, mapper)
         .optional()
-        .map_err(|source| sqlite_error(path, source))
+        .map_err(map_sqlite_error(path))
 }
 
 /// Run `sql` with `params`, returning the single mapped row and routing query
@@ -565,7 +567,7 @@ where
     F: FnOnce(&Row<'_>) -> rusqlite::Result<T>,
 {
     conn.query_row(sql, params, mapper)
-        .map_err(|source| sqlite_error(path, source))
+        .map_err(map_sqlite_error(path))
 }
 
 /// Execute `sql` with `params`, returning the number of affected rows and
@@ -574,8 +576,7 @@ pub(crate) fn execute_sql<P>(path: &Path, conn: &Connection, sql: &str, params: 
 where
     P: rusqlite::Params,
 {
-    conn.execute(sql, params)
-        .map_err(|source| sqlite_error(path, source))
+    conn.execute(sql, params).map_err(map_sqlite_error(path))
 }
 
 /// Read column `idx` from `row`, routing an access/decode failure through
@@ -586,7 +587,7 @@ pub(crate) fn row_value<T>(path: &Path, row: &Row<'_>, idx: usize) -> Result<T>
 where
     T: rusqlite::types::FromSql,
 {
-    row.get(idx).map_err(|source| sqlite_error(path, source))
+    row.get(idx).map_err(map_sqlite_error(path))
 }
 
 #[cfg(test)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -531,6 +531,16 @@ where
         .map_err(|source| sqlite_error(path, source))
 }
 
+/// Execute `sql` with `params`, returning the number of affected rows and
+/// routing failures through [`sqlite_error`] for `path`.
+pub(crate) fn execute_sql<P>(path: &Path, conn: &Connection, sql: &str, params: P) -> Result<usize>
+where
+    P: rusqlite::Params,
+{
+    conn.execute(sql, params)
+        .map_err(|source| sqlite_error(path, source))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,7 +3,9 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use crate::{JottraceError, Result, data_dir_from_env, ensure_private_file};
+use crate::{
+    JottraceError, Result, data_dir_from_env, ensure_private_file, unsupported_schema_version,
+};
 
 pub const DB_FILE_NAME: &str = "db.sqlite";
 pub const LATEST_SCHEMA_VERSION: i64 = 13;
@@ -225,11 +227,11 @@ fn run_migrations(path: &Path, conn: &mut Connection) -> Result<()> {
     let current = user_version(path, conn)?;
 
     if current > LATEST_SCHEMA_VERSION {
-        return Err(JottraceError::UnsupportedSchemaVersion {
-            path: path.to_path_buf(),
-            actual: current,
-            supported: LATEST_SCHEMA_VERSION,
-        });
+        return Err(unsupported_schema_version(
+            path,
+            current,
+            LATEST_SCHEMA_VERSION,
+        ));
     }
 
     if current == LATEST_SCHEMA_VERSION {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -257,8 +257,8 @@ pub(crate) fn status_from_connection(path: &Path, conn: &Connection) -> Result<S
     Ok(StatusReport {
         db_path: path.to_path_buf(),
         schema_version: user_version(path, conn)?,
-        session_count: count(path, conn, "SELECT COUNT(*) FROM sessions")?,
-        event_count: count(path, conn, "SELECT COUNT(*) FROM events")?,
+        session_count: count(path, conn, "SELECT COUNT(*) FROM sessions", [])?,
+        event_count: count(path, conn, "SELECT COUNT(*) FROM events", [])?,
         unresolved_ingest_error_count: unresolved_ingest_error_count_from_connection(path, conn)?,
     })
 }
@@ -267,7 +267,7 @@ pub(crate) fn unresolved_ingest_error_count_from_connection(
     path: &Path,
     conn: &Connection,
 ) -> Result<u64> {
-    count(path, conn, UNRESOLVED_INGEST_ERROR_COUNT_SQL)
+    count(path, conn, UNRESOLVED_INGEST_ERROR_COUNT_SQL, [])
 }
 
 pub(crate) fn unresolved_ingest_errors_from_connection(
@@ -487,8 +487,13 @@ fn ingest_error_summary_from_row(row: &Row<'_>) -> rusqlite::Result<IngestErrorS
     })
 }
 
-fn count(path: &Path, conn: &Connection, sql: &str) -> Result<u64> {
-    let value: i64 = query_one(path, conn, sql, [], |row| row.get(0))?;
+pub(crate) fn count(
+    path: &Path,
+    conn: &Connection,
+    sql: &str,
+    params: impl rusqlite::Params,
+) -> Result<u64> {
+    let value: i64 = query_one(path, conn, sql, params, |row| row.get(0))?;
     Ok(value as u64)
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -472,15 +472,12 @@ fn ingest_error_summary_from_row(row: &Row<'_>) -> rusqlite::Result<IngestErrorS
 }
 
 fn count(path: &Path, conn: &Connection, sql: &str) -> Result<u64> {
-    let value: i64 = conn
-        .query_row(sql, [], |row| row.get(0))
-        .map_err(|source| sqlite_error(path, source))?;
+    let value: i64 = query_one(path, conn, sql, [], |row| row.get(0))?;
     Ok(value as u64)
 }
 
 fn user_version(path: &Path, conn: &Connection) -> Result<i64> {
-    conn.query_row("PRAGMA user_version", [], |row| row.get(0))
-        .map_err(|source| sqlite_error(path, source))
+    query_one(path, conn, "PRAGMA user_version", [], |row| row.get(0))
 }
 
 pub(crate) fn sqlite_error(path: &Path, source: rusqlite::Error) -> JottraceError {
@@ -528,6 +525,23 @@ where
 {
     conn.query_row(sql, params, mapper)
         .optional()
+        .map_err(|source| sqlite_error(path, source))
+}
+
+/// Run `sql` with `params`, returning the single mapped row and routing query
+/// failures (including no matching row) through [`sqlite_error`] for `path`.
+pub(crate) fn query_one<T, P, F>(
+    path: &Path,
+    conn: &Connection,
+    sql: &str,
+    params: P,
+    mapper: F,
+) -> Result<T>
+where
+    P: rusqlite::Params,
+    F: FnOnce(&Row<'_>) -> rusqlite::Result<T>,
+{
+    conn.query_row(sql, params, mapper)
         .map_err(|source| sqlite_error(path, source))
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -298,7 +298,9 @@ fn event_session_id(
     source: &str,
     source_session_id: &str,
 ) -> Result<Option<i64>> {
-    conn.query_row(
+    query_optional(
+        path,
+        conn,
         "SELECT id
          FROM sessions
          WHERE source = ?1
@@ -306,8 +308,6 @@ fn event_session_id(
         params![source, source_session_id],
         |row| row.get(0),
     )
-    .optional()
-    .map_err(|source| sqlite_error(path, source))
 }
 
 fn for_each_decoded_event_payload_from_connection(
@@ -378,9 +378,10 @@ fn reject_unsupported_event_codecs(
         Some((generation, seq)) => (Some(generation), Some(seq)),
         None => (None, None),
     };
-    let codec: Option<String> = conn
-        .query_row(
-            "SELECT events.codec
+    let codec: Option<String> = query_optional(
+        path,
+        conn,
+        "SELECT events.codec
              FROM events
              WHERE events.session_id = ?1
                AND events.codec NOT IN (?2, ?3)
@@ -391,17 +392,15 @@ fn reject_unsupported_event_codecs(
                )
              ORDER BY events.generation, events.seq
              LIMIT 1",
-            params![
-                session_id,
-                RAW_CODEC,
-                ZSTD_CODEC,
-                bound_generation,
-                bound_seq
-            ],
-            |row| row.get(0),
-        )
-        .optional()
-        .map_err(|source| sqlite_error(path, source))?;
+        params![
+            session_id,
+            RAW_CODEC,
+            ZSTD_CODEC,
+            bound_generation,
+            bound_seq
+        ],
+        |row| row.get(0),
+    )?;
 
     match codec {
         Some(codec) => Err(unsupported_event_payload_codec(&codec)),
@@ -420,7 +419,9 @@ fn selected_event_upper_bound(
     };
 
     let offset = limit - 1;
-    conn.query_row(
+    query_optional(
+        path,
+        conn,
         "SELECT generation, seq
          FROM events
          WHERE session_id = ?1
@@ -429,8 +430,6 @@ fn selected_event_upper_bound(
         params![session_id, offset],
         |row| Ok((row.get(0)?, row.get(1)?)),
     )
-    .optional()
-    .map_err(|source| sqlite_error(path, source))
 }
 
 fn unsupported_event_payload_codec(codec: &str) -> JottraceError {
@@ -511,6 +510,24 @@ where
         .query_map(params, mapper)
         .map_err(|source| sqlite_error(path, source))?
         .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|source| sqlite_error(path, source))
+}
+
+/// Run `sql` with `params`, returning the single mapped row if present (`Ok(None)` when
+/// no row matches), routing query failures through [`sqlite_error`] for `path`.
+pub(crate) fn query_optional<T, P, F>(
+    path: &Path,
+    conn: &Connection,
+    sql: &str,
+    params: P,
+    mapper: F,
+) -> Result<Option<T>>
+where
+    P: rusqlite::Params,
+    F: FnOnce(&Row<'_>) -> rusqlite::Result<T>,
+{
+    conn.query_row(sql, params, mapper)
+        .optional()
         .map_err(|source| sqlite_error(path, source))
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -355,8 +355,8 @@ fn for_each_decoded_event_payload_from_connection(
     };
 
     while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
-        let payload: Vec<u8> = row.get(0).map_err(|source| sqlite_error(path, source))?;
-        let codec: String = row.get(1).map_err(|source| sqlite_error(path, source))?;
+        let payload: Vec<u8> = row_value(path, row, 0)?;
+        let codec: String = row_value(path, row, 1)?;
         if codec == RAW_CODEC {
             visit(&payload)?;
         } else {
@@ -553,6 +553,17 @@ where
 {
     conn.execute(sql, params)
         .map_err(|source| sqlite_error(path, source))
+}
+
+/// Read column `idx` from `row`, routing an access/decode failure through
+/// [`sqlite_error`] for `path`. The manual row-streaming loops (whose bodies run
+/// in the crate `Result` rather than a `rusqlite::Result` mapper closure) use
+/// this to map each column read without repeating the `sqlite_error` closure.
+pub(crate) fn row_value<T>(path: &Path, row: &Row<'_>, idx: usize) -> Result<T>
+where
+    T: rusqlite::types::FromSql,
+{
+    row.get(idx).map_err(|source| sqlite_error(path, source))
 }
 
 #[cfg(test)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::{
-    JottraceError, Result, data_dir_from_env, ensure_private_file, unsupported_schema_version,
+    JottraceError, Result, data_dir_from_env, ensure_private_file, session_not_found,
+    unsupported_schema_version,
 };
 
 pub const DB_FILE_NAME: &str = "db.sqlite";
@@ -298,13 +299,8 @@ pub fn for_each_decoded_event_payload_for_session(
     visit: impl FnMut(&[u8]) -> Result<()>,
 ) -> Result<()> {
     let conn = open_database(path)?;
-    let session_id =
-        event_session_id(path, &conn, source, source_session_id)?.ok_or_else(|| {
-            JottraceError::SessionNotFound {
-                source: source.to_string(),
-                source_session_id: source_session_id.to_string(),
-            }
-        })?;
+    let session_id = event_session_id(path, &conn, source, source_session_id)?
+        .ok_or_else(|| session_not_found(source, source_session_id))?;
     for_each_decoded_event_payload_from_connection(path, &conn, session_id, limit, visit)
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -259,23 +259,19 @@ pub(crate) fn unresolved_ingest_errors_from_connection(
     conn: &Connection,
     limit: usize,
 ) -> Result<Vec<IngestErrorSummary>> {
-    let mut statement = conn
-        .prepare(
-            "SELECT source, source_session_id, file_path, generation, byte_offset,
-                    line_number, error_kind, message, first_seen_at, last_seen_at,
-                    occurrence_count
-             FROM ingest_errors
-             WHERE resolved_at IS NULL
-             ORDER BY last_seen_at DESC, id DESC
-             LIMIT ?1",
-        )
-        .map_err(|source| sqlite_error(path, source))?;
-
-    statement
-        .query_map(params![limit as i64], ingest_error_summary_from_row)
-        .map_err(|source| sqlite_error(path, source))?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|source| sqlite_error(path, source))
+    query_collect(
+        path,
+        conn,
+        "SELECT source, source_session_id, file_path, generation, byte_offset,
+                line_number, error_kind, message, first_seen_at, last_seen_at,
+                occurrence_count
+         FROM ingest_errors
+         WHERE resolved_at IS NULL
+         ORDER BY last_seen_at DESC, id DESC
+         LIMIT ?1",
+        params![limit as i64],
+        ingest_error_summary_from_row,
+    )
 }
 
 pub fn for_each_decoded_event_payload_for_session(
@@ -493,6 +489,29 @@ pub(crate) fn sqlite_error(path: &Path, source: rusqlite::Error) -> JottraceErro
         path: path.to_path_buf(),
         source,
     }
+}
+
+/// Prepare `sql`, run it with `params`, and collect every mapped row into a `Vec`,
+/// routing each fallible step's failure through [`sqlite_error`] for `path`.
+pub(crate) fn query_collect<T, P, F>(
+    path: &Path,
+    conn: &Connection,
+    sql: &str,
+    params: P,
+    mapper: F,
+) -> Result<Vec<T>>
+where
+    P: rusqlite::Params,
+    F: FnMut(&Row<'_>) -> rusqlite::Result<T>,
+{
+    let mut statement = conn
+        .prepare(sql)
+        .map_err(|source| sqlite_error(path, source))?;
+    statement
+        .query_map(params, mapper)
+        .map_err(|source| sqlite_error(path, source))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|source| sqlite_error(path, source))
 }
 
 #[cfg(test)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, OptionalExtension, Row, params};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, params};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -193,6 +193,22 @@ pub fn open_database(path: &Path) -> Result<Connection> {
     configure_connection(path, &conn)?;
     run_migrations(path, &mut conn)?;
     Ok(conn)
+}
+
+/// Open a SQLite database read-only, reporting a failed open through
+/// `make_error`.
+///
+/// Foreign session stores (and jottrace's own journal in the web server) are
+/// only ever read, so they are opened with `SQLITE_OPEN_READ_ONLY` rather than
+/// through [`open_database`], which migrates and writes. Callers pass a
+/// source-specific error constructor because the same open failure is labelled
+/// differently per store.
+pub(crate) fn open_readonly_database(
+    path: &Path,
+    make_error: fn(&Path, rusqlite::Error) -> JottraceError,
+) -> Result<Connection> {
+    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|source| make_error(path, source))
 }
 
 fn configure_connection(path: &Path, conn: &Connection) -> Result<()> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -134,12 +134,7 @@ pub fn decode_event_payload(payload: &[u8], codec: &str) -> Result<Vec<u8>> {
         return Ok(payload.to_vec());
     }
     if codec == ZSTD_CODEC {
-        return zstd::stream::decode_all(payload).map_err(|source| {
-            JottraceError::EventPayloadCodec {
-                codec: ZSTD_CODEC.to_string(),
-                source,
-            }
-        });
+        return zstd::stream::decode_all(payload).map_err(zstd_codec_error);
     }
 
     Err(unsupported_event_payload_codec(codec))
@@ -154,20 +149,12 @@ pub(crate) fn decode_event_payload_prefix(
         return Ok(payload[..payload.len().min(byte_limit)].to_vec());
     }
     if codec == ZSTD_CODEC {
-        let decoder = zstd::stream::read::Decoder::new(payload).map_err(|source| {
-            JottraceError::EventPayloadCodec {
-                codec: ZSTD_CODEC.to_string(),
-                source,
-            }
-        })?;
+        let decoder = zstd::stream::read::Decoder::new(payload).map_err(zstd_codec_error)?;
         let mut decoder = decoder.take(byte_limit as u64);
         let mut decoded = Vec::with_capacity(byte_limit);
         decoder
             .read_to_end(&mut decoded)
-            .map_err(|source| JottraceError::EventPayloadCodec {
-                codec: ZSTD_CODEC.to_string(),
-                source,
-            })?;
+            .map_err(zstd_codec_error)?;
         return Ok(decoded);
     }
 
@@ -179,12 +166,7 @@ pub(crate) fn encode_event_payload(payload: &[u8]) -> Result<EncodedEventPayload
         return Ok(raw_event_payload(payload));
     }
 
-    let compressed = zstd::stream::encode_all(payload, 0).map_err(|source| {
-        JottraceError::EventPayloadCodec {
-            codec: ZSTD_CODEC.to_string(),
-            source,
-        }
-    })?;
+    let compressed = zstd::stream::encode_all(payload, 0).map_err(zstd_codec_error)?;
     if compressed.len() < payload.len() {
         return Ok(EncodedEventPayload {
             payload: compressed,
@@ -458,6 +440,13 @@ fn selected_event_upper_bound(
 fn unsupported_event_payload_codec(codec: &str) -> JottraceError {
     JottraceError::UnsupportedEventPayloadCodec {
         codec: codec.to_string(),
+    }
+}
+
+fn zstd_codec_error(source: std::io::Error) -> JottraceError {
+    JottraceError::EventPayloadCodec {
+        codec: ZSTD_CODEC.to_string(),
+        source,
     }
 }
 

--- a/src/taste/compiler.rs
+++ b/src/taste/compiler.rs
@@ -99,6 +99,35 @@ pub struct PreferenceExample {
     pub extractor_version: String,
 }
 
+impl PreferenceExample {
+    /// Build an example from a `preference_examples` row whose columns are, in
+    /// order: source, source_session_id, generation, proposal_event_seq,
+    /// tool_use_id, file_path, tool_name, proposal_content, context, outcome,
+    /// confidence, evidence_kind, extractor_version.
+    pub(crate) fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        let generation: i64 = row.get(2)?;
+        let proposal_event_seq: i64 = row.get(3)?;
+        let outcome: String = row.get(9)?;
+        let evidence_kind: String = row.get(11)?;
+        Ok(Self {
+            source: row.get(0)?,
+            source_session_id: row.get(1)?,
+            generation: usize::try_from(generation).expect("generation fits in usize"),
+            proposal_event_seq: usize::try_from(proposal_event_seq)
+                .expect("proposal_event_seq fits in usize"),
+            tool_use_id: row.get(4)?,
+            file_path: row.get(5)?,
+            tool_name: row.get(6)?,
+            proposal_content: row.get(7)?,
+            context: row.get(8)?,
+            outcome: PreferenceOutcome::from_db_str(&outcome).expect("valid outcome"),
+            confidence: row.get(10)?,
+            evidence_kind: EvidenceKind::from_db_str(&evidence_kind).expect("valid evidence_kind"),
+            extractor_version: row.get(12)?,
+        })
+    }
+}
+
 /// Joins parsed proposals with materialized timelines and labels outcomes.
 #[derive(Debug, Default)]
 pub struct PreferenceCompiler;

--- a/src/taste/compiler.rs
+++ b/src/taste/compiler.rs
@@ -6,6 +6,7 @@ use rusqlite::{Connection, params};
 use crate::JottraceError;
 use crate::storage::execute_sql;
 
+use super::db_string_enum;
 use super::parse::{ContentRef, ParseKind, ParsedEvent};
 use super::timeline::{FileTimelineRow, normalize_file_path};
 
@@ -18,66 +19,24 @@ pub const HIGH_CONFIDENCE_THRESHOLD: f64 = 1.0;
 /// Maximum number of prior tool events included in proposal context.
 pub const PRIOR_EVENT_CONTEXT_LIMIT: usize = 5;
 
-/// Labeled outcome for a detected tool proposal.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PreferenceOutcome {
-    Accepted,
-    Rejected,
-    Edited,
-}
-
-impl PreferenceOutcome {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Accepted => "accepted",
-            Self::Rejected => "rejected",
-            Self::Edited => "edited",
-        }
-    }
-
-    pub fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "accepted" => Some(Self::Accepted),
-            "rejected" => Some(Self::Rejected),
-            "edited" => Some(Self::Edited),
-            _ => None,
-        }
+db_string_enum! {
+    /// Labeled outcome for a detected tool proposal.
+    pub enum PreferenceOutcome {
+        Accepted => "accepted",
+        Rejected => "rejected",
+        Edited => "edited",
     }
 }
 
-/// How a proposal was linked to file state for outcome detection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EvidenceKind {
-    DirectEdit,
-    DirectWrite,
-    BashCorrelation,
-    McpCorrelation,
-    PermissionDenial,
-    MissingFinalState,
-}
-
-impl EvidenceKind {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::DirectEdit => "direct_edit",
-            Self::DirectWrite => "direct_write",
-            Self::BashCorrelation => "bash_correlation",
-            Self::McpCorrelation => "mcp_correlation",
-            Self::PermissionDenial => "permission_denial",
-            Self::MissingFinalState => "missing_final_state",
-        }
-    }
-
-    pub fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "direct_edit" => Some(Self::DirectEdit),
-            "direct_write" => Some(Self::DirectWrite),
-            "bash_correlation" => Some(Self::BashCorrelation),
-            "mcp_correlation" => Some(Self::McpCorrelation),
-            "permission_denial" => Some(Self::PermissionDenial),
-            "missing_final_state" => Some(Self::MissingFinalState),
-            _ => None,
-        }
+db_string_enum! {
+    /// How a proposal was linked to file state for outcome detection.
+    pub enum EvidenceKind {
+        DirectEdit => "direct_edit",
+        DirectWrite => "direct_write",
+        BashCorrelation => "bash_correlation",
+        McpCorrelation => "mcp_correlation",
+        PermissionDenial => "permission_denial",
+        MissingFinalState => "missing_final_state",
     }
 }
 

--- a/src/taste/compiler.rs
+++ b/src/taste/compiler.rs
@@ -465,19 +465,20 @@ fn post_apply_content(
         .and_then(|row| row.content.clone())
 }
 
+fn content_has_line(content: &str, line: &str) -> bool {
+    content.lines().any(|content_line| content_line == line)
+}
+
 fn effect_present(before: &str, after: &str, final_content: &str) -> bool {
     let added = line_delta(before, after);
     let removed = line_delta(after, before);
 
-    added.iter().all(|line| {
-        final_content
-            .lines()
-            .any(|final_line| final_line == line.as_str())
-    }) && removed.iter().all(|line| {
-        !final_content
-            .lines()
-            .any(|final_line| final_line == line.as_str())
-    })
+    added
+        .iter()
+        .all(|line| content_has_line(final_content, line))
+        && removed
+            .iter()
+            .all(|line| !content_has_line(final_content, line))
 }
 
 fn partial_effect_present(before: &str, after: &str, final_content: &str) -> bool {
@@ -487,11 +488,7 @@ fn partial_effect_present(before: &str, after: &str, final_content: &str) -> boo
     }
     let preserved = added
         .iter()
-        .filter(|line| {
-            final_content
-                .lines()
-                .any(|final_line| final_line == line.as_str())
-        })
+        .filter(|line| content_has_line(final_content, line))
         .count();
     preserved > 0 && preserved < added.len()
 }

--- a/src/taste/compiler.rs
+++ b/src/taste/compiler.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use rusqlite::{Connection, params};
 
 use crate::JottraceError;
-use crate::storage::sqlite_error;
+use crate::storage::execute_sql;
 
 use super::parse::{ContentRef, ParseKind, ParsedEvent};
 use super::timeline::{FileTimelineRow, normalize_file_path};
@@ -191,15 +191,18 @@ pub fn replace_session_preference_examples(
     source_session_id: &str,
     examples: &[PreferenceExample],
 ) -> Result<usize, JottraceError> {
-    conn.execute(
+    execute_sql(
+        db_path,
+        conn,
         "DELETE FROM preference_examples WHERE source = ?1 AND source_session_id = ?2",
         params![source, source_session_id],
-    )
-    .map_err(|source| sqlite_error(db_path, source))?;
+    )?;
 
     let mut inserted = 0usize;
     for example in examples {
-        conn.execute(
+        execute_sql(
+            db_path,
+            conn,
             "INSERT INTO preference_examples (
                 source,
                 source_session_id,
@@ -230,8 +233,7 @@ pub fn replace_session_preference_examples(
                 example.evidence_kind.as_str(),
                 example.extractor_version,
             ],
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
+        )?;
         inserted += 1;
     }
 

--- a/src/taste/export.rs
+++ b/src/taste/export.rs
@@ -7,7 +7,7 @@ use crate::storage::query_collect;
 use crate::{JottraceError, io_error};
 use crate::{Result, data_dir_from_env, open_locked_database, private_open_options};
 
-use super::compiler::{EvidenceKind, PreferenceExample, PreferenceOutcome};
+use super::compiler::{PreferenceExample, PreferenceOutcome};
 
 const CLAUDE_SOURCE: &str = "claude_cli";
 
@@ -91,38 +91,14 @@ fn load_preference_examples(db_path: &Path, conn: &Connection) -> Result<Vec<Pre
     query_collect(
         db_path,
         conn,
-        "SELECT tool_use_id, source_session_id, generation, proposal_event_seq, file_path,
-                tool_name, proposal_content, context, outcome, confidence, evidence_kind,
-                extractor_version
+        "SELECT source, source_session_id, generation, proposal_event_seq, tool_use_id,
+                file_path, tool_name, proposal_content, context, outcome, confidence,
+                evidence_kind, extractor_version
          FROM preference_examples
          WHERE source = ?1
          ORDER BY source_session_id ASC, generation ASC, proposal_event_seq ASC",
         params![CLAUDE_SOURCE],
-        |row| {
-            let tool_use_id: String = row.get(0)?;
-            let source_session_id: String = row.get(1)?;
-            let generation: i64 = row.get(2)?;
-            let proposal_event_seq: i64 = row.get(3)?;
-            let outcome: String = row.get(8)?;
-            let evidence_kind: String = row.get(10)?;
-            Ok(PreferenceExample {
-                source: CLAUDE_SOURCE.to_string(),
-                source_session_id,
-                generation: usize::try_from(generation).expect("generation fits in usize"),
-                proposal_event_seq: usize::try_from(proposal_event_seq)
-                    .expect("proposal_event_seq fits in usize"),
-                tool_use_id,
-                file_path: row.get(4)?,
-                tool_name: row.get(5)?,
-                proposal_content: row.get(6)?,
-                context: row.get(7)?,
-                outcome: PreferenceOutcome::from_db_str(&outcome).expect("valid outcome"),
-                confidence: row.get(9)?,
-                evidence_kind: EvidenceKind::from_db_str(&evidence_kind)
-                    .expect("valid evidence_kind"),
-                extractor_version: row.get(11)?,
-            })
-        },
+        PreferenceExample::from_row,
     )
 }
 

--- a/src/taste/export.rs
+++ b/src/taste/export.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use crate::storage::{DB_FILE_NAME, open_database, sqlite_error};
+use crate::storage::{DB_FILE_NAME, open_database, query_collect};
 use crate::{JottraceError, io_error};
 use crate::{Result, acquire_data_lock, data_dir_from_env, private_open_options};
 
@@ -90,19 +90,17 @@ pub fn taste_export_for_data_dir(
 }
 
 fn load_preference_examples(db_path: &Path, conn: &Connection) -> Result<Vec<PreferenceExample>> {
-    let mut statement = conn
-        .prepare(
-            "SELECT tool_use_id, source_session_id, generation, proposal_event_seq, file_path,
-                    tool_name, proposal_content, context, outcome, confidence, evidence_kind,
-                    extractor_version
-             FROM preference_examples
-             WHERE source = ?1
-             ORDER BY source_session_id ASC, generation ASC, proposal_event_seq ASC",
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
-
-    statement
-        .query_map(params![CLAUDE_SOURCE], |row| {
+    query_collect(
+        db_path,
+        conn,
+        "SELECT tool_use_id, source_session_id, generation, proposal_event_seq, file_path,
+                tool_name, proposal_content, context, outcome, confidence, evidence_kind,
+                extractor_version
+         FROM preference_examples
+         WHERE source = ?1
+         ORDER BY source_session_id ASC, generation ASC, proposal_event_seq ASC",
+        params![CLAUDE_SOURCE],
+        |row| {
             let tool_use_id: String = row.get(0)?;
             let source_session_id: String = row.get(1)?;
             let generation: i64 = row.get(2)?;
@@ -126,10 +124,8 @@ fn load_preference_examples(db_path: &Path, conn: &Connection) -> Result<Vec<Pre
                     .expect("valid evidence_kind"),
                 extractor_version: row.get(11)?,
             })
-        })
-        .map_err(|source| sqlite_error(db_path, source))?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|source| sqlite_error(db_path, source))
+        },
+    )
 }
 
 fn write_export(examples: &[PreferenceExample], options: &TasteExportOptions) -> Result<()> {

--- a/src/taste/export.rs
+++ b/src/taste/export.rs
@@ -3,9 +3,9 @@ use serde::Serialize;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use crate::storage::{DB_FILE_NAME, open_database, query_collect};
+use crate::storage::query_collect;
 use crate::{JottraceError, io_error};
-use crate::{Result, acquire_data_lock, data_dir_from_env, private_open_options};
+use crate::{Result, data_dir_from_env, open_locked_database, private_open_options};
 
 use super::compiler::{EvidenceKind, PreferenceExample, PreferenceOutcome};
 
@@ -75,9 +75,7 @@ pub fn taste_export_for_data_dir(
     data_dir: &Path,
     options: TasteExportOptions,
 ) -> Result<TasteExportReport> {
-    let db_path = data_dir.join(DB_FILE_NAME);
-    let _lock = acquire_data_lock(data_dir)?;
-    let conn = open_database(&db_path)?;
+    let (db_path, _lock, conn) = open_locked_database(data_dir)?;
     let examples = load_preference_examples(&db_path, &conn)?;
     let rows_exported = u64::try_from(examples.len()).expect("row count fits in u64");
     write_export(&examples, &options)?;

--- a/src/taste/export.rs
+++ b/src/taste/export.rs
@@ -3,8 +3,8 @@ use serde::Serialize;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use crate::JottraceError;
 use crate::storage::{DB_FILE_NAME, open_database, sqlite_error};
+use crate::{JottraceError, io_error};
 use crate::{Result, acquire_data_lock, data_dir_from_env, private_open_options};
 
 use super::compiler::{EvidenceKind, PreferenceExample, PreferenceOutcome};
@@ -153,19 +153,13 @@ fn write_jsonl_export(examples: &[PreferenceExample], output_path: Option<&Path>
             if let Some(parent) = path.parent()
                 && !parent.as_os_str().is_empty()
             {
-                std::fs::create_dir_all(parent).map_err(|source| JottraceError::Io {
-                    path: parent.to_path_buf(),
-                    source,
-                })?;
+                std::fs::create_dir_all(parent).map_err(|source| io_error(parent, source))?;
             }
             let mut file = private_open_options()
                 .write(true)
                 .create_new(true)
                 .open(path)
-                .map_err(|source| JottraceError::Io {
-                    path: path.to_path_buf(),
-                    source,
-                })?;
+                .map_err(|source| io_error(path, source))?;
             file.write_all(&buffer)
                 .map_err(|source| JottraceError::Output { source })?;
         }

--- a/src/taste/export.rs
+++ b/src/taste/export.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use crate::storage::query_collect;
-use crate::{JottraceError, io_error};
+use crate::{JottraceError, map_io_error};
 use crate::{Result, data_dir_from_env, open_locked_database, private_open_options};
 
 use super::compiler::{PreferenceExample, PreferenceOutcome};
@@ -123,13 +123,13 @@ fn write_jsonl_export(examples: &[PreferenceExample], output_path: Option<&Path>
             if let Some(parent) = path.parent()
                 && !parent.as_os_str().is_empty()
             {
-                std::fs::create_dir_all(parent).map_err(|source| io_error(parent, source))?;
+                std::fs::create_dir_all(parent).map_err(map_io_error(parent))?;
             }
             let mut file = private_open_options()
                 .write(true)
                 .create_new(true)
                 .open(path)
-                .map_err(|source| io_error(path, source))?;
+                .map_err(map_io_error(path))?;
             file.write_all(&buffer)
                 .map_err(|source| JottraceError::Output { source })?;
         }

--- a/src/taste/extract.rs
+++ b/src/taste/extract.rs
@@ -3,7 +3,8 @@ use std::path::{Path, PathBuf};
 
 use crate::JottraceError;
 use crate::storage::{
-    for_each_decoded_event_payload_for_session, query_collect, query_optional, sqlite_error,
+    execute_sql, for_each_decoded_event_payload_for_session, query_collect, query_optional,
+    sqlite_error,
 };
 use crate::{Result, data_dir_from_env, open_locked_database};
 
@@ -303,7 +304,9 @@ fn replace_taste_extraction_meta(
     source_session_id: &str,
     event_count: u64,
 ) -> Result<()> {
-    conn.execute(
+    execute_sql(
+        db_path,
+        conn,
         "INSERT INTO taste_extractions (source, source_session_id, extractor_version, event_count)
          VALUES (?1, ?2, ?3, ?4)
          ON CONFLICT (source, source_session_id) DO UPDATE SET
@@ -315,8 +318,7 @@ fn replace_taste_extraction_meta(
             EXTRACTOR_VERSION,
             i64::try_from(event_count).expect("event_count fits in i64"),
         ],
-    )
-    .map_err(|source| sqlite_error(db_path, source))?;
+    )?;
     Ok(())
 }
 

--- a/src/taste/extract.rs
+++ b/src/taste/extract.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 
 use crate::JottraceError;
 use crate::storage::{
-    execute_sql, for_each_decoded_event_payload_for_session, query_collect, query_optional,
-    sqlite_error,
+    execute_sql, for_each_decoded_event_payload_for_session, query_collect, query_one,
+    query_optional, sqlite_error,
 };
 use crate::{Result, data_dir_from_env, open_locked_database};
 
@@ -241,30 +241,30 @@ fn session_needs_extract(
                 != current_event_count);
     }
 
-    let total: i64 = conn
-        .query_row(
-            "SELECT COUNT(*)
+    let total: i64 = query_one(
+        db_path,
+        conn,
+        "SELECT COUNT(*)
              FROM preference_examples
              WHERE source = ?1 AND source_session_id = ?2",
-            params![CLAUDE_SOURCE, source_session_id],
-            |row| row.get(0),
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
+        params![CLAUDE_SOURCE, source_session_id],
+        |row| row.get(0),
+    )?;
     if total == 0 {
         return Ok(true);
     }
 
-    let stale: i64 = conn
-        .query_row(
-            "SELECT COUNT(*)
+    let stale: i64 = query_one(
+        db_path,
+        conn,
+        "SELECT COUNT(*)
              FROM preference_examples
              WHERE source = ?1
                AND source_session_id = ?2
                AND extractor_version != ?3",
-            params![CLAUDE_SOURCE, source_session_id, EXTRACTOR_VERSION],
-            |row| row.get(0),
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
+        params![CLAUDE_SOURCE, source_session_id, EXTRACTOR_VERSION],
+        |row| row.get(0),
+    )?;
     Ok(stale > 0)
 }
 
@@ -273,23 +273,23 @@ fn count_merged_session_events(
     conn: &Connection,
     parent_db_id: i64,
 ) -> Result<u64> {
-    let parent_count: i64 = conn
-        .query_row(
-            "SELECT event_count FROM sessions WHERE id = ?1",
-            params![parent_db_id],
-            |row| row.get(0),
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
+    let parent_count: i64 = query_one(
+        db_path,
+        conn,
+        "SELECT event_count FROM sessions WHERE id = ?1",
+        params![parent_db_id],
+        |row| row.get(0),
+    )?;
 
-    let child_count: i64 = conn
-        .query_row(
-            "SELECT COALESCE(SUM(event_count), 0)
+    let child_count: i64 = query_one(
+        db_path,
+        conn,
+        "SELECT COALESCE(SUM(event_count), 0)
              FROM sessions
              WHERE source = ?1 AND parent_session_id = ?2",
-            params![CLAUDE_SOURCE, parent_db_id],
-            |row| row.get(0),
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
+        params![CLAUDE_SOURCE, parent_db_id],
+        |row| row.get(0),
+    )?;
 
     let total = parent_count
         .checked_add(child_count)

--- a/src/taste/extract.rs
+++ b/src/taste/extract.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 
 use crate::JottraceError;
 use crate::storage::{
-    execute_sql, for_each_decoded_event_payload_for_session, query_collect, query_one,
-    query_optional, sqlite_error,
+    execute_sql, for_each_decoded_event_payload_for_session, map_sqlite_error, query_collect,
+    query_one, query_optional,
 };
 use crate::{Result, data_dir_from_env, open_locked_database};
 
@@ -106,9 +106,7 @@ pub fn taste_extract_for_data_dir(
         let timeline_count;
         let example_count;
         {
-            let tx = conn
-                .transaction()
-                .map_err(|source| sqlite_error(&db_path, source))?;
+            let tx = conn.transaction().map_err(map_sqlite_error(&db_path))?;
             timeline_count = replace_session_file_timelines(
                 &db_path,
                 &tx,
@@ -142,7 +140,7 @@ pub fn taste_extract_for_data_dir(
 }
 
 fn commit_transaction(db_path: &Path, tx: Transaction<'_>) -> Result<()> {
-    tx.commit().map_err(|source| sqlite_error(db_path, source))
+    tx.commit().map_err(map_sqlite_error(db_path))
 }
 
 fn list_parent_claude_sessions(

--- a/src/taste/extract.rs
+++ b/src/taste/extract.rs
@@ -6,7 +6,7 @@ use crate::storage::{
     execute_sql, for_each_decoded_event_payload_for_session, map_sqlite_error, query_collect,
     query_one, query_optional,
 };
-use crate::{Result, data_dir_from_env, open_locked_database};
+use crate::{Result, data_dir_from_env, open_locked_database, session_not_found};
 
 use super::compiler::{EXTRACTOR_VERSION, PreferenceCompiler, replace_session_preference_examples};
 use super::parse::{SourceStream, merge_streams, parse_jsonl};
@@ -170,10 +170,7 @@ fn list_parent_claude_sessions(
     if let Some(requested) = source_session_id
         && rows.is_empty()
     {
-        return Err(JottraceError::SessionNotFound {
-            source: CLAUDE_SOURCE.to_string(),
-            source_session_id: requested.to_string(),
-        });
+        return Err(session_not_found(CLAUDE_SOURCE, requested));
     }
 
     Ok(rows)

--- a/src/taste/extract.rs
+++ b/src/taste/extract.rs
@@ -1,8 +1,10 @@
-use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use rusqlite::{Connection, Transaction, params};
 use std::path::{Path, PathBuf};
 
 use crate::JottraceError;
-use crate::storage::{for_each_decoded_event_payload_for_session, query_collect, sqlite_error};
+use crate::storage::{
+    for_each_decoded_event_payload_for_session, query_collect, query_optional, sqlite_error,
+};
 use crate::{Result, data_dir_from_env, open_locked_database};
 
 use super::compiler::{EXTRACTOR_VERSION, PreferenceCompiler, replace_session_preference_examples};
@@ -222,16 +224,15 @@ fn session_needs_extract(
     source_session_id: &str,
 ) -> Result<bool> {
     let current_event_count = count_merged_session_events(db_path, conn, parent_db_id)?;
-    let stored = conn
-        .query_row(
-            "SELECT extractor_version, event_count
+    let stored = query_optional(
+        db_path,
+        conn,
+        "SELECT extractor_version, event_count
              FROM taste_extractions
              WHERE source = ?1 AND source_session_id = ?2",
-            params![CLAUDE_SOURCE, source_session_id],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
-        )
-        .optional()
-        .map_err(|source| sqlite_error(db_path, source))?;
+        params![CLAUDE_SOURCE, source_session_id],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+    )?;
 
     if let Some((version, event_count)) = stored {
         return Ok(version != EXTRACTOR_VERSION

--- a/src/taste/extract.rs
+++ b/src/taste/extract.rs
@@ -3,7 +3,8 @@ use std::path::{Path, PathBuf};
 
 use crate::JottraceError;
 use crate::storage::{
-    DB_FILE_NAME, for_each_decoded_event_payload_for_session, open_database, sqlite_error,
+    DB_FILE_NAME, for_each_decoded_event_payload_for_session, open_database, query_collect,
+    sqlite_error,
 };
 use crate::{Result, acquire_data_lock, data_dir_from_env};
 
@@ -151,28 +152,24 @@ fn list_parent_claude_sessions(
     conn: &Connection,
     source_session_id: Option<&str>,
 ) -> Result<Vec<SessionTarget>> {
-    let mut statement = conn
-        .prepare(
-            "SELECT id, source_session_id, cwd
-             FROM sessions
-             WHERE source = ?1
-               AND parent_session_id IS NULL
-               AND (?2 IS NULL OR source_session_id = ?2)
-             ORDER BY id",
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
-
-    let rows = statement
-        .query_map(params![CLAUDE_SOURCE, source_session_id], |row| {
+    let rows = query_collect(
+        db_path,
+        conn,
+        "SELECT id, source_session_id, cwd
+         FROM sessions
+         WHERE source = ?1
+           AND parent_session_id IS NULL
+           AND (?2 IS NULL OR source_session_id = ?2)
+         ORDER BY id",
+        params![CLAUDE_SOURCE, source_session_id],
+        |row| {
             Ok(SessionTarget {
                 db_id: row.get(0)?,
                 source_session_id: row.get(1)?,
                 cwd: row.get(2)?,
             })
-        })
-        .map_err(|source| sqlite_error(db_path, source))?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|source| sqlite_error(db_path, source))?;
+        },
+    )?;
 
     if let Some(requested) = source_session_id
         && rows.is_empty()
@@ -191,25 +188,21 @@ fn list_child_sessions(
     conn: &Connection,
     parent_db_id: i64,
 ) -> Result<Vec<ChildSession>> {
-    let mut statement = conn
-        .prepare(
-            "SELECT source_session_id
-             FROM sessions
-             WHERE source = ?1
-               AND parent_session_id = ?2
-             ORDER BY id",
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
-
-    statement
-        .query_map(params![CLAUDE_SOURCE, parent_db_id], |row| {
+    query_collect(
+        db_path,
+        conn,
+        "SELECT source_session_id
+         FROM sessions
+         WHERE source = ?1
+           AND parent_session_id = ?2
+         ORDER BY id",
+        params![CLAUDE_SOURCE, parent_db_id],
+        |row| {
             Ok(ChildSession {
                 source_session_id: row.get(0)?,
             })
-        })
-        .map_err(|source| sqlite_error(db_path, source))?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|source| sqlite_error(db_path, source))
+        },
+    )
 }
 
 /// Whether a parent session's stored extraction matches the current extractor and event stream.

--- a/src/taste/extract.rs
+++ b/src/taste/extract.rs
@@ -2,11 +2,8 @@ use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use std::path::{Path, PathBuf};
 
 use crate::JottraceError;
-use crate::storage::{
-    DB_FILE_NAME, for_each_decoded_event_payload_for_session, open_database, query_collect,
-    sqlite_error,
-};
-use crate::{Result, acquire_data_lock, data_dir_from_env};
+use crate::storage::{for_each_decoded_event_payload_for_session, query_collect, sqlite_error};
+use crate::{Result, data_dir_from_env, open_locked_database};
 
 use super::compiler::{EXTRACTOR_VERSION, PreferenceCompiler, replace_session_preference_examples};
 use super::parse::{SourceStream, merge_streams, parse_jsonl};
@@ -57,9 +54,7 @@ pub fn taste_extract_for_data_dir(
     data_dir: &Path,
     options: TasteExtractOptions,
 ) -> Result<TasteExtractReport> {
-    let db_path = data_dir.join(DB_FILE_NAME);
-    let _lock = acquire_data_lock(data_dir)?;
-    let mut conn = open_database(&db_path)?;
+    let (db_path, _lock, mut conn) = open_locked_database(data_dir)?;
 
     let resolver = match &options.sidecar_history_root {
         Some(root) => SnapshotSidecarResolver::with_history_root(root),

--- a/src/taste/mod.rs
+++ b/src/taste/mod.rs
@@ -7,6 +7,40 @@ pub mod sidecar;
 pub mod status;
 pub mod timeline;
 
+/// Defines a database-backed enum whose variants serialize to and from fixed
+/// strings, generating the inverse `as_str` / `from_db_str` pair from a single
+/// variant-to-string table so the two directions cannot drift apart.
+macro_rules! db_string_enum {
+    (
+        $(#[$enum_meta:meta])*
+        $vis:vis enum $name:ident {
+            $($variant:ident => $value:literal),+ $(,)?
+        }
+    ) => {
+        $(#[$enum_meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        $vis enum $name {
+            $($variant),+
+        }
+
+        impl $name {
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $value,)+
+                }
+            }
+
+            pub fn from_db_str(value: &str) -> Option<Self> {
+                match value {
+                    $($value => Some(Self::$variant),)+
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+pub(crate) use db_string_enum;
+
 pub use compiler::{
     EXTRACTOR_VERSION, EvidenceKind, HIGH_CONFIDENCE_THRESHOLD, PreferenceCompiler,
     PreferenceExample, PreferenceOutcome, replace_session_preference_examples,

--- a/src/taste/parse.rs
+++ b/src/taste/parse.rs
@@ -217,21 +217,29 @@ fn parse_snapshot_events(
     Ok(events)
 }
 
+/// Build one event per `message.content` block whose `type` matches `block_type`.
+fn parse_content_blocks(
+    value: &Value,
+    block_type: &str,
+    build: impl Fn(&Value) -> ParsedEvent,
+) -> Vec<ParsedEvent> {
+    let Some(content) = value.pointer("/message/content").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    content
+        .iter()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some(block_type))
+        .map(build)
+        .collect()
+}
+
 fn parse_assistant_events(
     seq: usize,
     source_stream: &SourceStream,
     timestamp: Option<String>,
     value: &Value,
 ) -> Result<Vec<ParsedEvent>, serde_json::Error> {
-    let Some(content) = value.pointer("/message/content").and_then(Value::as_array) else {
-        return Ok(Vec::new());
-    };
-
-    let mut events = Vec::new();
-    for block in content {
-        if block.get("type").and_then(Value::as_str) != Some("tool_use") {
-            continue;
-        }
+    Ok(parse_content_blocks(value, "tool_use", |block| {
         let tool_ref = block.get("id").and_then(Value::as_str).map(str::to_string);
         let tool_name = block
             .get("name")
@@ -240,7 +248,7 @@ fn parse_assistant_events(
         let input = block.get("input");
         let file_path = tool_file_path(input);
         let proposal_content = tool_proposal_content(tool_name.as_deref(), input);
-        events.push(ParsedEvent {
+        ParsedEvent {
             seq,
             timestamp: timestamp.clone(),
             kind: ParseKind::ToolProposal,
@@ -249,10 +257,8 @@ fn parse_assistant_events(
             tool_ref,
             tool_name,
             source_stream: source_stream.clone(),
-        });
-    }
-
-    Ok(events)
+        }
+    }))
 }
 
 fn tool_file_path(input: Option<&Value>) -> Option<String> {
@@ -302,15 +308,7 @@ fn parse_user_events(
     timestamp: Option<String>,
     value: &Value,
 ) -> Result<Vec<ParsedEvent>, serde_json::Error> {
-    let Some(content) = value.pointer("/message/content").and_then(Value::as_array) else {
-        return Ok(Vec::new());
-    };
-
-    let mut events = Vec::new();
-    for block in content {
-        if block.get("type").and_then(Value::as_str) != Some("tool_result") {
-            continue;
-        }
+    Ok(parse_content_blocks(value, "tool_result", |block| {
         let tool_ref = block
             .get("tool_use_id")
             .and_then(Value::as_str)
@@ -319,7 +317,7 @@ fn parse_user_events(
         let denied = result_text
             .as_deref()
             .is_some_and(|text| text.contains("new_string was NOT written"));
-        events.push(ParsedEvent {
+        ParsedEvent {
             seq,
             timestamp: timestamp.clone(),
             kind: if denied {
@@ -332,10 +330,8 @@ fn parse_user_events(
             tool_ref,
             tool_name: None,
             source_stream: source_stream.clone(),
-        });
-    }
-
-    Ok(events)
+        }
+    }))
 }
 
 fn tool_result_text(block: &Value) -> Option<String> {

--- a/src/taste/show.rs
+++ b/src/taste/show.rs
@@ -5,7 +5,7 @@ use crate::JottraceError;
 use crate::storage::{query_collect, sqlite_error};
 use crate::{Result, data_dir_from_env, open_locked_database};
 
-use super::compiler::{EvidenceKind, PreferenceExample, PreferenceOutcome};
+use super::compiler::PreferenceExample;
 use super::timeline::{FileTimelineRow, TimelineSourceKind, normalize_file_path};
 
 const CLAUDE_SOURCE: &str = "claude_cli";
@@ -153,23 +153,25 @@ fn query_preference_example(
         Some(source_session_id) => query_collect(
             db_path,
             conn,
-            "SELECT source_session_id, generation, proposal_event_seq, file_path, tool_name,
-                    proposal_content, context, outcome, confidence, evidence_kind, extractor_version
+            "SELECT source, source_session_id, generation, proposal_event_seq, tool_use_id,
+                    file_path, tool_name, proposal_content, context, outcome, confidence,
+                    evidence_kind, extractor_version
              FROM preference_examples
              WHERE source = ?1 AND source_session_id = ?2 AND tool_use_id = ?3",
             params![source, source_session_id, tool_use_id],
-            |row| map_preference_row(source, tool_use_id, row),
+            PreferenceExample::from_row,
         )?,
         None => query_collect(
             db_path,
             conn,
-            "SELECT source_session_id, generation, proposal_event_seq, file_path, tool_name,
-                    proposal_content, context, outcome, confidence, evidence_kind, extractor_version
+            "SELECT source, source_session_id, generation, proposal_event_seq, tool_use_id,
+                    file_path, tool_name, proposal_content, context, outcome, confidence,
+                    evidence_kind, extractor_version
              FROM preference_examples
              WHERE source = ?1 AND tool_use_id = ?2
              ORDER BY source_session_id ASC",
             params![source, tool_use_id],
-            |row| map_preference_row(source, tool_use_id, row),
+            PreferenceExample::from_row,
         )?,
     };
 
@@ -183,34 +185,6 @@ fn query_preference_example(
             session_count: rows.len(),
         }),
     }
-}
-
-fn map_preference_row(
-    source: &str,
-    tool_use_id: &str,
-    row: &rusqlite::Row<'_>,
-) -> rusqlite::Result<PreferenceExample> {
-    let source_session_id: String = row.get(0)?;
-    let generation: i64 = row.get(1)?;
-    let proposal_event_seq: i64 = row.get(2)?;
-    let outcome: String = row.get(7)?;
-    let evidence_kind: String = row.get(9)?;
-    Ok(PreferenceExample {
-        source: source.to_string(),
-        source_session_id,
-        generation: usize::try_from(generation).expect("generation fits in usize"),
-        proposal_event_seq: usize::try_from(proposal_event_seq)
-            .expect("proposal_event_seq fits in usize"),
-        tool_use_id: tool_use_id.to_string(),
-        file_path: row.get(3)?,
-        tool_name: row.get(4)?,
-        proposal_content: row.get(5)?,
-        context: row.get(6)?,
-        outcome: PreferenceOutcome::from_db_str(&outcome).expect("valid outcome"),
-        confidence: row.get(8)?,
-        evidence_kind: EvidenceKind::from_db_str(&evidence_kind).expect("valid evidence_kind"),
-        extractor_version: row.get(10)?,
-    })
 }
 
 fn query_timeline_rows(

--- a/src/taste/show.rs
+++ b/src/taste/show.rs
@@ -2,7 +2,7 @@ use rusqlite::{Connection, params};
 use std::path::{Path, PathBuf};
 
 use crate::JottraceError;
-use crate::storage::{DB_FILE_NAME, open_database, sqlite_error};
+use crate::storage::{DB_FILE_NAME, open_database, query_collect, sqlite_error};
 use crate::{Result, acquire_data_lock, data_dir_from_env};
 
 use super::compiler::{EvidenceKind, PreferenceExample, PreferenceOutcome};
@@ -154,41 +154,27 @@ fn query_preference_example(
     source_session_id: Option<&str>,
 ) -> Result<PreferenceExample> {
     let rows = match source_session_id {
-        Some(source_session_id) => {
-            let mut statement = conn
-                .prepare(
-                    "SELECT source_session_id, generation, proposal_event_seq, file_path, tool_name,
-                            proposal_content, context, outcome, confidence, evidence_kind, extractor_version
-                     FROM preference_examples
-                     WHERE source = ?1 AND source_session_id = ?2 AND tool_use_id = ?3",
-                )
-                .map_err(|source| sqlite_error(db_path, source))?;
-            statement
-                .query_map(params![source, source_session_id, tool_use_id], |row| {
-                    map_preference_row(source, tool_use_id, row)
-                })
-                .map_err(|source| sqlite_error(db_path, source))?
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(|source| sqlite_error(db_path, source))?
-        }
-        None => {
-            let mut statement = conn
-                .prepare(
-                    "SELECT source_session_id, generation, proposal_event_seq, file_path, tool_name,
-                            proposal_content, context, outcome, confidence, evidence_kind, extractor_version
-                     FROM preference_examples
-                     WHERE source = ?1 AND tool_use_id = ?2
-                     ORDER BY source_session_id ASC",
-                )
-                .map_err(|source| sqlite_error(db_path, source))?;
-            statement
-                .query_map(params![source, tool_use_id], |row| {
-                    map_preference_row(source, tool_use_id, row)
-                })
-                .map_err(|source| sqlite_error(db_path, source))?
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(|source| sqlite_error(db_path, source))?
-        }
+        Some(source_session_id) => query_collect(
+            db_path,
+            conn,
+            "SELECT source_session_id, generation, proposal_event_seq, file_path, tool_name,
+                    proposal_content, context, outcome, confidence, evidence_kind, extractor_version
+             FROM preference_examples
+             WHERE source = ?1 AND source_session_id = ?2 AND tool_use_id = ?3",
+            params![source, source_session_id, tool_use_id],
+            |row| map_preference_row(source, tool_use_id, row),
+        )?,
+        None => query_collect(
+            db_path,
+            conn,
+            "SELECT source_session_id, generation, proposal_event_seq, file_path, tool_name,
+                    proposal_content, context, outcome, confidence, evidence_kind, extractor_version
+             FROM preference_examples
+             WHERE source = ?1 AND tool_use_id = ?2
+             ORDER BY source_session_id ASC",
+            params![source, tool_use_id],
+            |row| map_preference_row(source, tool_use_id, row),
+        )?,
     };
 
     match rows.len() {
@@ -238,17 +224,15 @@ fn query_timeline_rows(
     source_session_id: &str,
     file_path: &str,
 ) -> Result<Vec<FileTimelineRow>> {
-    let mut statement = conn
-        .prepare(
-            "SELECT seq, event_seq, content, trigger_event_ref, source_kind
-             FROM file_timelines
-             WHERE source = ?1 AND source_session_id = ?2 AND file_path = ?3
-             ORDER BY seq ASC",
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
-
-    let rows = statement
-        .query_map(params![source, source_session_id, file_path], |row| {
+    query_collect(
+        db_path,
+        conn,
+        "SELECT seq, event_seq, content, trigger_event_ref, source_kind
+         FROM file_timelines
+         WHERE source = ?1 AND source_session_id = ?2 AND file_path = ?3
+         ORDER BY seq ASC",
+        params![source, source_session_id, file_path],
+        |row| {
             let seq: i64 = row.get(0)?;
             let event_seq: i64 = row.get(1)?;
             let source_kind: String = row.get(4)?;
@@ -263,10 +247,6 @@ fn query_timeline_rows(
                 source_kind: TimelineSourceKind::from_db_str(&source_kind)
                     .expect("valid source_kind"),
             })
-        })
-        .map_err(|source| sqlite_error(db_path, source))?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|source| sqlite_error(db_path, source))?;
-
-    Ok(rows)
+        },
+    )
 }

--- a/src/taste/show.rs
+++ b/src/taste/show.rs
@@ -2,8 +2,8 @@ use rusqlite::{Connection, params};
 use std::path::{Path, PathBuf};
 
 use crate::JottraceError;
-use crate::storage::{DB_FILE_NAME, open_database, query_collect, sqlite_error};
-use crate::{Result, acquire_data_lock, data_dir_from_env};
+use crate::storage::{query_collect, sqlite_error};
+use crate::{Result, data_dir_from_env, open_locked_database};
 
 use super::compiler::{EvidenceKind, PreferenceExample, PreferenceOutcome};
 use super::timeline::{FileTimelineRow, TimelineSourceKind, normalize_file_path};
@@ -51,9 +51,7 @@ pub fn show_example_for_data_dir(
     data_dir: &Path,
     options: TasteShowExampleOptions,
 ) -> Result<TasteExampleShowReport> {
-    let db_path = data_dir.join(DB_FILE_NAME);
-    let _lock = acquire_data_lock(data_dir)?;
-    let conn = open_database(&db_path)?;
+    let (db_path, _lock, conn) = open_locked_database(data_dir)?;
     load_example(&db_path, &conn, options)
 }
 
@@ -70,9 +68,7 @@ pub fn show_timeline_for_data_dir(
     data_dir: &Path,
     options: TasteShowTimelineOptions,
 ) -> Result<TasteTimelineShowReport> {
-    let db_path = data_dir.join(DB_FILE_NAME);
-    let _lock = acquire_data_lock(data_dir)?;
-    let conn = open_database(&db_path)?;
+    let (db_path, _lock, conn) = open_locked_database(data_dir)?;
     load_timeline(&db_path, &conn, options)
 }
 

--- a/src/taste/show.rs
+++ b/src/taste/show.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::JottraceError;
 use crate::storage::{query_collect, sqlite_error};
-use crate::{Result, data_dir_from_env, open_locked_database};
+use crate::{Result, data_dir_from_env, open_locked_database, session_not_found};
 
 use super::compiler::PreferenceExample;
 use super::timeline::{FileTimelineRow, TimelineSourceKind, normalize_file_path};
@@ -134,10 +134,7 @@ fn lookup_session_cwd(
         |row| row.get(0),
     )
     .map_err(|source| match source {
-        rusqlite::Error::QueryReturnedNoRows => JottraceError::SessionNotFound {
-            source: CLAUDE_SOURCE.to_string(),
-            source_session_id: source_session_id.to_string(),
-        },
+        rusqlite::Error::QueryReturnedNoRows => session_not_found(CLAUDE_SOURCE, source_session_id),
         source => sqlite_error(db_path, source),
     })
 }

--- a/src/taste/sidecar.rs
+++ b/src/taste/sidecar.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use crate::JottraceError;
+use crate::{JottraceError, io_error};
 
 use super::parse::{ContentRef, ParseKind, ParsedEvent};
 
@@ -120,7 +120,7 @@ impl SnapshotSidecarResolver {
                     path,
                 })
             }
-            Err(source) => Err(JottraceError::Io { path, source }),
+            Err(source) => Err(io_error(&path, source)),
         }
     }
 }

--- a/src/taste/status.rs
+++ b/src/taste/status.rs
@@ -1,7 +1,7 @@
 use rusqlite::{Connection, params};
 use std::path::{Path, PathBuf};
 
-use crate::storage::{count, sqlite_error};
+use crate::storage::{count, map_sqlite_error};
 use crate::{Result, data_dir_from_env, open_locked_database};
 
 use super::compiler::{EXTRACTOR_VERSION, HIGH_CONFIDENCE_THRESHOLD};
@@ -103,18 +103,17 @@ fn count_sessions_up_to_date(db_path: &Path, conn: &Connection) -> Result<u64> {
              WHERE source = ?1 AND parent_session_id IS NULL
              ORDER BY id",
         )
-        .map_err(|source| sqlite_error(db_path, source))?;
+        .map_err(map_sqlite_error(db_path))?;
 
     let rows = statement
         .query_map(params![CLAUDE_SOURCE], |row| {
             Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
         })
-        .map_err(|source| sqlite_error(db_path, source))?;
+        .map_err(map_sqlite_error(db_path))?;
 
     let mut count = 0u64;
     for row in rows {
-        let (parent_db_id, source_session_id) =
-            row.map_err(|source| sqlite_error(db_path, source))?;
+        let (parent_db_id, source_session_id) = row.map_err(map_sqlite_error(db_path))?;
         if session_extract_is_up_to_date(db_path, conn, parent_db_id, &source_session_id)? {
             count += 1;
         }
@@ -133,24 +132,22 @@ fn count_proposals(db_path: &Path, conn: &Connection) -> Result<u64> {
 }
 
 /// Run a `(key, COUNT(*))` GROUP BY query over `CLAUDE_SOURCE` preference rows and hand
-/// each `(key, count)` pair to `record`, routing every fallible step through [`sqlite_error`].
+/// each `(key, count)` pair to `record`, routing every fallible step through [`map_sqlite_error`].
 fn for_each_grouped_count<F: FnMut(&str, u64)>(
     db_path: &Path,
     conn: &Connection,
     sql: &str,
     mut record: F,
 ) -> Result<()> {
-    let mut statement = conn
-        .prepare(sql)
-        .map_err(|source| sqlite_error(db_path, source))?;
+    let mut statement = conn.prepare(sql).map_err(map_sqlite_error(db_path))?;
     let rows = statement
         .query_map(params![CLAUDE_SOURCE], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
         })
-        .map_err(|source| sqlite_error(db_path, source))?;
+        .map_err(map_sqlite_error(db_path))?;
 
     for row in rows {
-        let (key, count) = row.map_err(|source| sqlite_error(db_path, source))?;
+        let (key, count) = row.map_err(map_sqlite_error(db_path))?;
         let count = u64::try_from(count).expect("grouped count fits in u64");
         record(&key, count);
     }

--- a/src/taste/status.rs
+++ b/src/taste/status.rs
@@ -1,7 +1,7 @@
 use rusqlite::{Connection, params};
 use std::path::{Path, PathBuf};
 
-use crate::storage::sqlite_error;
+use crate::storage::{query_one, sqlite_error};
 use crate::{Result, data_dir_from_env, open_locked_database};
 
 use super::compiler::{EXTRACTOR_VERSION, HIGH_CONFIDENCE_THRESHOLD};
@@ -85,15 +85,15 @@ fn taste_status_from_connection(db_path: &Path, conn: &Connection) -> Result<Tas
 }
 
 fn count_claude_parent_sessions(db_path: &Path, conn: &Connection) -> Result<u64> {
-    let count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*)
+    let count: i64 = query_one(
+        db_path,
+        conn,
+        "SELECT COUNT(*)
              FROM sessions
              WHERE source = ?1 AND parent_session_id IS NULL",
-            params![CLAUDE_SOURCE],
-            |row| row.get(0),
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
+        params![CLAUDE_SOURCE],
+        |row| row.get(0),
+    )?;
     Ok(u64::try_from(count).expect("session count fits in u64"))
 }
 
@@ -126,13 +126,13 @@ fn count_sessions_up_to_date(db_path: &Path, conn: &Connection) -> Result<u64> {
 }
 
 fn count_proposals(db_path: &Path, conn: &Connection) -> Result<u64> {
-    let count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM preference_examples WHERE source = ?1",
-            params![CLAUDE_SOURCE],
-            |row| row.get(0),
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
+    let count: i64 = query_one(
+        db_path,
+        conn,
+        "SELECT COUNT(*) FROM preference_examples WHERE source = ?1",
+        params![CLAUDE_SOURCE],
+        |row| row.get(0),
+    )?;
     Ok(u64::try_from(count).expect("proposal count fits in u64"))
 }
 
@@ -202,14 +202,14 @@ fn count_evidence(db_path: &Path, conn: &Connection) -> Result<TasteEvidenceCoun
 }
 
 fn count_high_confidence_proposals(db_path: &Path, conn: &Connection) -> Result<u64> {
-    let count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*)
+    let count: i64 = query_one(
+        db_path,
+        conn,
+        "SELECT COUNT(*)
              FROM preference_examples
              WHERE source = ?1 AND confidence >= ?2",
-            params![CLAUDE_SOURCE, HIGH_CONFIDENCE_THRESHOLD],
-            |row| row.get(0),
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
+        params![CLAUDE_SOURCE, HIGH_CONFIDENCE_THRESHOLD],
+        |row| row.get(0),
+    )?;
     Ok(u64::try_from(count).expect("high-confidence count fits in u64"))
 }

--- a/src/taste/status.rs
+++ b/src/taste/status.rs
@@ -132,17 +132,17 @@ fn count_proposals(db_path: &Path, conn: &Connection) -> Result<u64> {
     )
 }
 
-fn count_outcomes(db_path: &Path, conn: &Connection) -> Result<TasteOutcomeCounts> {
+/// Run a `(key, COUNT(*))` GROUP BY query over `CLAUDE_SOURCE` preference rows and hand
+/// each `(key, count)` pair to `record`, routing every fallible step through [`sqlite_error`].
+fn for_each_grouped_count<F: FnMut(&str, u64)>(
+    db_path: &Path,
+    conn: &Connection,
+    sql: &str,
+    mut record: F,
+) -> Result<()> {
     let mut statement = conn
-        .prepare(
-            "SELECT outcome, COUNT(*)
-             FROM preference_examples
-             WHERE source = ?1
-             GROUP BY outcome",
-        )
+        .prepare(sql)
         .map_err(|source| sqlite_error(db_path, source))?;
-
-    let mut counts = TasteOutcomeCounts::default();
     let rows = statement
         .query_map(params![CLAUDE_SOURCE], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
@@ -150,40 +150,44 @@ fn count_outcomes(db_path: &Path, conn: &Connection) -> Result<TasteOutcomeCount
         .map_err(|source| sqlite_error(db_path, source))?;
 
     for row in rows {
-        let (outcome, count) = row.map_err(|source| sqlite_error(db_path, source))?;
-        let count = u64::try_from(count).expect("outcome count fits in u64");
-        match outcome.as_str() {
+        let (key, count) = row.map_err(|source| sqlite_error(db_path, source))?;
+        let count = u64::try_from(count).expect("grouped count fits in u64");
+        record(&key, count);
+    }
+
+    Ok(())
+}
+
+fn count_outcomes(db_path: &Path, conn: &Connection) -> Result<TasteOutcomeCounts> {
+    let mut counts = TasteOutcomeCounts::default();
+    for_each_grouped_count(
+        db_path,
+        conn,
+        "SELECT outcome, COUNT(*)
+             FROM preference_examples
+             WHERE source = ?1
+             GROUP BY outcome",
+        |outcome, count| match outcome {
             "accepted" => counts.accepted = count,
             "rejected" => counts.rejected = count,
             "edited" => counts.edited = count,
             _ => {}
-        }
-    }
+        },
+    )?;
 
     Ok(counts)
 }
 
 fn count_evidence(db_path: &Path, conn: &Connection) -> Result<TasteEvidenceCounts> {
-    let mut statement = conn
-        .prepare(
-            "SELECT evidence_kind, COUNT(*)
+    let mut counts = TasteEvidenceCounts::default();
+    for_each_grouped_count(
+        db_path,
+        conn,
+        "SELECT evidence_kind, COUNT(*)
              FROM preference_examples
              WHERE source = ?1
              GROUP BY evidence_kind",
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
-
-    let mut counts = TasteEvidenceCounts::default();
-    let rows = statement
-        .query_map(params![CLAUDE_SOURCE], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-        })
-        .map_err(|source| sqlite_error(db_path, source))?;
-
-    for row in rows {
-        let (evidence_kind, count) = row.map_err(|source| sqlite_error(db_path, source))?;
-        let count = u64::try_from(count).expect("evidence count fits in u64");
-        match evidence_kind.as_str() {
+        |evidence_kind, count| match evidence_kind {
             "direct_edit" => counts.direct_edit = count,
             "direct_write" => counts.direct_write = count,
             "bash_correlation" => counts.bash_correlation = count,
@@ -191,8 +195,8 @@ fn count_evidence(db_path: &Path, conn: &Connection) -> Result<TasteEvidenceCoun
             "permission_denial" => counts.permission_denial = count,
             "missing_final_state" => counts.missing_final_state = count,
             _ => {}
-        }
-    }
+        },
+    )?;
 
     Ok(counts)
 }

--- a/src/taste/status.rs
+++ b/src/taste/status.rs
@@ -1,8 +1,8 @@
 use rusqlite::{Connection, params};
 use std::path::{Path, PathBuf};
 
-use crate::storage::{DB_FILE_NAME, open_database, sqlite_error};
-use crate::{Result, acquire_data_lock, data_dir_from_env};
+use crate::storage::sqlite_error;
+use crate::{Result, data_dir_from_env, open_locked_database};
 
 use super::compiler::{EXTRACTOR_VERSION, HIGH_CONFIDENCE_THRESHOLD};
 use super::extract::session_extract_is_up_to_date;
@@ -52,9 +52,7 @@ pub fn run_taste_status() -> Result<TasteStatusReport> {
 
 /// Report taste extraction counts for a specific journal directory (tests).
 pub fn taste_status_for_data_dir(data_dir: &Path) -> Result<TasteStatusReport> {
-    let db_path = data_dir.join(DB_FILE_NAME);
-    let _lock = acquire_data_lock(data_dir)?;
-    let conn = open_database(&db_path)?;
+    let (db_path, _lock, conn) = open_locked_database(data_dir)?;
     taste_status_from_connection(&db_path, &conn)
 }
 

--- a/src/taste/status.rs
+++ b/src/taste/status.rs
@@ -1,7 +1,7 @@
 use rusqlite::{Connection, params};
 use std::path::{Path, PathBuf};
 
-use crate::storage::{query_one, sqlite_error};
+use crate::storage::{count, sqlite_error};
 use crate::{Result, data_dir_from_env, open_locked_database};
 
 use super::compiler::{EXTRACTOR_VERSION, HIGH_CONFIDENCE_THRESHOLD};
@@ -85,16 +85,14 @@ fn taste_status_from_connection(db_path: &Path, conn: &Connection) -> Result<Tas
 }
 
 fn count_claude_parent_sessions(db_path: &Path, conn: &Connection) -> Result<u64> {
-    let count: i64 = query_one(
+    count(
         db_path,
         conn,
         "SELECT COUNT(*)
              FROM sessions
              WHERE source = ?1 AND parent_session_id IS NULL",
         params![CLAUDE_SOURCE],
-        |row| row.get(0),
-    )?;
-    Ok(u64::try_from(count).expect("session count fits in u64"))
+    )
 }
 
 fn count_sessions_up_to_date(db_path: &Path, conn: &Connection) -> Result<u64> {
@@ -126,14 +124,12 @@ fn count_sessions_up_to_date(db_path: &Path, conn: &Connection) -> Result<u64> {
 }
 
 fn count_proposals(db_path: &Path, conn: &Connection) -> Result<u64> {
-    let count: i64 = query_one(
+    count(
         db_path,
         conn,
         "SELECT COUNT(*) FROM preference_examples WHERE source = ?1",
         params![CLAUDE_SOURCE],
-        |row| row.get(0),
-    )?;
-    Ok(u64::try_from(count).expect("proposal count fits in u64"))
+    )
 }
 
 fn count_outcomes(db_path: &Path, conn: &Connection) -> Result<TasteOutcomeCounts> {
@@ -202,14 +198,12 @@ fn count_evidence(db_path: &Path, conn: &Connection) -> Result<TasteEvidenceCoun
 }
 
 fn count_high_confidence_proposals(db_path: &Path, conn: &Connection) -> Result<u64> {
-    let count: i64 = query_one(
+    count(
         db_path,
         conn,
         "SELECT COUNT(*)
              FROM preference_examples
              WHERE source = ?1 AND confidence >= ?2",
         params![CLAUDE_SOURCE, HIGH_CONFIDENCE_THRESHOLD],
-        |row| row.get(0),
-    )?;
-    Ok(u64::try_from(count).expect("high-confidence count fits in u64"))
+    )
 }

--- a/src/taste/timeline.rs
+++ b/src/taste/timeline.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use rusqlite::{Connection, params};
 
 use crate::JottraceError;
-use crate::storage::sqlite_error;
+use crate::storage::execute_sql;
 
 use super::parse::{ParseKind, ParsedEvent};
 use super::sidecar::{ResolvedContent, SnapshotSidecarResolver};
@@ -140,15 +140,18 @@ pub fn replace_session_file_timelines(
     source_session_id: &str,
     rows: &[FileTimelineRow],
 ) -> Result<usize, JottraceError> {
-    conn.execute(
+    execute_sql(
+        db_path,
+        conn,
         "DELETE FROM file_timelines WHERE source = ?1 AND source_session_id = ?2",
         params![source, source_session_id],
-    )
-    .map_err(|source| sqlite_error(db_path, source))?;
+    )?;
 
     let mut inserted = 0usize;
     for row in rows {
-        conn.execute(
+        execute_sql(
+            db_path,
+            conn,
             "INSERT INTO file_timelines (
                 source,
                 source_session_id,
@@ -169,8 +172,7 @@ pub fn replace_session_file_timelines(
                 row.trigger_event_ref,
                 row.source_kind.as_str(),
             ],
-        )
-        .map_err(|source| sqlite_error(db_path, source))?;
+        )?;
         inserted += 1;
     }
 

--- a/src/taste/timeline.rs
+++ b/src/taste/timeline.rs
@@ -6,33 +6,16 @@ use rusqlite::{Connection, params};
 use crate::JottraceError;
 use crate::storage::execute_sql;
 
+use super::db_string_enum;
 use super::parse::{ParseKind, ParsedEvent};
 use super::sidecar::{ResolvedContent, SnapshotSidecarResolver};
 
-/// Where a timeline row's content was resolved from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TimelineSourceKind {
-    InlineSnapshot,
-    SidecarSnapshot,
-    MissingSidecar,
-}
-
-impl TimelineSourceKind {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::InlineSnapshot => "inline_snapshot",
-            Self::SidecarSnapshot => "sidecar_snapshot",
-            Self::MissingSidecar => "missing_sidecar",
-        }
-    }
-
-    pub fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "inline_snapshot" => Some(Self::InlineSnapshot),
-            "sidecar_snapshot" => Some(Self::SidecarSnapshot),
-            "missing_sidecar" => Some(Self::MissingSidecar),
-            _ => None,
-        }
+db_string_enum! {
+    /// Where a timeline row's content was resolved from.
+    pub enum TimelineSourceKind {
+        InlineSnapshot => "inline_snapshot",
+        SidecarSnapshot => "sidecar_snapshot",
+        MissingSidecar => "missing_sidecar",
     }
 }
 

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -526,6 +526,17 @@ fn inspect_archive_safety(archive: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Build a `JottraceError::ArchiveDatabaseInvalid` for a staged archive that
+/// failed validation. Mirrors `io_error`/`sqlite_error` so the repeated
+/// `archive: archive.to_path_buf()` struct literal does not recur at every
+/// validation site in this module.
+fn archive_database_invalid(archive: &Path, reason: String) -> JottraceError {
+    JottraceError::ArchiveDatabaseInvalid {
+        archive: archive.to_path_buf(),
+        reason,
+    }
+}
+
 /// Open the staged `db.sqlite` and confirm it is actually a Jottrace journal
 /// at the *latest* schema version before we wipe the live journal. The
 /// `user_version` range check intentionally runs against a bare
@@ -544,10 +555,10 @@ fn validate_staged_jottrace_database(staging: &Path, archive: &Path) -> Result<(
             // `enforce_private_permissions` already rejects non-regular files,
             // so reaching this arm would be a logic bug. Fail loudly with the
             // archive path so the user is not left wondering.
-            return Err(JottraceError::ArchiveDatabaseInvalid {
-                archive: archive.to_path_buf(),
-                reason: format!("{} is not a regular file", storage::DB_FILE_NAME),
-            });
+            return Err(archive_database_invalid(
+                archive,
+                format!("{} is not a regular file", storage::DB_FILE_NAME),
+            ));
         }
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
             return Err(JottraceError::ArchiveMissingDatabase(archive.to_path_buf()));
@@ -558,27 +569,20 @@ fn validate_staged_jottrace_database(staging: &Path, archive: &Path) -> Result<(
     }
 
     let user_version: i64 = {
-        let conn = Connection::open(&staged_db).map_err(|source| {
-            JottraceError::ArchiveDatabaseInvalid {
-                archive: archive.to_path_buf(),
-                reason: source.to_string(),
-            }
-        })?;
+        let conn = Connection::open(&staged_db)
+            .map_err(|source| archive_database_invalid(archive, source.to_string()))?;
         conn.pragma_query_value(None, "user_version", |row| row.get(0))
-            .map_err(|source| JottraceError::ArchiveDatabaseInvalid {
-                archive: archive.to_path_buf(),
-                reason: source.to_string(),
-            })?
+            .map_err(|source| archive_database_invalid(archive, source.to_string()))?
     };
 
     if user_version <= 0 {
-        return Err(JottraceError::ArchiveDatabaseInvalid {
-            archive: archive.to_path_buf(),
-            reason: format!(
+        return Err(archive_database_invalid(
+            archive,
+            format!(
                 "{} has no Jottrace schema (user_version={user_version})",
                 storage::DB_FILE_NAME
             ),
-        });
+        ));
     }
     if user_version > storage::LATEST_SCHEMA_VERSION {
         return Err(JottraceError::UnsupportedSchemaVersion {
@@ -597,10 +601,7 @@ fn validate_staged_jottrace_database(staging: &Path, archive: &Path) -> Result<(
         JottraceError::Sqlite {
             source: rusqlite_err,
             ..
-        } => JottraceError::ArchiveDatabaseInvalid {
-            archive: archive.to_path_buf(),
-            reason: rusqlite_err.to_string(),
-        },
+        } => archive_database_invalid(archive, rusqlite_err.to_string()),
         JottraceError::UnsupportedSchemaVersion {
             actual, supported, ..
         } => JottraceError::UnsupportedSchemaVersion {
@@ -618,11 +619,12 @@ fn validate_staged_jottrace_database(staging: &Path, archive: &Path) -> Result<(
     // 001 — would otherwise wave through here and break the receiving
     // machine after the live journal had already been wiped.
     for (table, probe_sql) in REQUIRED_JOURNAL_SCHEMA_PROBES {
-        conn.prepare(probe_sql)
-            .map_err(|source| JottraceError::ArchiveDatabaseInvalid {
-                archive: archive.to_path_buf(),
-                reason: format!("table `{table}` has unexpected schema: {source}"),
-            })?;
+        conn.prepare(probe_sql).map_err(|source| {
+            archive_database_invalid(
+                archive,
+                format!("table `{table}` has unexpected schema: {source}"),
+            )
+        })?;
     }
 
     // Columns alone do not guarantee a usable journal: ingest relies on the
@@ -679,20 +681,17 @@ fn require_unique_index_named(
             |row| row.get(0),
         )
         .optional()
-        .map_err(|source| JottraceError::ArchiveDatabaseInvalid {
-            archive: archive.to_path_buf(),
-            reason: source.to_string(),
-        })?;
+        .map_err(|source| archive_database_invalid(archive, source.to_string()))?;
     match unique {
         Some(value) if value != 0 => Ok(()),
-        Some(_) => Err(JottraceError::ArchiveDatabaseInvalid {
-            archive: archive.to_path_buf(),
-            reason: format!("index `{index_name}` on `{table}` is not unique"),
-        }),
-        None => Err(JottraceError::ArchiveDatabaseInvalid {
-            archive: archive.to_path_buf(),
-            reason: format!("missing unique index `{index_name}` on `{table}`"),
-        }),
+        Some(_) => Err(archive_database_invalid(
+            archive,
+            format!("index `{index_name}` on `{table}` is not unique"),
+        )),
+        None => Err(archive_database_invalid(
+            archive,
+            format!("missing unique index `{index_name}` on `{table}`"),
+        )),
     }
 }
 
@@ -709,20 +708,17 @@ fn require_primary_key_unique_index(conn: &Connection, archive: &Path, table: &s
             |row| row.get(0),
         )
         .optional()
-        .map_err(|source| JottraceError::ArchiveDatabaseInvalid {
-            archive: archive.to_path_buf(),
-            reason: source.to_string(),
-        })?;
+        .map_err(|source| archive_database_invalid(archive, source.to_string()))?;
     match unique {
         Some(value) if value != 0 => Ok(()),
-        Some(_) => Err(JottraceError::ArchiveDatabaseInvalid {
-            archive: archive.to_path_buf(),
-            reason: format!("PRIMARY KEY index on `{table}` is not unique"),
-        }),
-        None => Err(JottraceError::ArchiveDatabaseInvalid {
-            archive: archive.to_path_buf(),
-            reason: format!("missing PRIMARY KEY index on `{table}`"),
-        }),
+        Some(_) => Err(archive_database_invalid(
+            archive,
+            format!("PRIMARY KEY index on `{table}` is not unique"),
+        )),
+        None => Err(archive_database_invalid(
+            archive,
+            format!("missing PRIMARY KEY index on `{table}`"),
+        )),
     }
 }
 

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -812,29 +812,33 @@ fn move_staged_into_place(staging: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Canonicalise `path`, mapping a missing path to `None` rather than an error.
+/// The `*_inside_journal` checks treat a not-yet-existing path as "nothing to be
+/// inside of", so they short-circuit to `Ok(false)` when this returns `None`.
+fn canonicalize_optional(path: &Path) -> Result<Option<PathBuf>> {
+    match fs::canonicalize(path) {
+        Ok(canonical) => Ok(Some(canonical)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(io_error(path, source)),
+    }
+}
+
 /// Decide whether `pack`'s output path would land inside the source journal.
 /// Unlike `archive_is_inside`, the candidate file does not exist yet, so we
 /// canonicalise the parent directory (which must exist) and rejoin the file
 /// name to obtain a stable resolved path before comparing.
 fn pack_output_inside_journal(output: &Path, data_dir: &Path) -> Result<bool> {
-    let canonical_data = match fs::canonicalize(data_dir) {
-        Ok(path) => path,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
-        Err(source) => {
-            return Err(io_error(data_dir, source));
-        }
+    let Some(canonical_data) = canonicalize_optional(data_dir)? else {
+        return Ok(false);
     };
     let parent = output.parent().filter(|p| !p.as_os_str().is_empty());
     let canonical_parent = match parent {
-        Some(parent) => match fs::canonicalize(parent) {
-            Ok(path) => path,
+        Some(parent) => match canonicalize_optional(parent)? {
+            Some(canonical) => canonical,
             // If the parent does not exist there is nothing to be inside of
             // yet; the subsequent `claim_private_path` will turn that into a
             // proper I/O error with the right path.
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
-            Err(source) => {
-                return Err(io_error(parent, source));
-            }
+            None => return Ok(false),
         },
         None => fs::canonicalize(".").map_err(|source| io_error(Path::new("."), source))?,
     };
@@ -853,12 +857,8 @@ fn pack_output_inside_journal(output: &Path, data_dir: &Path) -> Result<bool> {
 fn archive_is_inside(archive: &Path, data_dir: &Path) -> Result<bool> {
     let canonical_archive =
         fs::canonicalize(archive).map_err(|source| io_error(archive, source))?;
-    let canonical_data = match fs::canonicalize(data_dir) {
-        Ok(path) => path,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
-        Err(source) => {
-            return Err(io_error(data_dir, source));
-        }
+    let Some(canonical_data) = canonicalize_optional(data_dir)? else {
+        return Ok(false);
     };
     Ok(canonical_archive.starts_with(canonical_data))
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -377,20 +377,14 @@ fn enforce_private_permissions(root: &Path) -> Result<()> {
             .file_type()
             .map_err(|source| io_error(&path, source))?;
         if file_type.is_symlink() {
-            return Err(JottraceError::UnsafeArchiveEntry {
-                path,
-                kind: "symbolic link",
-            });
+            return Err(unsafe_archive_entry(path, "symbolic link"));
         }
         if file_type.is_dir() {
             enforce_private_permissions(&path)?;
         } else if file_type.is_file() {
             chmod(&path, PRIVATE_FILE_MODE)?;
         } else {
-            return Err(JottraceError::UnsafeArchiveEntry {
-                path,
-                kind: "non-regular file",
-            });
+            return Err(unsafe_archive_entry(path, "non-regular file"));
         }
     }
     Ok(())
@@ -463,10 +457,7 @@ fn inspect_archive_safety(archive: &Path) -> Result<()> {
         .collect();
     let paths: Vec<&str> = paths_stdout.lines().collect();
     if types.len() != paths.len() {
-        return Err(JottraceError::UnsafeArchiveEntry {
-            path: archive.to_path_buf(),
-            kind: "inconsistent tar listing",
-        });
+        return Err(unsafe_archive_entry(archive, "inconsistent tar listing"));
     }
 
     for (type_char, path) in types.iter().zip(paths.iter()) {
@@ -480,17 +471,11 @@ fn inspect_archive_safety(archive: &Path) -> Result<()> {
             _ => Some("unknown archive entry"),
         };
         if let Some(kind) = unsafe_kind {
-            return Err(JottraceError::UnsafeArchiveEntry {
-                path: PathBuf::from(*path),
-                kind,
-            });
+            return Err(unsafe_archive_entry(*path, kind));
         }
         let path_obj = Path::new(*path);
         if path_obj.is_absolute() {
-            return Err(JottraceError::UnsafeArchiveEntry {
-                path: PathBuf::from(*path),
-                kind: "absolute path",
-            });
+            return Err(unsafe_archive_entry(*path, "absolute path"));
         }
         // Iterate components to catch two distinct problems with a single pass:
         // `..` segments (which would let a relative path escape staging once
@@ -505,18 +490,12 @@ fn inspect_archive_safety(archive: &Path) -> Result<()> {
         for component in path_obj.components() {
             match component {
                 std::path::Component::ParentDir => {
-                    return Err(JottraceError::UnsafeArchiveEntry {
-                        path: PathBuf::from(*path),
-                        kind: "parent traversal",
-                    });
+                    return Err(unsafe_archive_entry(*path, "parent traversal"));
                 }
                 std::path::Component::Normal(name) if !saw_first_real_segment => {
                     saw_first_real_segment = true;
                     if is_reserved_archive_top_level(name) {
-                        return Err(JottraceError::UnsafeArchiveEntry {
-                            path: PathBuf::from(*path),
-                            kind: "reserved top-level entry",
-                        });
+                        return Err(unsafe_archive_entry(*path, "reserved top-level entry"));
                     }
                 }
                 _ => {}
@@ -534,6 +513,18 @@ fn archive_database_invalid(archive: &Path, reason: String) -> JottraceError {
     JottraceError::ArchiveDatabaseInvalid {
         archive: archive.to_path_buf(),
         reason,
+    }
+}
+
+/// Build a `JottraceError::UnsafeArchiveEntry` for an entry that would escape
+/// `JOTTRACE_HOME`. Mirrors `archive_database_invalid` so the repeated struct
+/// literal does not recur at every `settle` safety check; `impl Into<PathBuf>`
+/// absorbs the heterogeneous path sources (owned `PathBuf`, borrowed `&Path`,
+/// and tar-listing `&str`) without a conversion at each call site.
+fn unsafe_archive_entry(path: impl Into<PathBuf>, kind: &'static str) -> JottraceError {
+    JottraceError::UnsafeArchiveEntry {
+        path: path.into(),
+        kind,
     }
 }
 
@@ -648,10 +639,7 @@ fn validate_staged_jottrace_database(staging: &Path, archive: &Path) -> Result<(
         match fs::symlink_metadata(&sidecar) {
             Ok(meta) if meta.file_type().is_file() => chmod(&sidecar, PRIVATE_FILE_MODE)?,
             Ok(_) => {
-                return Err(JottraceError::UnsafeArchiveEntry {
-                    path: sidecar,
-                    kind: "non-regular file",
-                });
+                return Err(unsafe_archive_entry(sidecar, "non-regular file"));
             }
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             Err(source) => {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -22,7 +22,7 @@ use rusqlite::Connection;
 use crate::update::{AUTO_UPDATE_LOCK_FILE, AUTO_UPDATE_STAMP_FILE};
 use crate::{
     JottraceError, LOCK_FILE_NAME, PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, Result, acquire_data_lock,
-    data_dir_from_env, ensure_private_dir, io_error, storage,
+    data_dir_from_env, ensure_private_dir, io_error, storage, unsupported_schema_version,
 };
 
 #[cfg(unix)]
@@ -576,11 +576,11 @@ fn validate_staged_jottrace_database(staging: &Path, archive: &Path) -> Result<(
         ));
     }
     if user_version > storage::LATEST_SCHEMA_VERSION {
-        return Err(JottraceError::UnsupportedSchemaVersion {
-            path: archive.to_path_buf(),
-            actual: user_version,
-            supported: storage::LATEST_SCHEMA_VERSION,
-        });
+        return Err(unsupported_schema_version(
+            archive,
+            user_version,
+            storage::LATEST_SCHEMA_VERSION,
+        ));
     }
 
     // Bring the staged file up to `LATEST_SCHEMA_VERSION` via the standard
@@ -595,11 +595,7 @@ fn validate_staged_jottrace_database(staging: &Path, archive: &Path) -> Result<(
         } => archive_database_invalid(archive, rusqlite_err.to_string()),
         JottraceError::UnsupportedSchemaVersion {
             actual, supported, ..
-        } => JottraceError::UnsupportedSchemaVersion {
-            path: archive.to_path_buf(),
-            actual,
-            supported,
-        },
+        } => unsupported_schema_version(archive, actual, supported),
         other => other,
     })?;
 

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -22,7 +22,7 @@ use rusqlite::Connection;
 use crate::update::{AUTO_UPDATE_LOCK_FILE, AUTO_UPDATE_STAMP_FILE};
 use crate::{
     JottraceError, LOCK_FILE_NAME, PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, Result, acquire_data_lock,
-    data_dir_from_env, ensure_private_dir, storage,
+    data_dir_from_env, ensure_private_dir, io_error, storage,
 };
 
 #[cfg(unix)]
@@ -104,10 +104,7 @@ pub fn run_pack(options: PackOptions) -> Result<PackReport> {
             return Err(JottraceError::NotDirectory(data_dir));
         }
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: data_dir,
-                source,
-            });
+            return Err(io_error(&data_dir, source));
         }
     }
 
@@ -179,10 +176,7 @@ pub fn run_pack(options: PackOptions) -> Result<PackReport> {
     run_tar(&mut command)?;
 
     let archive_bytes = fs::metadata(&archive)
-        .map_err(|source| JottraceError::Io {
-            path: archive.clone(),
-            source,
-        })?
+        .map_err(|source| io_error(&archive, source))?
         .len();
 
     claim.commit();
@@ -242,15 +236,9 @@ pub fn run_settle(options: SettleOptions) -> Result<SettleReport> {
     if let Err(source) = fs::remove_dir_all(&staging)
         && source.kind() != io::ErrorKind::NotFound
     {
-        return Err(JottraceError::Io {
-            path: staging.clone(),
-            source,
-        });
+        return Err(io_error(&staging, source));
     }
-    fs::create_dir(&staging).map_err(|source| JottraceError::Io {
-        path: staging.clone(),
-        source,
-    })?;
+    fs::create_dir(&staging).map_err(|source| io_error(&staging, source))?;
     chmod(&staging, PRIVATE_DIR_MODE)?;
     let mut staging_guard = StagingGuard::new(&staging);
 
@@ -294,10 +282,7 @@ pub fn run_settle(options: SettleOptions) -> Result<SettleReport> {
     // within a single filesystem (guaranteed since staging is a child of the
     // journal), and the files keep the 0600 mode set during validation.
     move_staged_into_place(&staging, &data_dir)?;
-    fs::remove_dir(&staging).map_err(|source| JottraceError::Io {
-        path: staging.clone(),
-        source,
-    })?;
+    fs::remove_dir(&staging).map_err(|source| io_error(&staging, source))?;
     staging_guard.commit();
 
     let db_path = data_dir.join(storage::DB_FILE_NAME);
@@ -327,17 +312,11 @@ fn directory_has_journal_content(path: &Path) -> Result<bool> {
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: path.to_path_buf(),
-                source,
-            });
+            return Err(io_error(path, source));
         }
     };
     for entry in entries {
-        let entry = entry.map_err(|source| JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        let entry = entry.map_err(|source| io_error(path, source))?;
         // Skip runtime artefacts (lock + auto-update sentinels). A directory
         // that only holds these is, from a user's perspective, an empty
         // journal — for example, on installer-managed binaries
@@ -357,15 +336,9 @@ fn directory_has_journal_content(path: &Path) -> Result<bool> {
 }
 
 fn clear_journal_contents(path: &Path) -> Result<()> {
-    let entries = fs::read_dir(path).map_err(|source| JottraceError::Io {
-        path: path.to_path_buf(),
-        source,
-    })?;
+    let entries = fs::read_dir(path).map_err(|source| io_error(path, source))?;
     for entry in entries {
-        let entry = entry.map_err(|source| JottraceError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        let entry = entry.map_err(|source| io_error(path, source))?;
         let name = entry.file_name();
         // Preserve the lock file (settle is holding it; removing it would
         // orphan the OS flock) and the staging dir (it holds the validated
@@ -374,10 +347,9 @@ fn clear_journal_contents(path: &Path) -> Result<()> {
             continue;
         }
         let child = entry.path();
-        let file_type = entry.file_type().map_err(|source| JottraceError::Io {
-            path: child.clone(),
-            source,
-        })?;
+        let file_type = entry
+            .file_type()
+            .map_err(|source| io_error(&child, source))?;
         // remove_dir_all and remove_file both refuse to traverse symlinks, so
         // a stray link in the existing journal can only ever delete itself —
         // never the target it points at.
@@ -386,34 +358,24 @@ fn clear_journal_contents(path: &Path) -> Result<()> {
         } else {
             fs::remove_file(&child)
         };
-        result.map_err(|source| JottraceError::Io {
-            path: child,
-            source,
-        })?;
+        result.map_err(|source| io_error(&child, source))?;
     }
     Ok(())
 }
 
 fn enforce_private_permissions(root: &Path) -> Result<()> {
     chmod(root, PRIVATE_DIR_MODE)?;
-    let entries = fs::read_dir(root).map_err(|source| JottraceError::Io {
-        path: root.to_path_buf(),
-        source,
-    })?;
+    let entries = fs::read_dir(root).map_err(|source| io_error(root, source))?;
     for entry in entries {
-        let entry = entry.map_err(|source| JottraceError::Io {
-            path: root.to_path_buf(),
-            source,
-        })?;
+        let entry = entry.map_err(|source| io_error(root, source))?;
         let path = entry.path();
         // Use `file_type` (which does NOT follow symlinks) instead of
         // `metadata`. A crafted archive could otherwise place a symlink
         // pointing outside `JOTTRACE_HOME`; chmod follows symlinks, so the
         // permission change would land on the target file.
-        let file_type = entry.file_type().map_err(|source| JottraceError::Io {
-            path: path.clone(),
-            source,
-        })?;
+        let file_type = entry
+            .file_type()
+            .map_err(|source| io_error(&path, source))?;
         if file_type.is_symlink() {
             return Err(JottraceError::UnsafeArchiveEntry {
                 path,
@@ -437,10 +399,7 @@ fn enforce_private_permissions(root: &Path) -> Result<()> {
 #[cfg(unix)]
 fn chmod(path: &Path, mode: u32) -> Result<()> {
     let permissions = fs::Permissions::from_mode(mode);
-    fs::set_permissions(path, permissions).map_err(|source| JottraceError::Io {
-        path: path.to_path_buf(),
-        source,
-    })
+    fs::set_permissions(path, permissions).map_err(|source| io_error(path, source))
 }
 
 #[cfg(not(unix))]
@@ -594,10 +553,7 @@ fn validate_staged_jottrace_database(staging: &Path, archive: &Path) -> Result<(
             return Err(JottraceError::ArchiveMissingDatabase(archive.to_path_buf()));
         }
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: staged_db,
-                source,
-            });
+            return Err(io_error(&staged_db, source));
         }
     }
 
@@ -697,10 +653,7 @@ fn validate_staged_jottrace_database(staging: &Path, archive: &Path) -> Result<(
             }
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             Err(source) => {
-                return Err(JottraceError::Io {
-                    path: sidecar,
-                    source,
-                });
+                return Err(io_error(&sidecar, source));
             }
         }
     }
@@ -786,10 +739,7 @@ fn claim_private_path(path: &Path) -> Result<std::fs::File> {
         if source.kind() == io::ErrorKind::AlreadyExists {
             JottraceError::PackOutputExists(path.to_path_buf())
         } else {
-            JottraceError::Io {
-                path: path.to_path_buf(),
-                source,
-            }
+            io_error(path, source)
         }
     })
 }
@@ -856,18 +806,12 @@ impl Drop for StagingGuard {
 /// for ensuring `dest` already has space for the renamed entries (typically by
 /// running `clear_journal_contents` first).
 fn move_staged_into_place(staging: &Path, dest: &Path) -> Result<()> {
-    let entries = fs::read_dir(staging).map_err(|source| JottraceError::Io {
-        path: staging.to_path_buf(),
-        source,
-    })?;
+    let entries = fs::read_dir(staging).map_err(|source| io_error(staging, source))?;
     for entry in entries {
-        let entry = entry.map_err(|source| JottraceError::Io {
-            path: staging.to_path_buf(),
-            source,
-        })?;
+        let entry = entry.map_err(|source| io_error(staging, source))?;
         let from = entry.path();
         let to = dest.join(entry.file_name());
-        fs::rename(&from, &to).map_err(|source| JottraceError::Io { path: from, source })?;
+        fs::rename(&from, &to).map_err(|source| io_error(&from, source))?;
     }
     Ok(())
 }
@@ -881,10 +825,7 @@ fn pack_output_inside_journal(output: &Path, data_dir: &Path) -> Result<bool> {
         Ok(path) => path,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: data_dir.to_path_buf(),
-                source,
-            });
+            return Err(io_error(data_dir, source));
         }
     };
     let parent = output.parent().filter(|p| !p.as_os_str().is_empty());
@@ -896,16 +837,10 @@ fn pack_output_inside_journal(output: &Path, data_dir: &Path) -> Result<bool> {
             // proper I/O error with the right path.
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
             Err(source) => {
-                return Err(JottraceError::Io {
-                    path: parent.to_path_buf(),
-                    source,
-                });
+                return Err(io_error(parent, source));
             }
         },
-        None => fs::canonicalize(".").map_err(|source| JottraceError::Io {
-            path: PathBuf::from("."),
-            source,
-        })?,
+        None => fs::canonicalize(".").map_err(|source| io_error(Path::new("."), source))?,
     };
     let file_name = match output.file_name() {
         Some(name) => name,
@@ -920,18 +855,13 @@ fn pack_output_inside_journal(output: &Path, data_dir: &Path) -> Result<bool> {
 /// check. If `data_dir` does not exist yet the check is a no-op: there is
 /// nothing to be inside.
 fn archive_is_inside(archive: &Path, data_dir: &Path) -> Result<bool> {
-    let canonical_archive = fs::canonicalize(archive).map_err(|source| JottraceError::Io {
-        path: archive.to_path_buf(),
-        source,
-    })?;
+    let canonical_archive =
+        fs::canonicalize(archive).map_err(|source| io_error(archive, source))?;
     let canonical_data = match fs::canonicalize(data_dir) {
         Ok(path) => path,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
         Err(source) => {
-            return Err(JottraceError::Io {
-                path: data_dir.to_path_buf(),
-                source,
-            });
+            return Err(io_error(data_dir, source));
         }
     };
     Ok(canonical_archive.starts_with(canonical_data))

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -22,7 +22,8 @@ use rusqlite::Connection;
 use crate::update::{AUTO_UPDATE_LOCK_FILE, AUTO_UPDATE_STAMP_FILE};
 use crate::{
     JottraceError, LOCK_FILE_NAME, PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, Result, acquire_data_lock,
-    data_dir_from_env, ensure_private_dir, io_error, storage, unsupported_schema_version,
+    data_dir_from_env, ensure_private_dir, io_error, map_io_error, storage,
+    unsupported_schema_version,
 };
 
 #[cfg(unix)]
@@ -176,7 +177,7 @@ pub fn run_pack(options: PackOptions) -> Result<PackReport> {
     run_tar(&mut command)?;
 
     let archive_bytes = fs::metadata(&archive)
-        .map_err(|source| io_error(&archive, source))?
+        .map_err(map_io_error(&archive))?
         .len();
 
     claim.commit();
@@ -238,7 +239,7 @@ pub fn run_settle(options: SettleOptions) -> Result<SettleReport> {
     {
         return Err(io_error(&staging, source));
     }
-    fs::create_dir(&staging).map_err(|source| io_error(&staging, source))?;
+    fs::create_dir(&staging).map_err(map_io_error(&staging))?;
     chmod(&staging, PRIVATE_DIR_MODE)?;
     let mut staging_guard = StagingGuard::new(&staging);
 
@@ -282,7 +283,7 @@ pub fn run_settle(options: SettleOptions) -> Result<SettleReport> {
     // within a single filesystem (guaranteed since staging is a child of the
     // journal), and the files keep the 0600 mode set during validation.
     move_staged_into_place(&staging, &data_dir)?;
-    fs::remove_dir(&staging).map_err(|source| io_error(&staging, source))?;
+    fs::remove_dir(&staging).map_err(map_io_error(&staging))?;
     staging_guard.commit();
 
     let db_path = data_dir.join(storage::DB_FILE_NAME);
@@ -316,7 +317,7 @@ fn directory_has_journal_content(path: &Path) -> Result<bool> {
         }
     };
     for entry in entries {
-        let entry = entry.map_err(|source| io_error(path, source))?;
+        let entry = entry.map_err(map_io_error(path))?;
         // Skip runtime artefacts (lock + auto-update sentinels). A directory
         // that only holds these is, from a user's perspective, an empty
         // journal — for example, on installer-managed binaries
@@ -336,9 +337,9 @@ fn directory_has_journal_content(path: &Path) -> Result<bool> {
 }
 
 fn clear_journal_contents(path: &Path) -> Result<()> {
-    let entries = fs::read_dir(path).map_err(|source| io_error(path, source))?;
+    let entries = fs::read_dir(path).map_err(map_io_error(path))?;
     for entry in entries {
-        let entry = entry.map_err(|source| io_error(path, source))?;
+        let entry = entry.map_err(map_io_error(path))?;
         let name = entry.file_name();
         // Preserve the lock file (settle is holding it; removing it would
         // orphan the OS flock) and the staging dir (it holds the validated
@@ -347,9 +348,7 @@ fn clear_journal_contents(path: &Path) -> Result<()> {
             continue;
         }
         let child = entry.path();
-        let file_type = entry
-            .file_type()
-            .map_err(|source| io_error(&child, source))?;
+        let file_type = entry.file_type().map_err(map_io_error(&child))?;
         // remove_dir_all and remove_file both refuse to traverse symlinks, so
         // a stray link in the existing journal can only ever delete itself —
         // never the target it points at.
@@ -358,24 +357,22 @@ fn clear_journal_contents(path: &Path) -> Result<()> {
         } else {
             fs::remove_file(&child)
         };
-        result.map_err(|source| io_error(&child, source))?;
+        result.map_err(map_io_error(&child))?;
     }
     Ok(())
 }
 
 fn enforce_private_permissions(root: &Path) -> Result<()> {
     chmod(root, PRIVATE_DIR_MODE)?;
-    let entries = fs::read_dir(root).map_err(|source| io_error(root, source))?;
+    let entries = fs::read_dir(root).map_err(map_io_error(root))?;
     for entry in entries {
-        let entry = entry.map_err(|source| io_error(root, source))?;
+        let entry = entry.map_err(map_io_error(root))?;
         let path = entry.path();
         // Use `file_type` (which does NOT follow symlinks) instead of
         // `metadata`. A crafted archive could otherwise place a symlink
         // pointing outside `JOTTRACE_HOME`; chmod follows symlinks, so the
         // permission change would land on the target file.
-        let file_type = entry
-            .file_type()
-            .map_err(|source| io_error(&path, source))?;
+        let file_type = entry.file_type().map_err(map_io_error(&path))?;
         if file_type.is_symlink() {
             return Err(unsafe_archive_entry(path, "symbolic link"));
         }
@@ -393,7 +390,7 @@ fn enforce_private_permissions(root: &Path) -> Result<()> {
 #[cfg(unix)]
 fn chmod(path: &Path, mode: u32) -> Result<()> {
     let permissions = fs::Permissions::from_mode(mode);
-    fs::set_permissions(path, permissions).map_err(|source| io_error(path, source))
+    fs::set_permissions(path, permissions).map_err(map_io_error(path))
 }
 
 #[cfg(not(unix))]
@@ -786,12 +783,12 @@ impl Drop for StagingGuard {
 /// for ensuring `dest` already has space for the renamed entries (typically by
 /// running `clear_journal_contents` first).
 fn move_staged_into_place(staging: &Path, dest: &Path) -> Result<()> {
-    let entries = fs::read_dir(staging).map_err(|source| io_error(staging, source))?;
+    let entries = fs::read_dir(staging).map_err(map_io_error(staging))?;
     for entry in entries {
-        let entry = entry.map_err(|source| io_error(staging, source))?;
+        let entry = entry.map_err(map_io_error(staging))?;
         let from = entry.path();
         let to = dest.join(entry.file_name());
-        fs::rename(&from, &to).map_err(|source| io_error(&from, source))?;
+        fs::rename(&from, &to).map_err(map_io_error(&from))?;
     }
     Ok(())
 }
@@ -824,7 +821,7 @@ fn pack_output_inside_journal(output: &Path, data_dir: &Path) -> Result<bool> {
             // proper I/O error with the right path.
             None => return Ok(false),
         },
-        None => fs::canonicalize(".").map_err(|source| io_error(Path::new("."), source))?,
+        None => fs::canonicalize(".").map_err(map_io_error(Path::new(".")))?,
     };
     let file_name = match output.file_name() {
         Some(name) => name,
@@ -839,8 +836,7 @@ fn pack_output_inside_journal(output: &Path, data_dir: &Path) -> Result<bool> {
 /// check. If `data_dir` does not exist yet the check is a no-op: there is
 /// nothing to be inside.
 fn archive_is_inside(archive: &Path, data_dir: &Path) -> Result<bool> {
-    let canonical_archive =
-        fs::canonicalize(archive).map_err(|source| io_error(archive, source))?;
+    let canonical_archive = fs::canonicalize(archive).map_err(map_io_error(archive))?;
     let Some(canonical_data) = canonicalize_optional(data_dir)? else {
         return Ok(false);
     };

--- a/src/update.rs
+++ b/src/update.rs
@@ -124,6 +124,13 @@ impl std::error::Error for UpdateError {
 
 pub type Result<T> = std::result::Result<T, UpdateError>;
 
+fn io_error(path: &Path, source: io::Error) -> UpdateError {
+    UpdateError::Io {
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
 pub fn is_auto_update_command(command: &str) -> bool {
     command == AUTO_UPDATE_COMMAND
 }
@@ -187,10 +194,7 @@ fn install_path() -> Result<PathBuf> {
         return Ok(PathBuf::from(path));
     }
 
-    env::current_exe().map_err(|source| UpdateError::Io {
-        path: PathBuf::from("current executable"),
-        source,
-    })
+    env::current_exe().map_err(|source| io_error(Path::new("current executable"), source))
 }
 
 fn release_url(target: &str, version: &str) -> String {
@@ -260,10 +264,7 @@ fn binary_version(path: &Path) -> Result<String> {
     let output = Command::new(path)
         .arg("--version")
         .output()
-        .map_err(|source| UpdateError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        .map_err(|source| io_error(path, source))?;
 
     if !output.status.success() {
         return Err(UpdateError::InvalidArtifact(format!(
@@ -524,26 +525,17 @@ fn replace_installed_binary(candidate: &Path, install_path: &Path) -> Result<()>
         unique_suffix()
     ));
 
-    fs::copy(candidate, &staged).map_err(|source| UpdateError::Io {
-        path: staged.clone(),
-        source,
-    })?;
+    fs::copy(candidate, &staged).map_err(|source| io_error(&staged, source))?;
 
     #[cfg(unix)]
     fs::set_permissions(&staged, fs::Permissions::from_mode(0o755)).map_err(|source| {
         let _ = fs::remove_file(&staged);
-        UpdateError::Io {
-            path: staged.clone(),
-            source,
-        }
+        io_error(&staged, source)
     })?;
 
     fs::rename(&staged, install_path).map_err(|source| {
         let _ = fs::remove_file(&staged);
-        UpdateError::Io {
-            path: install_path.to_path_buf(),
-            source,
-        }
+        io_error(install_path, source)
     })
 }
 
@@ -558,10 +550,7 @@ impl TempDir {
             std::process::id(),
             unique_suffix()
         ));
-        fs::create_dir(&path).map_err(|source| UpdateError::Io {
-            path: path.clone(),
-            source,
-        })?;
+        fs::create_dir(&path).map_err(|source| io_error(&path, source))?;
         Ok(Self { path })
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -131,6 +131,13 @@ fn io_error(path: &Path, source: io::Error) -> UpdateError {
     }
 }
 
+/// Build a `map_err` adapter that routes an `io::Error` through [`io_error`] for
+/// `path`, so the per-operation `|source| io_error(path, source)` closure is
+/// written once. The `UpdateError` sibling of `crate::map_io_error`.
+fn map_io_error(path: &Path) -> impl Fn(io::Error) -> UpdateError {
+    move |source| io_error(path, source)
+}
+
 pub fn is_auto_update_command(command: &str) -> bool {
     command == AUTO_UPDATE_COMMAND
 }
@@ -194,7 +201,7 @@ fn install_path() -> Result<PathBuf> {
         return Ok(PathBuf::from(path));
     }
 
-    env::current_exe().map_err(|source| io_error(Path::new("current executable"), source))
+    env::current_exe().map_err(map_io_error(Path::new("current executable")))
 }
 
 fn release_url(target: &str, version: &str) -> String {
@@ -264,7 +271,7 @@ fn binary_version(path: &Path) -> Result<String> {
     let output = Command::new(path)
         .arg("--version")
         .output()
-        .map_err(|source| io_error(path, source))?;
+        .map_err(map_io_error(path))?;
 
     if !output.status.success() {
         return Err(UpdateError::InvalidArtifact(format!(
@@ -525,7 +532,7 @@ fn replace_installed_binary(candidate: &Path, install_path: &Path) -> Result<()>
         unique_suffix()
     ));
 
-    fs::copy(candidate, &staged).map_err(|source| io_error(&staged, source))?;
+    fs::copy(candidate, &staged).map_err(map_io_error(&staged))?;
 
     #[cfg(unix)]
     fs::set_permissions(&staged, fs::Permissions::from_mode(0o755)).map_err(|source| {
@@ -550,7 +557,7 @@ impl TempDir {
             std::process::id(),
             unique_suffix()
         ));
-        fs::create_dir(&path).map_err(|source| io_error(&path, source))?;
+        fs::create_dir(&path).map_err(map_io_error(&path))?;
         Ok(Self { path })
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 
 use crate::storage::{
     IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload,
-    decode_event_payload_prefix, sqlite_error, unresolved_ingest_errors_from_connection,
+    decode_event_payload_prefix, query_collect, sqlite_error,
+    unresolved_ingest_errors_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
 
@@ -493,18 +494,13 @@ fn load_sessions(
           LIMIT ?2 OFFSET ?3",
     );
 
-    let mut statement = conn
-        .prepare(&sql)
-        .map_err(|source| sqlite_error(path, source))?;
-
-    let sessions = statement
-        .query_map(
-            params![search.like.as_deref(), (limit + 1) as i64, offset as i64],
-            loaded_session_from_row,
-        )
-        .map_err(|source| sqlite_error(path, source))?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|source| sqlite_error(path, source))?;
+    let sessions = query_collect(
+        path,
+        conn,
+        &sql,
+        params![search.like.as_deref(), (limit + 1) as i64, offset as i64],
+        loaded_session_from_row,
+    )?;
     Ok(paginate(sessions, offset, limit))
 }
 
@@ -595,24 +591,17 @@ fn load_events(
     offset: usize,
 ) -> Result<(Vec<JournalEvent>, PageInfo)> {
     let limit = EVENT_PAGE_SIZE;
-    let mut statement = conn
-        .prepare(
-            "SELECT generation, seq, ts, codec, payload_size
-             FROM events
-             WHERE session_id = ?1
-             ORDER BY generation, seq
-             LIMIT ?2 OFFSET ?3",
-        )
-        .map_err(|source| sqlite_error(path, source))?;
-
-    let events = statement
-        .query_map(
-            params![session_id, (limit + 1) as i64, offset as i64],
-            journal_event_metadata_from_row,
-        )
-        .map_err(|source| sqlite_error(path, source))?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|source| sqlite_error(path, source))?;
+    let events = query_collect(
+        path,
+        conn,
+        "SELECT generation, seq, ts, codec, payload_size
+         FROM events
+         WHERE session_id = ?1
+         ORDER BY generation, seq
+         LIMIT ?2 OFFSET ?3",
+        params![session_id, (limit + 1) as i64, offset as i64],
+        journal_event_metadata_from_row,
+    )?;
     Ok(paginate(events, offset, limit))
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use crate::storage::{
     IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload,
-    decode_event_payload_prefix, query_collect, query_optional, sqlite_error,
+    decode_event_payload_prefix, query_collect, query_one, query_optional, sqlite_error,
     unresolved_ingest_errors_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
@@ -422,9 +422,7 @@ fn open_web_database(path: &Path) -> Result<Connection> {
         .map_err(|source| sqlite_error(path, source))?;
     conn.busy_timeout(Duration::from_secs(5))
         .map_err(|source| sqlite_error(path, source))?;
-    let schema_version: i64 = conn
-        .query_row("PRAGMA user_version", [], |row| row.get(0))
-        .map_err(|source| sqlite_error(path, source))?;
+    let schema_version: i64 = query_one(path, &conn, "PRAGMA user_version", [], |row| row.get(0))?;
     if schema_version > LATEST_SCHEMA_VERSION {
         return Err(JottraceError::UnsupportedSchemaVersion {
             path: path.to_path_buf(),

--- a/src/web.rs
+++ b/src/web.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use crate::storage::{
     IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload,
-    decode_event_payload_prefix, open_readonly_database, query_collect, query_one, query_optional,
-    row_value, sqlite_error, unresolved_ingest_errors_from_connection,
+    decode_event_payload_prefix, map_sqlite_error, open_readonly_database, query_collect,
+    query_one, query_optional, row_value, sqlite_error, unresolved_ingest_errors_from_connection,
 };
 use crate::{JottraceError, Result, io_error, unsupported_schema_version};
 
@@ -405,7 +405,7 @@ pub fn render_home_page(view: &JournalView, query: &JournalQuery) -> String {
 fn open_web_database(path: &Path) -> Result<Connection> {
     let conn = open_readonly_database(path, sqlite_error)?;
     conn.busy_timeout(Duration::from_secs(5))
-        .map_err(|source| sqlite_error(path, source))?;
+        .map_err(map_sqlite_error(path))?;
     let schema_version: i64 = query_one(path, &conn, "PRAGMA user_version", [], |row| row.get(0))?;
     if schema_version > LATEST_SCHEMA_VERSION {
         return Err(unsupported_schema_version(
@@ -763,13 +763,13 @@ fn decoded_payload_matching_session_ids(
              WHERE codec IN (?1, ?2)
              ORDER BY session_id, generation, seq",
         )
-        .map_err(|source| sqlite_error(path, source))?;
+        .map_err(map_sqlite_error(path))?;
     let mut rows = statement
         .query(params![RAW_CODEC, ZSTD_CODEC, PAYLOAD_PREVIEW_BYTES as i64])
-        .map_err(|source| sqlite_error(path, source))?;
+        .map_err(map_sqlite_error(path))?;
     let mut session_ids = Vec::new();
     let mut matched_session_id = None;
-    while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
+    while let Some(row) = rows.next().map_err(map_sqlite_error(path))? {
         let session_id: i64 = row_value(path, row, 0)?;
         if matched_session_id == Some(session_id) {
             continue;

--- a/src/web.rs
+++ b/src/web.rs
@@ -10,7 +10,7 @@ use crate::storage::{
     decode_event_payload_prefix, open_readonly_database, query_collect, query_one, query_optional,
     row_value, sqlite_error, unresolved_ingest_errors_from_connection,
 };
-use crate::{JottraceError, Result, io_error};
+use crate::{JottraceError, Result, io_error, unsupported_schema_version};
 
 const SESSION_PAGE_SIZE: usize = 50;
 const EVENT_PAGE_SIZE: usize = 25;
@@ -408,11 +408,11 @@ fn open_web_database(path: &Path) -> Result<Connection> {
         .map_err(|source| sqlite_error(path, source))?;
     let schema_version: i64 = query_one(path, &conn, "PRAGMA user_version", [], |row| row.get(0))?;
     if schema_version > LATEST_SCHEMA_VERSION {
-        return Err(JottraceError::UnsupportedSchemaVersion {
-            path: path.to_path_buf(),
-            actual: schema_version,
-            supported: LATEST_SCHEMA_VERSION,
-        });
+        return Err(unsupported_schema_version(
+            path,
+            schema_version,
+            LATEST_SCHEMA_VERSION,
+        ));
     }
     Ok(conn)
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, params};
+use rusqlite::{Connection, OpenFlags, Row, params};
 use std::fmt::Write as _;
 use std::io::{self, Read, Write as IoWrite};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use crate::storage::{
     IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload,
-    decode_event_payload_prefix, query_collect, sqlite_error,
+    decode_event_payload_prefix, query_collect, query_optional, sqlite_error,
     unresolved_ingest_errors_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
@@ -510,19 +510,18 @@ fn load_event_payload_text(
     session_id: i64,
     key: EventKey,
 ) -> Result<Option<String>> {
-    let row = conn
-        .query_row(
-            "SELECT payload, codec
+    let row = query_optional(
+        path,
+        conn,
+        "SELECT payload, codec
              FROM events
              WHERE session_id = ?1
                AND generation = ?2
                AND seq = ?3
              LIMIT 1",
-            params![session_id, key.generation, key.seq],
-            |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, String>(1)?)),
-        )
-        .optional()
-        .map_err(|source| sqlite_error(path, source))?;
+        params![session_id, key.generation, key.seq],
+        |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, String>(1)?)),
+    )?;
 
     row.map(|(payload, codec)| {
         decode_event_payload(&payload, &codec)
@@ -558,7 +557,9 @@ fn load_session_by_source_session_id(
     source: Option<&str>,
     source_session_id: &str,
 ) -> Result<Option<LoadedSession>> {
-    conn.query_row(
+    query_optional(
+        path,
+        conn,
         "SELECT sessions.id, sessions.source, sessions.source_session_id,
                 sessions.file_path, sessions.cwd, parent.source_session_id,
                 sessions.started_at, sessions.ended_at, sessions.event_count
@@ -571,8 +572,6 @@ fn load_session_by_source_session_id(
         params![source, source_session_id],
         loaded_session_from_row,
     )
-    .optional()
-    .map_err(|source| sqlite_error(path, source))
 }
 
 fn session_matches(
@@ -611,9 +610,10 @@ fn load_event_payload(
     session_id: i64,
     key: EventKey,
 ) -> Result<Option<JournalEvent>> {
-    let row = conn
-        .query_row(
-            "SELECT generation, seq, ts, codec, payload_size,
+    let row = query_optional(
+        path,
+        conn,
+        "SELECT generation, seq, ts, codec, payload_size,
                 CASE
                     WHEN codec = ?4 THEN substr(payload, 1, ?5)
                     ELSE payload
@@ -623,27 +623,25 @@ fn load_event_payload(
            AND generation = ?2
            AND seq = ?3
          LIMIT 1",
-            params![
-                session_id,
-                key.generation,
-                key.seq,
-                RAW_CODEC,
-                PAYLOAD_PREVIEW_BYTES as i64,
-            ],
-            |row| {
-                let payload_size: i64 = row.get("payload_size")?;
-                Ok((
-                    row.get("generation")?,
-                    row.get("seq")?,
-                    row.get("ts")?,
-                    row.get("codec")?,
-                    payload_size as u64,
-                    row.get("payload_preview")?,
-                ))
-            },
-        )
-        .optional()
-        .map_err(|source| sqlite_error(path, source))?;
+        params![
+            session_id,
+            key.generation,
+            key.seq,
+            RAW_CODEC,
+            PAYLOAD_PREVIEW_BYTES as i64,
+        ],
+        |row| {
+            let payload_size: i64 = row.get("payload_size")?;
+            Ok((
+                row.get("generation")?,
+                row.get("seq")?,
+                row.get("ts")?,
+                row.get("codec")?,
+                payload_size as u64,
+                row.get("payload_preview")?,
+            ))
+        },
+    )?;
 
     row.map(
         |(generation, seq, ts, codec, payload_size, payload_preview)| {

--- a/src/web.rs
+++ b/src/web.rs
@@ -10,7 +10,7 @@ use crate::storage::{
     decode_event_payload_prefix, map_sqlite_error, open_readonly_database, query_collect,
     query_one, query_optional, row_value, sqlite_error, unresolved_ingest_errors_from_connection,
 };
-use crate::{JottraceError, Result, io_error, unsupported_schema_version};
+use crate::{JottraceError, Result, io_error, map_io_error, unsupported_schema_version};
 
 const SESSION_PAGE_SIZE: usize = 50;
 const EVENT_PAGE_SIZE: usize = 25;
@@ -120,8 +120,8 @@ pub struct WebServer {
 impl WebServer {
     pub fn bind(db_path: PathBuf, port: u16) -> Result<Self> {
         drop(open_web_database(&db_path)?);
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, port))
-            .map_err(|source| io_error(&db_path, source))?;
+        let listener =
+            TcpListener::bind((Ipv4Addr::LOCALHOST, port)).map_err(map_io_error(&db_path))?;
         Ok(Self { db_path, listener })
     }
 
@@ -154,7 +154,7 @@ impl WebServer {
         self.listener
             .accept()
             .map(|(stream, _)| stream)
-            .map_err(|source| io_error(&self.db_path, source))
+            .map_err(map_io_error(&self.db_path))
     }
 
     fn handle_stream(&self, stream: &mut TcpStream) -> Result<()> {

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, OpenFlags, Row, params};
+use rusqlite::{Connection, Row, params};
 use std::fmt::Write as _;
 use std::io::{self, Read, Write as IoWrite};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use crate::storage::{
     IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload,
-    decode_event_payload_prefix, query_collect, query_one, query_optional, row_value, sqlite_error,
-    unresolved_ingest_errors_from_connection,
+    decode_event_payload_prefix, open_readonly_database, query_collect, query_one, query_optional,
+    row_value, sqlite_error, unresolved_ingest_errors_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
 
@@ -418,8 +418,7 @@ pub fn render_home_page(view: &JournalView, query: &JournalQuery) -> String {
 }
 
 fn open_web_database(path: &Path) -> Result<Connection> {
-    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .map_err(|source| sqlite_error(path, source))?;
+    let conn = open_readonly_database(path, sqlite_error)?;
     conn.busy_timeout(Duration::from_secs(5))
         .map_err(|source| sqlite_error(path, source))?;
     let schema_version: i64 = query_one(path, &conn, "PRAGMA user_version", [], |row| row.get(0))?;

--- a/src/web.rs
+++ b/src/web.rs
@@ -680,30 +680,23 @@ fn journal_event_with_payload(
     payload_size: u64,
     payload: Vec<u8>,
 ) -> Result<JournalEvent> {
-    let payload_preview = match decode_event_payload_prefix(&payload, &codec, PAYLOAD_PREVIEW_BYTES)
-    {
-        Ok(decoded) => String::from_utf8_lossy(&decoded)
-            .chars()
-            .take(PAYLOAD_PREVIEW_CHARS)
-            .collect(),
-        Err(error) => {
-            return Ok(JournalEvent {
-                generation,
-                seq,
-                ts,
-                payload_preview: String::new(),
-                payload_error: Some(error.to_string()),
-                codec,
-                payload_size,
-            });
-        }
-    };
+    let (payload_preview, payload_error) =
+        match decode_event_payload_prefix(&payload, &codec, PAYLOAD_PREVIEW_BYTES) {
+            Ok(decoded) => (
+                String::from_utf8_lossy(&decoded)
+                    .chars()
+                    .take(PAYLOAD_PREVIEW_CHARS)
+                    .collect(),
+                None,
+            ),
+            Err(error) => (String::new(), Some(error.to_string())),
+        };
     Ok(JournalEvent {
         generation,
         seq,
         ts,
         payload_preview,
-        payload_error: None,
+        payload_error,
         codec,
         payload_size,
     })

--- a/src/web.rs
+++ b/src/web.rs
@@ -20,6 +20,8 @@ const MIN_PAYLOAD_SEARCH_CHARS: usize = 3;
 const PAYLOAD_PREVIEW_BYTES: usize = 4096;
 const PAYLOAD_PREVIEW_CHARS: usize = 280;
 const READ_LIMIT_BYTES: usize = 8192;
+const TEXT_PLAIN: &str = "text/plain; charset=utf-8";
+const TEXT_HTML: &str = "text/html; charset=utf-8";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JournalQuery {
@@ -161,19 +163,14 @@ impl WebServer {
             .map_err(|source| self.io_error(source))?;
         let request = self.read_request(stream)?;
         let Some((method, target)) = request_line(&request) else {
-            return self.write_response(
-                stream,
-                "400 Bad Request",
-                "text/plain; charset=utf-8",
-                "bad request",
-            );
+            return self.write_response(stream, "400 Bad Request", TEXT_PLAIN, "bad request");
         };
 
         if method != "GET" {
             return self.write_response(
                 stream,
                 "405 Method Not Allowed",
-                "text/plain; charset=utf-8",
+                TEXT_PLAIN,
                 "method not allowed",
             );
         }
@@ -185,26 +182,14 @@ impl WebServer {
                     Ok(view) => render_home_page(&view, &query),
                     Err(error) => render_error_page(&self.db_path, &error),
                 };
-                ("200 OK", "text/html; charset=utf-8", body)
+                ("200 OK", TEXT_HTML, body)
             }
             "/payload" => match event_payload_text_for_path(&self.db_path, target) {
-                Ok(Some(payload)) => ("200 OK", "text/plain; charset=utf-8", payload),
-                Ok(None) => (
-                    "404 Not Found",
-                    "text/plain; charset=utf-8",
-                    "payload not found".to_string(),
-                ),
-                Err(error) => (
-                    "500 Internal Server Error",
-                    "text/plain; charset=utf-8",
-                    error.to_string(),
-                ),
+                Ok(Some(payload)) => ("200 OK", TEXT_PLAIN, payload),
+                Ok(None) => ("404 Not Found", TEXT_PLAIN, "payload not found".to_string()),
+                Err(error) => ("500 Internal Server Error", TEXT_PLAIN, error.to_string()),
             },
-            _ => (
-                "404 Not Found",
-                "text/plain; charset=utf-8",
-                "not found".to_string(),
-            ),
+            _ => ("404 Not Found", TEXT_PLAIN, "not found".to_string()),
         };
         self.write_response(stream, status, content_type, &body)
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use crate::storage::{
     IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload,
-    decode_event_payload_prefix, query_collect, query_one, query_optional, sqlite_error,
+    decode_event_payload_prefix, query_collect, query_one, query_optional, row_value, sqlite_error,
     unresolved_ingest_errors_from_connection,
 };
 use crate::{JottraceError, Result, io_error};
@@ -793,12 +793,12 @@ fn decoded_payload_matching_session_ids(
     let mut session_ids = Vec::new();
     let mut matched_session_id = None;
     while let Some(row) = rows.next().map_err(|source| sqlite_error(path, source))? {
-        let session_id: i64 = row.get(0).map_err(|source| sqlite_error(path, source))?;
+        let session_id: i64 = row_value(path, row, 0)?;
         if matched_session_id == Some(session_id) {
             continue;
         }
-        let payload: Vec<u8> = row.get(1).map_err(|source| sqlite_error(path, source))?;
-        let codec: String = row.get(2).map_err(|source| sqlite_error(path, source))?;
+        let payload: Vec<u8> = row_value(path, row, 1)?;
+        let codec: String = row_value(path, row, 2)?;
         let Ok(decoded) = decode_event_payload_prefix(&payload, &codec, PAYLOAD_PREVIEW_BYTES)
         else {
             continue;

--- a/src/web.rs
+++ b/src/web.rs
@@ -9,7 +9,7 @@ use crate::storage::{
     IngestErrorSummary, LATEST_SCHEMA_VERSION, RAW_CODEC, ZSTD_CODEC, decode_event_payload,
     decode_event_payload_prefix, sqlite_error, unresolved_ingest_errors_from_connection,
 };
-use crate::{JottraceError, Result};
+use crate::{JottraceError, Result, io_error};
 
 const SESSION_PAGE_SIZE: usize = 50;
 const EVENT_PAGE_SIZE: usize = 25;
@@ -117,11 +117,8 @@ pub struct WebServer {
 impl WebServer {
     pub fn bind(db_path: PathBuf, port: u16) -> Result<Self> {
         drop(open_web_database(&db_path)?);
-        let listener =
-            TcpListener::bind((Ipv4Addr::LOCALHOST, port)).map_err(|source| JottraceError::Io {
-                path: db_path.clone(),
-                source,
-            })?;
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, port))
+            .map_err(|source| io_error(&db_path, source))?;
         Ok(Self { db_path, listener })
     }
 
@@ -154,10 +151,7 @@ impl WebServer {
         self.listener
             .accept()
             .map(|(stream, _)| stream)
-            .map_err(|source| JottraceError::Io {
-                path: self.db_path.clone(),
-                source,
-            })
+            .map_err(|source| io_error(&self.db_path, source))
     }
 
     fn handle_stream(&self, stream: &mut TcpStream) -> Result<()> {
@@ -232,10 +226,7 @@ impl WebServer {
     }
 
     fn io_error(&self, source: io::Error) -> JottraceError {
-        JottraceError::Io {
-            path: self.db_path.clone(),
-            source,
-        }
+        io_error(&self.db_path, source)
     }
 
     fn read_request(&self, stream: &mut TcpStream) -> Result<String> {


### PR DESCRIPTION
## Summary

A sweep through the crate to collapse repeated boilerplate into a small family of shared helpers, with no functional change. Each commit is one focused, self-contained extraction.

The work falls into a few groups:

- **Error construction** — crate-level `io_error`/`sqlite_error` plus curried `map_io_error`/`map_sqlite_error` adapters, and constructor helpers for the recurring `SessionNotFound`, `UnsafeArchiveEntry`, `ArchiveDatabaseInvalid`, `UnsupportedSchemaVersion`, and zstd-codec error literals.
- **SQLite access** — a `query_one`/`query_optional`/`query_collect`/`execute_sql`/`count`/`row_value` helper family, `open_readonly_database`/`open_locked_database`, and shared `from_row` row mappers (`StoredSession`, `PreferenceExample`).
- **Ingest/discovery** — `for_each_dir_entry`, `metadata_optional`, `canonicalize_optional`, `parse_session_json`, `serialize_payload`, and shared session-discovery scaffolding.
- **CLI** — a generic `ParsedCommand<T>` with `resolve_command`/`run_resolved_command`/`finish_command`, plus `next_flag_value`/`take_single_flag_value` for flag parsing.
- **Taste** — a `db_string_enum!` macro for the three DB-backed string enums, `for_each_grouped_count`, and `parse_content_blocks`.

Net: **+1533 / −1882** across 17 files.

## Verification

- `cargo build` clean, full test suite green (~294 tests, 0 failures).
- The branch was reviewed at maximum effort. Every extracted helper, mapper, macro, and consolidated SQL statement was traced to its call sites field-by-field / column-by-column and confirmed behavior-preserving.

## Review fixes included

Two items the review surfaced are fixed in the final commit:

- **`storage::count`** restored its checked `u64::try_from(...).expect(...)` conversion (the generalization had silently swapped in a bare `as u64` cast, dropping the negative/overflow guard the call sites previously had). Latent only — every adopting query is non-negative — but it brings the helper back in line with the convention used elsewhere and keeps the dedup a true no-op.
- **pack `--output`** now parses its value through `next_flag_value`, the single-value flag helper already adopted at every other flag site, removing the last hand-rolled straggler.